### PR TITLE
chore: prepare v0.3.0 release for crates.io

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ DOWNLOAD_PROGRESS_IMPROVEMENT.md
 IMPLEMENTATION_SUMMARY.md
 QUICKSTART.md
 docs/registry_pattern_explanation.md
+.env.local

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1167,7 +1167,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ferrum-cli"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1208,7 +1208,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-cuda-kernels"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "bindgen_cuda",
  "candle-core",
@@ -1220,7 +1220,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-engine"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1269,7 +1269,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-interfaces"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1286,7 +1286,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-kv"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1307,7 +1307,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-models"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1348,7 +1348,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-runtime"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1379,7 +1379,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-sampler"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1399,7 +1399,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-scheduler"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1427,7 +1427,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-server"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1462,7 +1462,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-testkit"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1477,7 +1477,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-tokenizer"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1502,7 +1502,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-types"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "chrono",
  "rand 0.9.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,11 +25,12 @@ resolver = "2"
 
 
 [workspace.package]
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 authors = ["Ferrum Team"]
 license = "MIT"
-repository = "https://github.com/ferrum-rs/ferrum-infer"
+repository = "https://github.com/sizzlecar/ferrum-infer-rs"
+homepage = "https://github.com/sizzlecar/ferrum-infer-rs"
 
 [workspace.dependencies]
 # Async runtime
@@ -124,25 +125,25 @@ candle-flash-attn = "0.9.2"
 candle-metal-kernels = "0.9.2"
 
 # Internal crates - New refactored crates
-ferrum-types = { path = "crates/ferrum-types" }
-ferrum-interfaces = { path = "crates/ferrum-interfaces" }
+ferrum-types = { path = "crates/ferrum-types", version = "0.3.0" }
+ferrum-interfaces = { path = "crates/ferrum-interfaces", version = "0.3.0" }
 
 # Internal crates - Implementation crates
-ferrum-runtime = { path = "crates/ferrum-runtime" }
-ferrum-scheduler = { path = "crates/ferrum-scheduler" }
-ferrum-tokenizer = { path = "crates/ferrum-tokenizer" }
-ferrum-sampler = { path = "crates/ferrum-sampler" }
-ferrum-kv = { path = "crates/ferrum-kv" }
+ferrum-runtime = { path = "crates/ferrum-runtime", version = "0.3.0" }
+ferrum-scheduler = { path = "crates/ferrum-scheduler", version = "0.3.0" }
+ferrum-tokenizer = { path = "crates/ferrum-tokenizer", version = "0.3.0" }
+ferrum-sampler = { path = "crates/ferrum-sampler", version = "0.3.0" }
+ferrum-kv = { path = "crates/ferrum-kv", version = "0.3.0" }
 
 # CUDA kernel crate
-ferrum-cuda-kernels = { path = "crates/ferrum-cuda-kernels" }
+ferrum-cuda-kernels = { path = "crates/ferrum-cuda-kernels", version = "0.3.0" }
 
 # Internal crates - Existing crates (to be refactored)
-ferrum-engine = { path = "crates/ferrum-engine" }
-ferrum-models = { path = "crates/ferrum-models" }
-ferrum-server = { path = "crates/ferrum-server" }
-ferrum-cli = { path = "crates/ferrum-cli" }
-ferrum-testkit = { path = "crates/ferrum-testkit" }
+ferrum-engine = { path = "crates/ferrum-engine", version = "0.3.0" }
+ferrum-models = { path = "crates/ferrum-models", version = "0.3.0" }
+ferrum-server = { path = "crates/ferrum-server", version = "0.3.0" }
+ferrum-cli = { path = "crates/ferrum-cli", version = "0.3.0" }
+ferrum-testkit = { path = "crates/ferrum-testkit", version = "0.3.0" }
 
 
 [profile.release]

--- a/README.md
+++ b/README.md
@@ -7,9 +7,17 @@ A Rust-native LLM inference engine. Load models from Hugging Face, chat locally 
 
 [中文说明](README_zh.md)
 
-## Quick Start
+## Install
 
-Prerequisites: Rust stable toolchain.
+```bash
+# From crates.io
+cargo install ferrum-cli
+
+# Or build from source
+cargo build --release -p ferrum-cli --bin ferrum
+```
+
+## Quick Start
 
 For gated models (e.g. Llama 3.2), set your Hugging Face token first:
 ```bash
@@ -17,17 +25,14 @@ export HF_TOKEN=hf_your_token_here
 ```
 
 ```bash
-# Build
-cargo build --release -p ferrum-cli --bin ferrum
-
 # Download a model
-./target/release/ferrum pull qwen3:0.6b
+ferrum pull qwen3:0.6b
 
 # Chat
-./target/release/ferrum run qwen3:0.6b
+ferrum run qwen3:0.6b
 
 # Or start an API server
-./target/release/ferrum serve --model qwen3:0.6b --port 8000
+ferrum serve --model qwen3:0.6b --port 8000
 ```
 
 ## Supported Models
@@ -132,15 +137,20 @@ See [docs/ROADMAP.md](docs/ROADMAP.md) for full details.
 
 ```bash
 # CPU only (default)
-cargo build --release -p ferrum-cli
+cargo install ferrum-cli
 
 # With Metal acceleration (macOS)
-cargo build --release -p ferrum-cli --features metal
+cargo install ferrum-cli --features metal
 
-# With CUDA acceleration (NVIDIA, requires CUDA toolkit)
-cargo build --release -p ferrum-cli --features cuda
+# With CUDA acceleration (NVIDIA, requires CUDA toolkit + nvcc)
+cargo install ferrum-cli --features cuda
+```
 
-# CUDA includes Marlin INT4 kernel automatically (requires nvcc, SM >= 8.0)
+Or build from source:
+```bash
+cargo build --release -p ferrum-cli                    # CPU
+cargo build --release -p ferrum-cli --features metal   # Metal (macOS)
+cargo build --release -p ferrum-cli --features cuda    # CUDA (NVIDIA)
 ```
 
 Prerequisites: Rust stable toolchain.

--- a/README_zh.md
+++ b/README_zh.md
@@ -7,9 +7,17 @@
 
 [English](README.md)
 
-## 快速开始
+## 安装
 
-前置条件：Rust stable 工具链。
+```bash
+# 从 crates.io 安装
+cargo install ferrum-cli
+
+# 或从源码编译
+cargo build --release -p ferrum-cli --bin ferrum
+```
+
+## 快速开始
 
 访问受限模型（如 Llama 3.2）需先设置 Hugging Face token：
 ```bash
@@ -17,17 +25,14 @@ export HF_TOKEN=hf_your_token_here
 ```
 
 ```bash
-# 编译
-cargo build --release -p ferrum-cli --bin ferrum
-
 # 下载模型
-./target/release/ferrum pull qwen3:0.6b
+ferrum pull qwen3:0.6b
 
 # 对话
-./target/release/ferrum run qwen3:0.6b
+ferrum run qwen3:0.6b
 
 # 或启动 API 服务
-./target/release/ferrum serve --model qwen3:0.6b --port 8000
+ferrum serve --model qwen3:0.6b --port 8000
 ```
 
 ## 支持的模型
@@ -132,15 +137,20 @@ curl http://localhost:8000/health
 
 ```bash
 # 仅 CPU（默认）
-cargo build --release -p ferrum-cli
+cargo install ferrum-cli
 
 # 启用 Metal 加速（macOS）
-cargo build --release -p ferrum-cli --features metal
+cargo install ferrum-cli --features metal
 
-# 启用 CUDA 加速（NVIDIA，需要 CUDA Toolkit）
-cargo build --release -p ferrum-cli --features cuda
+# 启用 CUDA 加速（NVIDIA，需要 CUDA Toolkit + nvcc）
+cargo install ferrum-cli --features cuda
+```
 
-# CUDA 自动包含 Marlin INT4 内核（需要 nvcc，SM >= 8.0）
+或从源码编译：
+```bash
+cargo build --release -p ferrum-cli                    # CPU
+cargo build --release -p ferrum-cli --features metal   # Metal (macOS)
+cargo build --release -p ferrum-cli --features cuda    # CUDA (NVIDIA)
 ```
 
 前置条件：Rust stable 工具链。

--- a/crates/ferrum-cli/Cargo.toml
+++ b/crates/ferrum-cli/Cargo.toml
@@ -4,6 +4,8 @@ version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
+description = "CLI for Ferrum — a Rust-native LLM inference engine"
+readme = "../../README.md"
 
 [[bin]]
 name = "ferrum"

--- a/crates/ferrum-cuda-kernels/Cargo.toml
+++ b/crates/ferrum-cuda-kernels/Cargo.toml
@@ -4,6 +4,8 @@ version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
+description = "Custom CUDA kernels and decode runner for Ferrum inference"
+readme = "../../README.md"
 
 [dependencies]
 ferrum-types = { workspace = true }

--- a/crates/ferrum-engine/Cargo.toml
+++ b/crates/ferrum-engine/Cargo.toml
@@ -4,6 +4,8 @@ version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
+description = "Model orchestration engine for Ferrum LLM inference"
+readme = "../../README.md"
 
 [dependencies]
 # Core dependencies - New architecture

--- a/crates/ferrum-interfaces/Cargo.toml
+++ b/crates/ferrum-interfaces/Cargo.toml
@@ -5,6 +5,8 @@ edition.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true
+description = "Core trait contracts for the Ferrum LLM inference engine"
+readme = "../../README.md"
 
 [dependencies]
 # Core types

--- a/crates/ferrum-kv/Cargo.toml
+++ b/crates/ferrum-kv/Cargo.toml
@@ -4,6 +4,8 @@ version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
+description = "KV cache management with PagedAttention for Ferrum inference"
+readme = "../../README.md"
 
 [dependencies]
 # Core dependencies - New architecture

--- a/crates/ferrum-models/Cargo.toml
+++ b/crates/ferrum-models/Cargo.toml
@@ -4,6 +4,8 @@ version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
+description = "Model architectures (LLaMA, Qwen, BERT) for Ferrum inference"
+readme = "../../README.md"
 
 [dependencies]
 # Core dependencies - New architecture

--- a/crates/ferrum-runtime/Cargo.toml
+++ b/crates/ferrum-runtime/Cargo.toml
@@ -4,6 +4,8 @@ version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
+description = "Backend implementations (Candle, CPU) for Ferrum inference"
+readme = "../../README.md"
 
 [dependencies]
 # Core dependencies - New architecture

--- a/crates/ferrum-sampler/Cargo.toml
+++ b/crates/ferrum-sampler/Cargo.toml
@@ -4,6 +4,8 @@ version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
+description = "Sampling strategies for Ferrum LLM inference engine"
+readme = "../../README.md"
 
 [dependencies]
 # Core dependencies - New architecture

--- a/crates/ferrum-scheduler/Cargo.toml
+++ b/crates/ferrum-scheduler/Cargo.toml
@@ -4,6 +4,8 @@ version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
+description = "Request scheduling for Ferrum LLM inference engine"
+readme = "../../README.md"
 
 [dependencies]
 # Core dependencies - New architecture

--- a/crates/ferrum-server/Cargo.toml
+++ b/crates/ferrum-server/Cargo.toml
@@ -4,6 +4,8 @@ version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
+description = "OpenAI-compatible HTTP API server for Ferrum inference"
+readme = "../../README.md"
 
 [dependencies]
 # Core dependencies

--- a/crates/ferrum-testkit/Cargo.toml
+++ b/crates/ferrum-testkit/Cargo.toml
@@ -4,7 +4,9 @@ version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
-description = "Mock components for testing ferrum inference engine without GPU"
+description = "Testing utilities for Ferrum inference (not published)"
+readme = "../../README.md"
+publish = false
 
 [dependencies]
 ferrum-types = { workspace = true }

--- a/crates/ferrum-tokenizer/Cargo.toml
+++ b/crates/ferrum-tokenizer/Cargo.toml
@@ -4,6 +4,8 @@ version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
+description = "Tokenization wrapper for Ferrum inference engine"
+readme = "../../README.md"
 
 [dependencies]
 # Core dependencies

--- a/crates/ferrum-types/Cargo.toml
+++ b/crates/ferrum-types/Cargo.toml
@@ -5,6 +5,8 @@ edition.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true
+description = "Shared type definitions for the Ferrum LLM inference engine"
+readme = "../../README.md"
 
 [dependencies]
 # Serialization


### PR DESCRIPTION
- Bump version to 0.3.0
- Fix repository URL to sizzlecar/ferrum-infer-rs
- Add version to all workspace path dependencies (crates.io requires it)
- Add description + readme to all 13 crate Cargo.toml files
- Set publish = false for ferrum-testkit
- Update README: add Install section (cargo install ferrum-cli)
- Update README: remove ./target/release/ prefix from commands
- Sync Chinese README