### PR TITLE
Release v0.4.0 — Tensor Parallelism

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1167,7 +1167,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ferrum-cli"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1208,7 +1208,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-cuda-kernels"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "bindgen_cuda",
  "candle-core",
@@ -1220,7 +1220,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-engine"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1269,7 +1269,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-interfaces"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1286,7 +1286,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-kv"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1307,7 +1307,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-models"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1348,7 +1348,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-runtime"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1379,7 +1379,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-sampler"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1399,7 +1399,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-scheduler"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1427,7 +1427,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-server"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1462,7 +1462,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-testkit"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1477,7 +1477,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-tokenizer"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1502,7 +1502,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-types"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "chrono",
  "rand 0.9.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ resolver = "2"
 
 
 [workspace.package]
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 authors = ["Ferrum Team"]
 license = "MIT"
@@ -125,25 +125,25 @@ candle-flash-attn = "0.9.2"
 candle-metal-kernels = "0.9.2"
 
 # Internal crates - New refactored crates
-ferrum-types = { path = "crates/ferrum-types", version = "0.3.0" }
-ferrum-interfaces = { path = "crates/ferrum-interfaces", version = "0.3.0" }
+ferrum-types = { path = "crates/ferrum-types", version = "0.4.0" }
+ferrum-interfaces = { path = "crates/ferrum-interfaces", version = "0.4.0" }
 
 # Internal crates - Implementation crates
-ferrum-runtime = { path = "crates/ferrum-runtime", version = "0.3.0" }
-ferrum-scheduler = { path = "crates/ferrum-scheduler", version = "0.3.0" }
-ferrum-tokenizer = { path = "crates/ferrum-tokenizer", version = "0.3.0" }
-ferrum-sampler = { path = "crates/ferrum-sampler", version = "0.3.0" }
-ferrum-kv = { path = "crates/ferrum-kv", version = "0.3.0" }
+ferrum-runtime = { path = "crates/ferrum-runtime", version = "0.4.0" }
+ferrum-scheduler = { path = "crates/ferrum-scheduler", version = "0.4.0" }
+ferrum-tokenizer = { path = "crates/ferrum-tokenizer", version = "0.4.0" }
+ferrum-sampler = { path = "crates/ferrum-sampler", version = "0.4.0" }
+ferrum-kv = { path = "crates/ferrum-kv", version = "0.4.0" }
 
 # CUDA kernel crate
-ferrum-cuda-kernels = { path = "crates/ferrum-cuda-kernels", version = "0.3.0" }
+ferrum-cuda-kernels = { path = "crates/ferrum-cuda-kernels", version = "0.4.0" }
 
 # Internal crates - Existing crates (to be refactored)
-ferrum-engine = { path = "crates/ferrum-engine", version = "0.3.0" }
-ferrum-models = { path = "crates/ferrum-models", version = "0.3.0" }
-ferrum-server = { path = "crates/ferrum-server", version = "0.3.0" }
-ferrum-cli = { path = "crates/ferrum-cli", version = "0.3.0" }
-ferrum-testkit = { path = "crates/ferrum-testkit", version = "0.3.0" }
+ferrum-engine = { path = "crates/ferrum-engine", version = "0.4.0" }
+ferrum-models = { path = "crates/ferrum-models", version = "0.4.0" }
+ferrum-server = { path = "crates/ferrum-server", version = "0.4.0" }
+ferrum-cli = { path = "crates/ferrum-cli", version = "0.4.0" }
+ferrum-testkit = { path = "crates/ferrum-testkit", version = "0.4.0" }
 
 
 [profile.release]


### PR DESCRIPTION
## Summary

- **Tensor Parallelism**: multi-GPU decode via NCCL all-reduce (Megatron-LM pattern)
  - Persistent per-rank worker threads with barrier sync (zero thread::scope overhead)
  - cudarc event tracking disabled on worker streams (eliminates per-NCCL-call overhead)
  - Auto-detects GPU count — no manual `FERRUM_TP` env var needed
  - Verified on 2× RTX PRO 6000 Blackwell: Qwen3-4B TP=2 → 26.1 tok/s
- **Feature cleanup**: `tensor-parallel` merged into `cuda` (NCCL ships with CUDA Toolkit)
- **README**: rewritten "Supported Models" → "Supported Architectures", added TP benchmark data
- **GPU scripts**: `remote.sh` with non-blocking ops, poll-based monitoring

## Benchmark (RTX PRO 6000 Blackwell, Qwen3-4B FP16)

| Config | tok/s | TPOT |
|--------|-------|------|
| 1× GPU | 82.3 | 12.1ms |
| 2× GPU TP | 26.1 | 38.4ms |

## Test plan

- [x] `cargo check --workspace --all-targets` (Mac, no GPU)
- [x] `cargo test --workspace` — 47 test suites pass
- [x] `cargo fmt --all -- --check`
- [x] GPU verified: single-GPU baseline + TP=2 decode on Blackwell

🤖 Generated with [Claude Code](https://claude.com/claude-code)