### PR TITLE
feat: CLIP/SigLIP embeddings + /v1/embeddings API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -360,6 +360,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
 name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1166,6 +1172,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
 name = "ferrum-cli"
 version = "0.4.0"
 dependencies = [
@@ -1311,6 +1326,7 @@ version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "base64 0.22.1",
  "bytemuck",
  "candle-core",
  "candle-flash-attn",
@@ -1327,6 +1343,7 @@ dependencies = [
  "futures-util",
  "half",
  "hf-hub",
+ "image",
  "indicatif",
  "once_cell",
  "parking_lot",
@@ -2415,6 +2432,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "image-webp",
+ "moxcms",
+ "num-traits",
+ "png",
+ "zune-core",
+ "zune-jpeg",
+]
+
+[[package]]
+name = "image-webp"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
+dependencies = [
+ "byteorder-lite",
+ "quick-error",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2819,6 +2862,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
 ]
 
 [[package]]
@@ -3337,6 +3390,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags 2.10.0",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3433,6 +3499,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40e24eee682d89fb193496edf918a7f407d30175b2e785fe057e4392dfd182e0"
 
 [[package]]
+name = "pxfm"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
+
+[[package]]
 name = "quanta"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3446,6 +3518,12 @@ dependencies = [
  "web-sys",
  "winapi",
 ]
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quinn"
@@ -5623,4 +5701,19 @@ dependencies = [
  "indexmap",
  "memchr",
  "typed-path",
+]
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
 ]

--- a/README.md
+++ b/README.md
@@ -39,25 +39,36 @@ ferrum serve --model qwen3:0.6b --port 8000
 
 Any Hugging Face model using a supported architecture works out of the box:
 
+### Text Generation
+
 | Architecture | CUDA Decode | INT4 (GPTQ) | Tensor Parallel | Example Models |
 |-------------|-------------|-------------|-----------------|----------------|
 | **LLaMA** | Yes | Yes | Yes | Llama-3.x, TinyLlama, Vicuna, Alpaca, ... |
 | **Qwen3** | Yes | Yes | Yes | Qwen3-0.6B ~ 4B |
 | **Qwen2** | — | — | — | Qwen2.5-Instruct-0.5B ~ 7B |
-| **BERT** | — | — | — | any BERT model (embeddings only) |
+
+### Embeddings (text + image)
+
+| Architecture | Modality | Embedding Dim | Example Models |
+|-------------|----------|--------------|----------------|
+| **CLIP** | Text + Image | 512/768 | openai/clip-vit-base-patch32 |
+| **Chinese-CLIP** | Text + Image | 512 | OFA-Sys/chinese-clip-vit-base-patch16 |
+| **SigLIP** | Text + Image | 768 | google/siglip-base-patch16-224 |
+| **BERT** | Text | 768 | google-bert/bert-base-chinese |
 
 ```bash
-# Use any Hugging Face model ID directly
+# Text generation
 ferrum run Qwen/Qwen3-4B
-ferrum run meta-llama/Llama-3.2-3B-Instruct
-
-# GPTQ INT4 quantized models are auto-detected
-ferrum run JunHowie/Qwen3-4B-GPTQ-Int4
-
-# Or use built-in aliases for convenience
-ferrum run qwen3:4b
 ferrum run llama3.2:3b
-ferrum run tinyllama
+
+# Embeddings (text + image)
+ferrum embed OFA-Sys/chinese-clip-vit-base-patch16 --text "sunset at the beach"
+ferrum embed google/siglip-base-patch16-224 --image photo.jpg
+
+# Embedding API server
+ferrum serve --model OFA-Sys/chinese-clip-vit-base-patch16
+curl localhost:8000/v1/embeddings -d '{"model":"clip","input":"hello"}'
+curl localhost:8000/v1/embeddings -d '{"model":"clip","input":{"image":"/path/to/photo.jpg"}}'
 ```
 
 ## Commands
@@ -70,7 +81,7 @@ ferrum run tinyllama
 | `ferrum pull <model>` | Download model from Hugging Face |
 | `ferrum list` | Show cached models |
 | `ferrum bench <model>` | Performance benchmark |
-| `ferrum embed <model>` | Generate BERT embeddings |
+| `ferrum embed <model>` | Generate embeddings (BERT/CLIP/SigLIP, text + image) |
 
 ## API Endpoints
 
@@ -139,6 +150,7 @@ What works:
 - Paged KV cache with block reclamation
 - Continuous batching with batch decode
 - Tensor parallelism (multi-GPU NCCL, auto-detects GPU count)
+- CLIP/Chinese-CLIP/SigLIP embeddings (text + image, `/v1/embeddings` API)
 - Top-k/top-p/temperature/repetition-penalty sampling
 
 ## Roadmap

--- a/README_zh.md
+++ b/README_zh.md
@@ -39,25 +39,36 @@ ferrum serve --model qwen3:0.6b --port 8000
 
 任何使用以下架构的 Hugging Face 模型都可以直接运行：
 
+### 文本生成
+
 | 架构 | CUDA Decode | INT4 (GPTQ) | 张量并行 | 示例模型 |
 |------|-------------|-------------|---------|----------|
 | **LLaMA** | 支持 | 支持 | 支持 | Llama-3.x, TinyLlama, Vicuna, Alpaca, ... |
 | **Qwen3** | 支持 | 支持 | 支持 | Qwen3-0.6B ~ 4B |
 | **Qwen2** | — | — | — | Qwen2.5-Instruct-0.5B ~ 7B |
-| **BERT** | — | — | — | 任意 BERT 模型（仅向量化） |
+
+### 向量化（文本 + 图片）
+
+| 架构 | 模态 | 向量维度 | 示例模型 |
+|------|------|---------|----------|
+| **CLIP** | 文本 + 图片 | 512/768 | openai/clip-vit-base-patch32 |
+| **Chinese-CLIP** | 文本 + 图片 | 512 | OFA-Sys/chinese-clip-vit-base-patch16 |
+| **SigLIP** | 文本 + 图片 | 768 | google/siglip-base-patch16-224 |
+| **BERT** | 文本 | 768 | google-bert/bert-base-chinese |
 
 ```bash
-# 直接使用 Hugging Face 模型 ID
+# 文本生成
 ferrum run Qwen/Qwen3-4B
-ferrum run meta-llama/Llama-3.2-3B-Instruct
-
-# GPTQ INT4 量化模型自动检测
-ferrum run JunHowie/Qwen3-4B-GPTQ-Int4
-
-# 也可使用内置别名
-ferrum run qwen3:4b
 ferrum run llama3.2:3b
-ferrum run tinyllama
+
+# 向量化（文本 + 图片）
+ferrum embed OFA-Sys/chinese-clip-vit-base-patch16 --text "海边日落"
+ferrum embed google/siglip-base-patch16-224 --image photo.jpg
+
+# Embedding API 服务
+ferrum serve --model OFA-Sys/chinese-clip-vit-base-patch16
+curl localhost:8000/v1/embeddings -d '{"model":"clip","input":"你好"}'
+curl localhost:8000/v1/embeddings -d '{"model":"clip","input":{"image":"/path/to/photo.jpg"}}'
 ```
 
 ## 命令
@@ -70,7 +81,7 @@ ferrum run tinyllama
 | `ferrum pull <model>` | 从 Hugging Face 下载模型 |
 | `ferrum list` | 查看已缓存模型 |
 | `ferrum bench <model>` | 性能基准测试 |
-| `ferrum embed <model>` | 生成 BERT 向量 |
+| `ferrum embed <model>` | 生成向量（BERT/CLIP/SigLIP，文本 + 图片） |
 
 ## API 接口
 
@@ -139,6 +150,7 @@ curl http://localhost:8000/health
 - Paged KV cache + block 回收
 - 连续批处理 + batch decode
 - 张量并行（多 GPU NCCL，自动检测 GPU 数量）
+- CLIP/Chinese-CLIP/SigLIP 向量化（文本 + 图片，`/v1/embeddings` API）
 - Top-k / Top-p / Temperature / 重复惩罚采样
 
 ## 路线图

--- a/crates/ferrum-cli/src/commands/embed.rs
+++ b/crates/ferrum-cli/src/commands/embed.rs
@@ -185,7 +185,7 @@ pub async fn execute(cmd: EmbedCommand, config: CliConfig) -> Result<()> {
 }
 
 /// Load tokenizer: try tokenizer.json first, fall back to vocab.txt (BERT-style).
-fn load_tokenizer(model_dir: &std::path::Path) -> Result<tokenizers::Tokenizer> {
+pub fn load_tokenizer(model_dir: &std::path::Path) -> Result<tokenizers::Tokenizer> {
     let tokenizer_json = model_dir.join("tokenizer.json");
     if tokenizer_json.exists() {
         return tokenizers::Tokenizer::from_file(&tokenizer_json)

--- a/crates/ferrum-cli/src/commands/embed.rs
+++ b/crates/ferrum-cli/src/commands/embed.rs
@@ -103,11 +103,7 @@ pub async fn execute(cmd: EmbedCommand, config: CliConfig) -> Result<()> {
 
         let texts = collect_texts(&cmd)?;
         if !texts.is_empty() {
-            let tokenizer =
-                tokenizers::Tokenizer::from_file(source.local_path.join("tokenizer.json"))
-                    .map_err(|e| {
-                        ferrum_types::FerrumError::model(format!("Load tokenizer: {e}"))
-                    })?;
+            let tokenizer = load_tokenizer(&source.local_path)?;
 
             for text in &texts {
                 let encoding = tokenizer
@@ -128,8 +124,7 @@ pub async fn execute(cmd: EmbedCommand, config: CliConfig) -> Result<()> {
         let executor = BertModelExecutor::from_path(&model_path, &model_def, device).await?;
         eprintln!("{}", "BERT model loaded.".green());
 
-        let tokenizer = tokenizers::Tokenizer::from_file(source.local_path.join("tokenizer.json"))
-            .map_err(|e| ferrum_types::FerrumError::model(format!("Load tokenizer: {e}")))?;
+        let tokenizer = load_tokenizer(&source.local_path)?;
 
         let texts = collect_texts(&cmd)?;
         if texts.is_empty() {
@@ -187,6 +182,32 @@ pub async fn execute(cmd: EmbedCommand, config: CliConfig) -> Result<()> {
     }
 
     Ok(())
+}
+
+/// Load tokenizer: try tokenizer.json first, fall back to vocab.txt (BERT-style).
+fn load_tokenizer(model_dir: &std::path::Path) -> Result<tokenizers::Tokenizer> {
+    let tokenizer_json = model_dir.join("tokenizer.json");
+    if tokenizer_json.exists() {
+        return tokenizers::Tokenizer::from_file(&tokenizer_json)
+            .map_err(|e| ferrum_types::FerrumError::model(format!("Load tokenizer.json: {e}")));
+    }
+
+    // Fall back to vocab.txt (Chinese-CLIP, older BERT models)
+    let vocab_txt = model_dir.join("vocab.txt");
+    if vocab_txt.exists() {
+        use tokenizers::models::wordpiece::WordPiece;
+        let wp = WordPiece::from_file(vocab_txt.to_str().unwrap())
+            .unk_token("[UNK]".to_string())
+            .build()
+            .map_err(|e| ferrum_types::FerrumError::model(format!("Load vocab.txt: {e}")))?;
+        let mut tokenizer = tokenizers::Tokenizer::new(wp);
+        tokenizer.with_pre_tokenizer(Some(tokenizers::pre_tokenizers::bert::BertPreTokenizer));
+        return Ok(tokenizer);
+    }
+
+    Err(ferrum_types::FerrumError::model(
+        "No tokenizer.json or vocab.txt found in model directory",
+    ))
 }
 
 fn collect_texts(cmd: &EmbedCommand) -> Result<Vec<String>> {

--- a/crates/ferrum-cli/src/commands/embed.rs
+++ b/crates/ferrum-cli/src/commands/embed.rs
@@ -196,12 +196,37 @@ pub fn load_tokenizer(model_dir: &std::path::Path) -> Result<tokenizers::Tokeniz
     let vocab_txt = model_dir.join("vocab.txt");
     if vocab_txt.exists() {
         use tokenizers::models::wordpiece::WordPiece;
+        use tokenizers::processors::template::TemplateProcessing;
+        use tokenizers::Model;
         let wp = WordPiece::from_file(vocab_txt.to_str().unwrap())
             .unk_token("[UNK]".to_string())
             .build()
             .map_err(|e| ferrum_types::FerrumError::model(format!("Load vocab.txt: {e}")))?;
+
+        // Look up [CLS] and [SEP] IDs from vocab dynamically
+        let vocab = wp.get_vocab();
+        let cls_id = vocab.get("[CLS]").copied().unwrap_or(101);
+        let sep_id = vocab.get("[SEP]").copied().unwrap_or(102);
+
         let mut tokenizer = tokenizers::Tokenizer::new(wp);
-        tokenizer.with_pre_tokenizer(Some(tokenizers::pre_tokenizers::bert::BertPreTokenizer));
+        // BertPreTokenizer + Chinese char splitting (add spaces around CJK chars
+        // so WordPiece treats each character as a separate token, matching Python's
+        // BertTokenizer._tokenize_chinese_chars behavior)
+        use tokenizers::pre_tokenizers::sequence::Sequence;
+        use tokenizers::pre_tokenizers::unicode_scripts::UnicodeScripts;
+        tokenizer.with_pre_tokenizer(Some(Sequence::new(vec![
+            tokenizers::pre_tokenizers::PreTokenizerWrapper::UnicodeScripts(UnicodeScripts),
+            tokenizers::pre_tokenizers::PreTokenizerWrapper::BertPreTokenizer(
+                tokenizers::pre_tokenizers::bert::BertPreTokenizer,
+            ),
+        ])));
+        let template = TemplateProcessing::builder()
+            .try_single("[CLS] $A [SEP]")
+            .unwrap()
+            .special_tokens(vec![("[CLS]", cls_id), ("[SEP]", sep_id)])
+            .build()
+            .map_err(|e| ferrum_types::FerrumError::model(format!("Template: {e}")))?;
+        tokenizer.with_post_processor(Some(template));
         return Ok(tokenizer);
     }
 

--- a/crates/ferrum-cli/src/commands/embed.rs
+++ b/crates/ferrum-cli/src/commands/embed.rs
@@ -11,16 +11,20 @@ use ferrum_types::Result;
 use std::io::{self, BufRead};
 use std::path::PathBuf;
 
-/// Generate embeddings using a BERT model
+/// Generate embeddings using BERT or CLIP models
 #[derive(Args, Debug)]
 pub struct EmbedCommand {
-    /// Model name (e.g., google-bert/bert-base-chinese)
+    /// Model name (e.g., google-bert/bert-base-chinese, OFA-Sys/chinese-clip-vit-base-patch16)
     #[arg(required = true)]
     pub model: String,
 
     /// Text to embed (if not provided, reads from stdin)
     #[arg(short, long)]
     pub text: Option<String>,
+
+    /// Image path to embed (CLIP models only)
+    #[arg(short, long)]
+    pub image: Option<String>,
 
     /// Output format: json, csv, or raw
     #[arg(short, long, default_value = "json")]
@@ -73,71 +77,74 @@ pub async fn execute(cmd: EmbedCommand, config: CliConfig) -> Result<()> {
     let model_path = source.local_path.to_string_lossy().to_string();
     eprintln!("{}", "Using CPU backend".dimmed());
 
-    // Load model definition
+    // Load model definition to detect architecture
     let mut config_manager = ConfigManager::new();
     let model_def = config_manager.load_from_path(&source.local_path).await?;
 
-    // Load BERT executor
     let device = CandleDevice::Cpu;
-    let executor = BertModelExecutor::from_path(&model_path, &model_def, device).await?;
+    let is_clip = model_def.architecture == ferrum_models::Architecture::Clip;
 
-    eprintln!("{}", "Model loaded. Ready for embedding.".green());
+    let mut all_embeddings: Vec<(String, Vec<f32>)> = Vec::new();
 
-    // Load tokenizer
-    let tokenizer = tokenizers::Tokenizer::from_file(source.local_path.join("tokenizer.json"))
-        .map_err(|e| {
-            ferrum_types::FerrumError::model(format!("Failed to load tokenizer: {}", e))
-        })?;
+    if is_clip {
+        // CLIP path: supports both text and image
+        let executor = ferrum_models::ClipModelExecutor::from_path(
+            &model_path,
+            device.clone(),
+            candle_core::DType::F32,
+        )?;
+        eprintln!("{}", "CLIP model loaded.".green());
 
-    // Process input text
-    let texts: Vec<String> = if let Some(text) = cmd.text {
-        vec![text]
-    } else {
-        eprintln!(
-            "{}",
-            "Reading text from stdin (one text per line, Ctrl+D to finish):".dimmed()
-        );
-        let stdin = io::stdin();
-        stdin.lock().lines().filter_map(|l| l.ok()).collect()
-    };
+        if let Some(ref image_path) = cmd.image {
+            let embedding_tensor = executor.embed_image_path(image_path)?;
+            let embedding = tensor_to_vec(&embedding_tensor, cmd.normalize)?;
+            all_embeddings.push((format!("[image] {image_path}"), embedding));
+        }
 
-    if texts.is_empty() {
-        eprintln!("{}", "No text provided.".yellow());
-        return Ok(());
-    }
+        let texts = collect_texts(&cmd)?;
+        if !texts.is_empty() {
+            let tokenizer =
+                tokenizers::Tokenizer::from_file(source.local_path.join("tokenizer.json"))
+                    .map_err(|e| {
+                        ferrum_types::FerrumError::model(format!("Load tokenizer: {e}"))
+                    })?;
 
-    // Generate embeddings for each text
-    let mut all_embeddings = Vec::new();
-
-    for text in &texts {
-        // Tokenize
-        let encoding = tokenizer
-            .encode(text.as_str(), true)
-            .map_err(|e| ferrum_types::FerrumError::model(format!("Tokenization failed: {}", e)))?;
-
-        let token_ids: Vec<u32> = encoding.get_ids().to_vec();
-
-        // Get embeddings
-        let embedding_tensor = executor.get_embeddings(&token_ids)?;
-
-        // Convert to vec
-        let mut embedding = embedding_tensor
-            .flatten_all()
-            .map_err(|e| ferrum_types::FerrumError::model(format!("Flatten failed: {}", e)))?
-            .to_vec1::<f32>()
-            .map_err(|e| ferrum_types::FerrumError::model(format!("to_vec1 failed: {}", e)))?;
-
-        // Normalize if requested
-        if cmd.normalize {
-            let norm: f32 = embedding.iter().map(|x| x * x).sum::<f32>().sqrt();
-            if norm > 0.0 {
-                for v in &mut embedding {
-                    *v /= norm;
-                }
+            for text in &texts {
+                let encoding = tokenizer
+                    .encode(text.as_str(), true)
+                    .map_err(|e| ferrum_types::FerrumError::model(format!("Tokenize: {e}")))?;
+                let embedding_tensor = executor.embed_text(encoding.get_ids())?;
+                let embedding = tensor_to_vec(&embedding_tensor, cmd.normalize)?;
+                all_embeddings.push((text.clone(), embedding));
             }
         }
 
-        all_embeddings.push((text.clone(), embedding));
+        if all_embeddings.is_empty() {
+            eprintln!("{}", "No input provided. Use --text or --image.".yellow());
+            return Ok(());
+        }
+    } else {
+        // BERT path (existing)
+        let executor = BertModelExecutor::from_path(&model_path, &model_def, device).await?;
+        eprintln!("{}", "BERT model loaded.".green());
+
+        let tokenizer = tokenizers::Tokenizer::from_file(source.local_path.join("tokenizer.json"))
+            .map_err(|e| ferrum_types::FerrumError::model(format!("Load tokenizer: {e}")))?;
+
+        let texts = collect_texts(&cmd)?;
+        if texts.is_empty() {
+            eprintln!("{}", "No text provided.".yellow());
+            return Ok(());
+        }
+
+        for text in &texts {
+            let encoding = tokenizer
+                .encode(text.as_str(), true)
+                .map_err(|e| ferrum_types::FerrumError::model(format!("Tokenize: {e}")))?;
+            let embedding_tensor = executor.get_embeddings(encoding.get_ids())?;
+            let embedding = tensor_to_vec(&embedding_tensor, cmd.normalize)?;
+            all_embeddings.push((text.clone(), embedding));
+        }
     }
 
     // Output embeddings
@@ -180,6 +187,40 @@ pub async fn execute(cmd: EmbedCommand, config: CliConfig) -> Result<()> {
     }
 
     Ok(())
+}
+
+fn collect_texts(cmd: &EmbedCommand) -> Result<Vec<String>> {
+    if let Some(ref text) = cmd.text {
+        Ok(vec![text.clone()])
+    } else if cmd.image.is_some() {
+        // Image-only mode, no text needed
+        Ok(vec![])
+    } else {
+        eprintln!(
+            "{}",
+            "Reading text from stdin (one per line, Ctrl+D to finish):".dimmed()
+        );
+        let stdin = io::stdin();
+        Ok(stdin.lock().lines().filter_map(|l| l.ok()).collect())
+    }
+}
+
+fn tensor_to_vec(tensor: &candle_core::Tensor, normalize: bool) -> Result<Vec<f32>> {
+    let mut embedding = tensor
+        .flatten_all()
+        .map_err(|e| ferrum_types::FerrumError::model(format!("Flatten: {e}")))?
+        .to_vec1::<f32>()
+        .map_err(|e| ferrum_types::FerrumError::model(format!("to_vec1: {e}")))?;
+
+    if normalize {
+        let norm: f32 = embedding.iter().map(|x| x * x).sum::<f32>().sqrt();
+        if norm > 0.0 {
+            for v in &mut embedding {
+                *v /= norm;
+            }
+        }
+    }
+    Ok(embedding)
 }
 
 fn find_cached_model(cache_dir: &PathBuf, model_id: &str) -> Option<ResolvedModelSource> {

--- a/crates/ferrum-cli/src/commands/serve.rs
+++ b/crates/ferrum-cli/src/commands/serve.rs
@@ -86,18 +86,38 @@ pub async fn execute(cmd: ServeCommand, config: CliConfig) -> Result<()> {
     let device = select_device();
     println!("{} {:?}", "Device:".dimmed(), device);
 
-    // Create engine with continuous batching for serve mode
+    // Detect architecture to choose engine type
     println!();
-    println!(
-        "{}",
-        "Initializing engine (continuous batching)...".dimmed()
-    );
-    let mut engine_config = ferrum_engine::simple_engine_config(model_id.clone(), device);
-    engine_config.scheduler.policy = ferrum_types::SchedulingPolicy::ContinuousBatch;
-    engine_config.kv_cache.cache_type = ferrum_types::KvCacheType::Paged;
-    let engine = ferrum_engine::create_mvp_engine(engine_config).await?;
-    // Convert Box<dyn InferenceEngine> to Arc<dyn InferenceEngine>
-    let engine: Arc<dyn InferenceEngine + Send + Sync> = Arc::from(engine);
+    let mut config_manager = ferrum_models::ConfigManager::new();
+    let model_def = config_manager.load_from_path(&source.local_path).await?;
+
+    let engine: Arc<dyn InferenceEngine + Send + Sync> =
+        if model_def.architecture == ferrum_models::Architecture::Clip {
+            println!("{}", "Initializing CLIP embedding engine...".dimmed());
+            let candle_device = candle_core::Device::Cpu;
+            let executor = ferrum_models::ClipModelExecutor::from_path(
+                &source.local_path.to_string_lossy(),
+                candle_device,
+                candle_core::DType::F32,
+            )?;
+            // Load tokenizer for text embedding
+            let tokenizer = crate::commands::embed::load_tokenizer(&source.local_path)?;
+            let engine_config = ferrum_engine::simple_engine_config(model_id.clone(), device);
+            Arc::new(
+                ferrum_engine::embedding_engine::EmbeddingEngine::new(executor, engine_config)
+                    .with_tokenizer(tokenizer),
+            )
+        } else {
+            println!(
+                "{}",
+                "Initializing engine (continuous batching)...".dimmed()
+            );
+            let mut engine_config = ferrum_engine::simple_engine_config(model_id.clone(), device);
+            engine_config.scheduler.policy = ferrum_types::SchedulingPolicy::ContinuousBatch;
+            engine_config.kv_cache.cache_type = ferrum_types::KvCacheType::Paged;
+            let engine = ferrum_engine::create_mvp_engine(engine_config).await?;
+            Arc::from(engine)
+        };
 
     // Create server config
     let server_config = ServerConfig {

--- a/crates/ferrum-engine/src/embedding_engine.rs
+++ b/crates/ferrum-engine/src/embedding_engine.rs
@@ -18,6 +18,7 @@ use std::sync::Arc;
 /// Embedding-only engine wrapping a ClipModelExecutor.
 pub struct EmbeddingEngine {
     executor: Arc<ClipModelExecutor>,
+    tokenizer: Option<tokenizers::Tokenizer>,
     config: EngineConfig,
 }
 
@@ -25,8 +26,15 @@ impl EmbeddingEngine {
     pub fn new(executor: ClipModelExecutor, config: EngineConfig) -> Self {
         Self {
             executor: Arc::new(executor),
+            tokenizer: None,
             config,
         }
+    }
+
+    /// Set tokenizer for text embedding.
+    pub fn with_tokenizer(mut self, tokenizer: tokenizers::Tokenizer) -> Self {
+        self.tokenizer = Some(tokenizer);
+        self
     }
 }
 
@@ -97,8 +105,15 @@ impl InferenceEngine for EmbeddingEngine {
         ferrum_types::HealthStatus::healthy()
     }
 
-    async fn embed_text(&self, tokens: &[u32]) -> Result<Vec<f32>> {
-        let embedding = self.executor.embed_text(tokens)?;
+    async fn embed_text(&self, text: &str) -> Result<Vec<f32>> {
+        let tokenizer = self
+            .tokenizer
+            .as_ref()
+            .ok_or_else(|| FerrumError::model("No tokenizer loaded for text embedding"))?;
+        let encoding = tokenizer
+            .encode(text, true)
+            .map_err(|e| FerrumError::model(format!("tokenize: {e}")))?;
+        let embedding = self.executor.embed_text(encoding.get_ids())?;
         embedding
             .squeeze(0)
             .and_then(|t| t.to_dtype(candle_core::DType::F32))

--- a/crates/ferrum-engine/src/embedding_engine.rs
+++ b/crates/ferrum-engine/src/embedding_engine.rs
@@ -1,0 +1,125 @@
+//! Lightweight engine for embedding models (CLIP, BERT, etc.).
+//!
+//! Unlike the full inference engine, this doesn't need scheduling,
+//! KV cache management, or token generation. It just wraps an executor
+//! and provides embed_text / embed_image via the InferenceEngine trait.
+
+use async_trait::async_trait;
+use ferrum_interfaces::engine::InferenceEngine;
+use ferrum_models::ClipModelExecutor;
+use ferrum_types::{
+    EngineConfig, EngineMetrics, EngineStatus, FerrumError, InferenceRequest, InferenceResponse,
+    Result, StreamChunk,
+};
+use futures::Stream;
+use std::pin::Pin;
+use std::sync::Arc;
+
+/// Embedding-only engine wrapping a ClipModelExecutor.
+pub struct EmbeddingEngine {
+    executor: Arc<ClipModelExecutor>,
+    config: EngineConfig,
+}
+
+impl EmbeddingEngine {
+    pub fn new(executor: ClipModelExecutor, config: EngineConfig) -> Self {
+        Self {
+            executor: Arc::new(executor),
+            config,
+        }
+    }
+}
+
+#[async_trait]
+impl InferenceEngine for EmbeddingEngine {
+    async fn infer(&self, _request: InferenceRequest) -> Result<InferenceResponse> {
+        Err(FerrumError::model(
+            "Embedding models don't support text generation. Use /v1/embeddings instead.",
+        ))
+    }
+
+    async fn infer_stream(
+        &self,
+        _request: InferenceRequest,
+    ) -> Result<Pin<Box<dyn Stream<Item = Result<StreamChunk>> + Send>>> {
+        Err(FerrumError::model(
+            "Embedding models don't support streaming. Use /v1/embeddings instead.",
+        ))
+    }
+
+    async fn status(&self) -> EngineStatus {
+        EngineStatus {
+            is_ready: true,
+            loaded_models: vec![],
+            active_requests: 0,
+            queued_requests: 0,
+            memory_usage: ferrum_types::MemoryUsage {
+                total_bytes: 0,
+                used_bytes: 0,
+                free_bytes: 0,
+                gpu_memory_bytes: None,
+                cpu_memory_bytes: None,
+                cache_memory_bytes: 0,
+                utilization_percent: 0.0,
+            },
+            uptime_seconds: 0,
+            last_heartbeat: chrono::Utc::now(),
+            version: env!("CARGO_PKG_VERSION").to_string(),
+        }
+    }
+
+    async fn shutdown(&self) -> Result<()> {
+        Ok(())
+    }
+
+    fn config(&self) -> &EngineConfig {
+        &self.config
+    }
+
+    fn metrics(&self) -> EngineMetrics {
+        EngineMetrics {
+            total_requests: 0,
+            successful_requests: 0,
+            failed_requests: 0,
+            avg_request_latency_ms: 0.0,
+            p95_request_latency_ms: 0.0,
+            p99_request_latency_ms: 0.0,
+            throughput_rps: 0.0,
+            tokens_per_second: 0.0,
+            queue_metrics: Default::default(),
+            resource_utilization: Default::default(),
+            error_stats: Default::default(),
+            performance_breakdown: Default::default(),
+        }
+    }
+
+    async fn health_check(&self) -> ferrum_types::HealthStatus {
+        ferrum_types::HealthStatus::healthy()
+    }
+
+    async fn embed_text(&self, tokens: &[u32]) -> Result<Vec<f32>> {
+        let embedding = self.executor.embed_text(tokens)?;
+        embedding
+            .squeeze(0)
+            .and_then(|t| t.to_dtype(candle_core::DType::F32))
+            .and_then(|t| t.to_vec1())
+            .map_err(|e| FerrumError::model(format!("embed_text tensor: {e}")))
+    }
+
+    async fn embed_image(&self, image: &str) -> Result<Vec<f32>> {
+        let embedding = if image.starts_with("data:") || image.len() > 1000 {
+            self.executor.embed_image_base64(image)?
+        } else {
+            self.executor.embed_image_path(image)?
+        };
+        embedding
+            .squeeze(0)
+            .and_then(|t| t.to_dtype(candle_core::DType::F32))
+            .and_then(|t| t.to_vec1())
+            .map_err(|e| FerrumError::model(format!("embed_image tensor: {e}")))
+    }
+
+    fn embedding_dim(&self) -> usize {
+        self.executor.projection_dim()
+    }
+}

--- a/crates/ferrum-engine/src/lib.rs
+++ b/crates/ferrum-engine/src/lib.rs
@@ -57,6 +57,7 @@
 
 pub mod builder;
 pub mod continuous_engine;
+pub mod embedding_engine;
 pub mod engine;
 pub mod factory;
 pub mod kernels;

--- a/crates/ferrum-engine/src/registry.rs
+++ b/crates/ferrum-engine/src/registry.rs
@@ -1134,6 +1134,15 @@ impl ComponentFactory<Arc<dyn ModelExecutor + Send + Sync>> for CandleExecutorFa
 
                 Ok(Arc::new(executor))
             }
+            ferrum_models::Architecture::Clip => {
+                info!("Using CLIP executor for multimodal embeddings");
+                let executor = ferrum_models::ClipModelExecutor::from_path(
+                    &model_path,
+                    candle_device.clone(),
+                    dtype,
+                )?;
+                Ok(Arc::new(executor))
+            }
             _ => Err(FerrumError::model(format!(
                 "Architecture {:?} not supported",
                 model_def.architecture
@@ -1151,6 +1160,7 @@ impl ComponentFactory<Arc<dyn ModelExecutor + Send + Sync>> for CandleExecutorFa
                 "llama".to_string(),
                 "qwen2".to_string(),
                 "qwen3".to_string(),
+                "clip".to_string(),
                 "fp16".to_string(),
                 "fp32".to_string(),
             ],

--- a/crates/ferrum-interfaces/src/engine.rs
+++ b/crates/ferrum-interfaces/src/engine.rs
@@ -36,8 +36,8 @@ pub trait InferenceEngine: Send + Sync {
     /// Health check
     async fn health_check(&self) -> ferrum_types::HealthStatus;
 
-    /// Embed text tokens → float vector. Default: not supported.
-    async fn embed_text(&self, _tokens: &[u32]) -> Result<Vec<f32>> {
+    /// Embed raw text string → float vector (engine handles tokenization).
+    async fn embed_text(&self, _text: &str) -> Result<Vec<f32>> {
         Err(ferrum_types::FerrumError::model(
             "This engine does not support text embedding",
         ))

--- a/crates/ferrum-interfaces/src/engine.rs
+++ b/crates/ferrum-interfaces/src/engine.rs
@@ -35,6 +35,25 @@ pub trait InferenceEngine: Send + Sync {
 
     /// Health check
     async fn health_check(&self) -> ferrum_types::HealthStatus;
+
+    /// Embed text tokens → float vector. Default: not supported.
+    async fn embed_text(&self, _tokens: &[u32]) -> Result<Vec<f32>> {
+        Err(ferrum_types::FerrumError::model(
+            "This engine does not support text embedding",
+        ))
+    }
+
+    /// Embed image (file path or base64) → float vector. Default: not supported.
+    async fn embed_image(&self, _image: &str) -> Result<Vec<f32>> {
+        Err(ferrum_types::FerrumError::model(
+            "This engine does not support image embedding",
+        ))
+    }
+
+    /// Get embedding dimension. Default: 0 (not an embedding model).
+    fn embedding_dim(&self) -> usize {
+        0
+    }
 }
 
 /// Advanced engine capabilities

--- a/crates/ferrum-models/Cargo.toml
+++ b/crates/ferrum-models/Cargo.toml
@@ -61,6 +61,8 @@ hf-hub = { workspace = true }
 indicatif = "0.17"
 pathdiff = "0.2"
 futures-util = "0.3"
+image = { version = "0.25", default-features = false, features = ["jpeg", "png", "webp"] }
+base64 = "0.22"
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/crates/ferrum-models/src/architectures/clip.rs
+++ b/crates/ferrum-models/src/architectures/clip.rs
@@ -1,0 +1,159 @@
+//! CLIP model wrapper — supports OpenAI CLIP and Chinese-CLIP.
+//!
+//! Wraps candle-transformers' ClipModel / ChineseClipModel with a unified interface
+//! for text and image embedding extraction.
+
+use candle_core::{DType, Device as CandleDevice, Tensor};
+use candle_nn::VarBuilder;
+use candle_transformers::models::chinese_clip::{ChineseClipConfig, ChineseClipModel};
+use candle_transformers::models::clip::{self, ClipConfig, ClipModel};
+use ferrum_types::{FerrumError, Result};
+use parking_lot::Mutex;
+use tracing::info;
+
+/// Which CLIP variant is loaded.
+enum ClipVariant {
+    OpenAI(ClipModel),
+    Chinese(ChineseClipModel),
+}
+
+/// Unified CLIP model wrapper.
+pub struct ClipModelWrapper {
+    model: Mutex<ClipVariant>,
+    device: CandleDevice,
+    dtype: DType,
+    image_size: usize,
+    projection_dim: usize,
+}
+
+impl ClipModelWrapper {
+    /// Load OpenAI CLIP from VarBuilder.
+    pub fn new_openai(
+        vb: VarBuilder,
+        config: &ClipConfig,
+        device: CandleDevice,
+        dtype: DType,
+    ) -> Result<Self> {
+        info!("Loading OpenAI CLIP (image_size={})", config.image_size);
+        let model = ClipModel::new(vb, config)
+            .map_err(|e| FerrumError::model(format!("CLIP load: {e}")))?;
+        Ok(Self {
+            projection_dim: config.vision_config.projection_dim,
+            image_size: config.image_size,
+            model: Mutex::new(ClipVariant::OpenAI(model)),
+            device,
+            dtype,
+        })
+    }
+
+    /// Load Chinese-CLIP from VarBuilder.
+    pub fn new_chinese(
+        vb: VarBuilder,
+        config: &ChineseClipConfig,
+        device: CandleDevice,
+        dtype: DType,
+    ) -> Result<Self> {
+        info!(
+            "Loading Chinese-CLIP (image_size={}, projection_dim={})",
+            config.image_size, config.projection_dim
+        );
+        let model = ChineseClipModel::new(vb, config)
+            .map_err(|e| FerrumError::model(format!("Chinese-CLIP load: {e}")))?;
+        Ok(Self {
+            projection_dim: config.projection_dim,
+            image_size: config.image_size,
+            model: Mutex::new(ClipVariant::Chinese(model)),
+            device,
+            dtype,
+        })
+    }
+
+    /// Load from config.json — auto-detects CLIP variant.
+    ///
+    /// candle's ClipConfig doesn't derive Deserialize, so we use preset configs
+    /// and override image_size / projection_dim from the JSON when present.
+    pub fn from_config_json(
+        vb: VarBuilder,
+        config_path: &std::path::Path,
+        device: CandleDevice,
+        dtype: DType,
+    ) -> Result<Self> {
+        let raw: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(config_path)
+                .map_err(|e| FerrumError::model(format!("read config: {e}")))?,
+        )
+        .map_err(|e| FerrumError::model(format!("parse config: {e}")))?;
+
+        let model_type = raw.get("model_type").and_then(|v| v.as_str()).unwrap_or("");
+
+        if model_type == "chinese_clip" {
+            let mut config = ChineseClipConfig::clip_vit_base_patch16();
+            if let Some(v) = raw.get("projection_dim").and_then(|v| v.as_u64()) {
+                config.projection_dim = v as usize;
+            }
+            if let Some(vc) = raw.get("vision_config") {
+                if let Some(v) = vc.get("image_size").and_then(|v| v.as_u64()) {
+                    config.vision_config.image_size = v as usize;
+                    config.image_size = v as usize;
+                }
+            }
+            Self::new_chinese(vb, &config, device, dtype)
+        } else {
+            let mut config = ClipConfig::vit_base_patch32();
+            if let Some(vc) = raw.get("vision_config") {
+                if let Some(v) = vc.get("image_size").and_then(|v| v.as_u64()) {
+                    config.vision_config.image_size = v as usize;
+                    config.image_size = v as usize;
+                }
+                if let Some(v) = vc.get("projection_dim").and_then(|v| v.as_u64()) {
+                    config.vision_config.projection_dim = v as usize;
+                }
+            }
+            Self::new_openai(vb, &config, device, dtype)
+        }
+    }
+
+    /// Get text embedding (L2-normalized).
+    pub fn get_text_features(&self, input_ids: &Tensor) -> Result<Tensor> {
+        let model = self.model.lock();
+        let features = match &*model {
+            ClipVariant::OpenAI(m) => m
+                .get_text_features(input_ids)
+                .map_err(|e| FerrumError::model(format!("text features: {e}")))?,
+            ClipVariant::Chinese(m) => m
+                .get_text_features(input_ids, None, None)
+                .map_err(|e| FerrumError::model(format!("text features: {e}")))?,
+        };
+        clip::div_l2_norm(&features).map_err(|e| FerrumError::model(format!("l2 norm: {e}")))
+    }
+
+    /// Get image embedding (L2-normalized).
+    pub fn get_image_features(&self, pixel_values: &Tensor) -> Result<Tensor> {
+        let model = self.model.lock();
+        let features = match &*model {
+            ClipVariant::OpenAI(m) => m
+                .get_image_features(pixel_values)
+                .map_err(|e| FerrumError::model(format!("image features: {e}")))?,
+            ClipVariant::Chinese(m) => m
+                .get_image_features(pixel_values)
+                .map_err(|e| FerrumError::model(format!("image features: {e}")))?,
+        };
+        clip::div_l2_norm(&features).map_err(|e| FerrumError::model(format!("l2 norm: {e}")))
+    }
+
+    pub fn device(&self) -> &CandleDevice {
+        &self.device
+    }
+
+    pub fn dtype(&self) -> DType {
+        self.dtype
+    }
+
+    pub fn image_size(&self) -> usize {
+        self.image_size
+    }
+
+    pub fn projection_dim(&self) -> usize {
+        self.projection_dim
+    }
+}

--- a/crates/ferrum-models/src/architectures/clip.rs
+++ b/crates/ferrum-models/src/architectures/clip.rs
@@ -1,12 +1,13 @@
-//! CLIP model wrapper — supports OpenAI CLIP and Chinese-CLIP.
+//! CLIP model wrapper — supports OpenAI CLIP, Chinese-CLIP, and SigLIP.
 //!
-//! Wraps candle-transformers' ClipModel / ChineseClipModel with a unified interface
-//! for text and image embedding extraction.
+//! Wraps candle-transformers' ClipModel / ChineseClipModel / siglip::Model
+//! with a unified interface for text and image embedding extraction.
 
 use candle_core::{DType, Device as CandleDevice, Tensor};
 use candle_nn::VarBuilder;
 use candle_transformers::models::chinese_clip::{ChineseClipConfig, ChineseClipModel};
 use candle_transformers::models::clip::{self, ClipConfig, ClipModel};
+use candle_transformers::models::siglip;
 use ferrum_types::{FerrumError, Result};
 use parking_lot::Mutex;
 use tracing::info;
@@ -15,6 +16,7 @@ use tracing::info;
 enum ClipVariant {
     OpenAI(ClipModel),
     Chinese(ChineseClipModel),
+    SigLIP(siglip::Model),
 }
 
 /// Unified CLIP model wrapper.
@@ -68,6 +70,30 @@ impl ClipModelWrapper {
         })
     }
 
+    /// Load SigLIP from VarBuilder.
+    pub fn new_siglip(
+        vb: VarBuilder,
+        config: &siglip::Config,
+        device: CandleDevice,
+        dtype: DType,
+    ) -> Result<Self> {
+        let image_size = config.vision_config.image_size;
+        let projection_dim = config.vision_config.hidden_size;
+        info!(
+            "Loading SigLIP (image_size={}, hidden_size={})",
+            image_size, projection_dim
+        );
+        let model = siglip::Model::new(config, vb)
+            .map_err(|e| FerrumError::model(format!("SigLIP load: {e}")))?;
+        Ok(Self {
+            projection_dim,
+            image_size,
+            model: Mutex::new(ClipVariant::SigLIP(model)),
+            device,
+            dtype,
+        })
+    }
+
     /// Load from config.json — auto-detects CLIP variant.
     ///
     /// candle's ClipConfig doesn't derive Deserialize, so we use preset configs
@@ -85,6 +111,13 @@ impl ClipModelWrapper {
         .map_err(|e| FerrumError::model(format!("parse config: {e}")))?;
 
         let model_type = raw.get("model_type").and_then(|v| v.as_str()).unwrap_or("");
+
+        if model_type == "siglip" {
+            // SigLIP config derives Deserialize — parse directly
+            let config: siglip::Config =
+                serde_json::from_value(raw).unwrap_or_else(|_| siglip::Config::base_patch16_224());
+            return Self::new_siglip(vb, &config, device, dtype);
+        }
 
         if model_type == "chinese_clip" {
             let mut config = ChineseClipConfig::clip_vit_base_patch16();
@@ -123,6 +156,9 @@ impl ClipModelWrapper {
             ClipVariant::Chinese(m) => m
                 .get_text_features(input_ids, None, None)
                 .map_err(|e| FerrumError::model(format!("text features: {e}")))?,
+            ClipVariant::SigLIP(m) => m
+                .get_text_features(input_ids)
+                .map_err(|e| FerrumError::model(format!("text features: {e}")))?,
         };
         clip::div_l2_norm(&features).map_err(|e| FerrumError::model(format!("l2 norm: {e}")))
     }
@@ -135,6 +171,9 @@ impl ClipModelWrapper {
                 .get_image_features(pixel_values)
                 .map_err(|e| FerrumError::model(format!("image features: {e}")))?,
             ClipVariant::Chinese(m) => m
+                .get_image_features(pixel_values)
+                .map_err(|e| FerrumError::model(format!("image features: {e}")))?,
+            ClipVariant::SigLIP(m) => m
                 .get_image_features(pixel_values)
                 .map_err(|e| FerrumError::model(format!("image features: {e}")))?,
         };

--- a/crates/ferrum-models/src/architectures/mod.rs
+++ b/crates/ferrum-models/src/architectures/mod.rs
@@ -1,11 +1,13 @@
 //! Model architecture implementations
 
 pub mod bert;
+pub mod clip;
 pub mod llama;
 pub mod qwen2;
 pub mod qwen3;
 
 pub use bert::BertModelWrapper;
+pub use clip::ClipModelWrapper;
 pub use llama::LlamaModelWrapper;
 pub use qwen2::Qwen2ModelWrapper;
 pub use qwen3::Qwen3ModelWrapper;

--- a/crates/ferrum-models/src/definition.rs
+++ b/crates/ferrum-models/src/definition.rs
@@ -170,10 +170,16 @@ impl ConfigManager {
         // Detect architecture
         let architecture = self.detect_architecture(raw)?;
 
-        // Parse common fields
+        // Parse common fields (CLIP stores these in text_config/vision_config)
+        let text_cfg = obj.get("text_config");
         let hidden_size = obj
             .get("hidden_size")
             .and_then(|v| v.as_u64())
+            .or_else(|| {
+                text_cfg
+                    .and_then(|tc| tc.get("hidden_size"))
+                    .and_then(|v| v.as_u64())
+            })
             .unwrap_or(4096) as usize;
 
         let intermediate_size = obj
@@ -182,11 +188,16 @@ impl ConfigManager {
             .or_else(|| obj.get("ffn_dim").and_then(|v| v.as_u64()))
             .unwrap_or(11008) as usize;
 
+        // CLIP models store vocab_size in text_config, not at top level
         let vocab_size = obj
             .get("vocab_size")
             .and_then(|v| v.as_u64())
-            .ok_or_else(|| FerrumError::model("vocab_size not found in config"))?
-            as usize;
+            .or_else(|| {
+                text_cfg
+                    .and_then(|tc| tc.get("vocab_size"))
+                    .and_then(|v| v.as_u64())
+            })
+            .unwrap_or(0) as usize;
 
         let num_hidden_layers = obj
             .get("num_hidden_layers")

--- a/crates/ferrum-models/src/executor/clip_executor.rs
+++ b/crates/ferrum-models/src/executor/clip_executor.rs
@@ -1,0 +1,248 @@
+//! CLIP Model Executor for multimodal embeddings.
+//!
+//! Supports both text and image embedding via unified interface.
+//! Text goes through CLIP text encoder, images through vision encoder.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use candle_core::{DType, Device as CandleDevice, Tensor};
+use candle_nn::VarBuilder;
+use ferrum_interfaces::{
+    model_executor::{
+        AttentionType, DecodeInput, DecodeOutput, ExecutorCapabilities, ExecutorMemoryUsage,
+        ExecutorState, ExecutorStatus, MemoryRequirements, PrefillInput, PrefillOutput,
+    },
+    BlockTable, CacheHandleStats, KvCacheHandle, ModelExecutor, TensorRef,
+};
+use ferrum_types::{DataType, Device, FerrumError, ModelInfo, ModelType, Result};
+use tracing::info;
+
+use super::common;
+use crate::architectures::clip::ClipModelWrapper;
+use crate::image_processor::ClipImageProcessor;
+use crate::tensor_wrapper::CandleTensorWrapper;
+
+/// CLIP executor for text and image embeddings.
+pub struct ClipModelExecutor {
+    model: ClipModelWrapper,
+    image_processor: ClipImageProcessor,
+    info: ModelInfo,
+}
+
+impl ClipModelExecutor {
+    pub fn new(model: ClipModelWrapper, info: ModelInfo) -> Self {
+        let image_processor = ClipImageProcessor::new(model.image_size());
+        info!(
+            "Created ClipModelExecutor: {} (dim={}, image_size={})",
+            info.model_id,
+            model.projection_dim(),
+            model.image_size()
+        );
+        Self {
+            model,
+            image_processor,
+            info,
+        }
+    }
+
+    /// Load from model directory (config.json + safetensors).
+    pub fn from_path(model_path: &str, device: CandleDevice, dtype: DType) -> Result<Self> {
+        let dir = std::path::Path::new(model_path);
+        let config_path = dir.join("config.json");
+
+        let safetensors: Vec<_> = std::fs::read_dir(dir)
+            .map_err(|e| FerrumError::model(format!("read dir: {e}")))?
+            .filter_map(|e| e.ok())
+            .map(|e| e.path())
+            .filter(|p| p.extension().map_or(false, |ext| ext == "safetensors"))
+            .collect();
+
+        if safetensors.is_empty() {
+            return Err(FerrumError::model("No safetensors files found"));
+        }
+
+        let vb = unsafe {
+            VarBuilder::from_mmaped_safetensors(&safetensors, dtype, &device)
+                .map_err(|e| FerrumError::model(format!("load weights: {e}")))?
+        };
+
+        let model = ClipModelWrapper::from_config_json(vb, &config_path, device, dtype)?;
+
+        let info = ModelInfo {
+            model_id: ferrum_types::ModelId(model_path.to_string()),
+            model_type: ModelType::Clip,
+            hidden_size: model.projection_dim(),
+            vocab_size: 0,
+            num_layers: 0,
+            num_heads: 0,
+            num_kv_heads: 0,
+            num_parameters: 0,
+            max_sequence_length: 77,
+            device: Device::CPU,
+            dtype: DataType::FP32,
+            version: None,
+            license: None,
+            metadata: HashMap::new(),
+        };
+
+        Ok(Self::new(model, info))
+    }
+
+    /// Embed text tokens → L2-normalized vector.
+    pub fn embed_text(&self, input_ids: &[u32]) -> Result<Tensor> {
+        let ids = Tensor::new(input_ids, self.model.device())
+            .map_err(|e| FerrumError::model(format!("tensor: {e}")))?
+            .unsqueeze(0)
+            .map_err(|e| FerrumError::model(format!("unsqueeze: {e}")))?;
+        self.model.get_text_features(&ids)
+    }
+
+    /// Embed image from file path → L2-normalized vector.
+    pub fn embed_image_path(&self, path: &str) -> Result<Tensor> {
+        let pixel_values = self
+            .image_processor
+            .process_path(path, self.model.device())?;
+        self.model.get_image_features(&pixel_values)
+    }
+
+    /// Embed image from base64 data → L2-normalized vector.
+    pub fn embed_image_base64(&self, data: &str) -> Result<Tensor> {
+        let pixel_values = self
+            .image_processor
+            .process_base64(data, self.model.device())?;
+        self.model.get_image_features(&pixel_values)
+    }
+
+    pub fn projection_dim(&self) -> usize {
+        self.model.projection_dim()
+    }
+}
+
+// Dummy KV cache for encoder-only CLIP (same pattern as BERT).
+#[derive(Clone, Debug)]
+struct DummyClipCache;
+
+impl KvCacheHandle for DummyClipCache {
+    fn block_table(&self) -> &BlockTable {
+        static EMPTY: std::sync::OnceLock<BlockTable> = std::sync::OnceLock::new();
+        EMPTY.get_or_init(|| BlockTable::new(16))
+    }
+
+    fn block_table_mut(&mut self) -> &mut BlockTable {
+        unimplemented!("CLIP does not use KV cache")
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn device(&self) -> Device {
+        Device::CPU
+    }
+
+    fn num_layers(&self) -> usize {
+        0
+    }
+
+    fn num_heads(&self) -> usize {
+        0
+    }
+
+    fn head_dim(&self) -> usize {
+        0
+    }
+
+    fn key_cache(&self, _layer: usize) -> Result<Option<TensorRef>> {
+        Ok(None)
+    }
+
+    fn value_cache(&self, _layer: usize) -> Result<Option<TensorRef>> {
+        Ok(None)
+    }
+
+    fn clone_handle(&self) -> Result<Arc<dyn KvCacheHandle>> {
+        Ok(Arc::new(self.clone()))
+    }
+
+    fn stats(&self) -> CacheHandleStats {
+        CacheHandleStats {
+            memory_bytes: 0,
+            blocks_allocated: 0,
+            tokens_stored: 0,
+            utilization: 0.0,
+            last_access: std::time::Instant::now(),
+        }
+    }
+
+    fn is_valid(&self) -> bool {
+        true
+    }
+
+    fn cache_id(&self) -> String {
+        "clip_dummy_cache".to_string()
+    }
+}
+
+#[async_trait]
+impl ModelExecutor for ClipModelExecutor {
+    fn info(&self) -> &ModelInfo {
+        &self.info
+    }
+
+    async fn prefill(&self, input: &PrefillInput) -> Result<PrefillOutput> {
+        let tokens: Vec<u32> = input
+            .input_ids
+            .as_any()
+            .downcast_ref::<CandleTensorWrapper>()
+            .and_then(|w| w.inner().flatten_all().and_then(|t| t.to_vec1()).ok())
+            .unwrap_or_default();
+
+        if tokens.is_empty() {
+            return Err(FerrumError::model("Empty input"));
+        }
+
+        let embedding = self.embed_text(&tokens)?;
+        let embedding = embedding
+            .unsqueeze(1)
+            .map_err(|e| FerrumError::model(format!("unsqueeze: {e}")))?;
+        let tensor_ref: TensorRef = Arc::new(CandleTensorWrapper::new(embedding));
+        let cache: Arc<dyn KvCacheHandle> = Arc::new(DummyClipCache);
+
+        Ok(PrefillOutput::new(tensor_ref, cache))
+    }
+
+    async fn decode(&self, _input: &DecodeInput) -> Result<DecodeOutput> {
+        Err(FerrumError::model(
+            "CLIP is an encoder model — decode not supported",
+        ))
+    }
+
+    fn capabilities(&self) -> ExecutorCapabilities {
+        ExecutorCapabilities {
+            max_batch_size: 32,
+            max_sequence_length: 77,
+            attention_mechanisms: vec![AttentionType::MultiHead],
+            supports_dynamic_batching: false,
+            supports_continuous_batching: false,
+            supports_speculative_decoding: false,
+            supports_tensor_parallelism: false,
+            supports_pipeline_parallelism: false,
+            supported_dtypes: vec![DataType::FP32],
+            supported_devices: vec![self.info.device.clone()],
+            memory_requirements: MemoryRequirements {
+                parameter_memory: 600 * 1024 * 1024,
+                activation_memory_per_token: 0,
+                kv_cache_memory_per_token: 0,
+                overhead_memory: 0,
+            },
+        }
+    }
+
+    fn release_cache(&self, _cache_id: &str) {}
+
+    fn status(&self) -> ExecutorStatus {
+        common::default_executor_status()
+    }
+}

--- a/crates/ferrum-models/src/executor/mod.rs
+++ b/crates/ferrum-models/src/executor/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod bert_executor;
 pub mod candle_executor;
+pub mod clip_executor;
 pub mod common;
 pub mod qwen2_executor;
 pub mod qwen3_executor;
@@ -10,6 +11,7 @@ pub mod tp_executor;
 
 pub use bert_executor::BertModelExecutor;
 pub use candle_executor::CandleModelExecutor;
+pub use clip_executor::ClipModelExecutor;
 pub use qwen2_executor::Qwen2ModelExecutor;
 pub use qwen3_executor::Qwen3ModelExecutor;
 pub use stub_executor::StubModelExecutor;

--- a/crates/ferrum-models/src/image_processor.rs
+++ b/crates/ferrum-models/src/image_processor.rs
@@ -1,0 +1,75 @@
+//! Image preprocessing for CLIP models.
+//!
+//! Load → resize → normalize → [1, 3, H, W] tensor.
+
+use candle_core::{DType, Device, Tensor};
+use ferrum_types::{FerrumError, Result};
+
+/// CLIP image processor with configurable size and normalization.
+pub struct ClipImageProcessor {
+    image_size: usize,
+    mean: [f32; 3],
+    std: [f32; 3],
+}
+
+impl ClipImageProcessor {
+    /// Standard CLIP normalization (ImageNet stats).
+    pub fn new(image_size: usize) -> Self {
+        Self {
+            image_size,
+            mean: [0.48145466, 0.4578275, 0.40821073],
+            std: [0.26862954, 0.26130258, 0.27577711],
+        }
+    }
+
+    /// Load image from file path → preprocessed tensor.
+    pub fn process_path(&self, path: &str, device: &Device) -> Result<Tensor> {
+        let img =
+            image::open(path).map_err(|e| FerrumError::model(format!("image load {path}: {e}")))?;
+        self.process_image(img, device)
+    }
+
+    /// Decode base64 image data → preprocessed tensor.
+    pub fn process_base64(&self, data: &str, device: &Device) -> Result<Tensor> {
+        use base64::Engine;
+        // Strip optional data URI prefix
+        let raw = if let Some(pos) = data.find(",") {
+            &data[pos + 1..]
+        } else {
+            data
+        };
+        let bytes = base64::engine::general_purpose::STANDARD
+            .decode(raw)
+            .map_err(|e| FerrumError::model(format!("base64 decode: {e}")))?;
+        let img = image::load_from_memory(&bytes)
+            .map_err(|e| FerrumError::model(format!("image decode: {e}")))?;
+        self.process_image(img, device)
+    }
+
+    /// Core pipeline: DynamicImage → resize → normalize → [1, 3, H, W] tensor.
+    fn process_image(&self, img: image::DynamicImage, device: &Device) -> Result<Tensor> {
+        let size = self.image_size as u32;
+        let img = img.resize_exact(size, size, image::imageops::FilterType::Triangle);
+        let img = img.to_rgb8();
+
+        let (w, h) = (img.width() as usize, img.height() as usize);
+        let raw: Vec<f32> = img
+            .into_raw()
+            .into_iter()
+            .map(|p| p as f32 / 255.0)
+            .collect();
+
+        // [H, W, 3] → [3, H, W] with normalization
+        let mut chw = vec![0f32; 3 * h * w];
+        for c in 0..3 {
+            for i in 0..h * w {
+                chw[c * h * w + i] = (raw[i * 3 + c] - self.mean[c]) / self.std[c];
+            }
+        }
+
+        Tensor::from_vec(chw, (1, 3, h, w), device)
+            .map_err(|e| FerrumError::model(format!("tensor: {e}")))?
+            .to_dtype(DType::F32)
+            .map_err(|e| FerrumError::model(format!("dtype: {e}")))
+    }
+}

--- a/crates/ferrum-models/src/lib.rs
+++ b/crates/ferrum-models/src/lib.rs
@@ -9,6 +9,7 @@ pub mod builder;
 pub mod definition;
 pub mod executor;
 pub mod hf_download;
+pub mod image_processor;
 pub mod loader;
 pub mod registry;
 pub mod source;
@@ -17,15 +18,16 @@ pub mod tokenizer;
 pub mod weights;
 
 pub use architectures::{
-    BertModelWrapper, LlamaModelWrapper, Qwen2ModelWrapper, Qwen3ModelWrapper,
+    BertModelWrapper, ClipModelWrapper, LlamaModelWrapper, Qwen2ModelWrapper, Qwen3ModelWrapper,
 };
 pub use builder::{DefaultModelBuilderFactory, SimpleModelBuilder};
 pub use definition::{ConfigManager, ModelDefinition};
 pub use executor::{
-    BertModelExecutor, CandleModelExecutor, Qwen2ModelExecutor, Qwen3ModelExecutor,
-    StubModelExecutor,
+    BertModelExecutor, CandleModelExecutor, ClipModelExecutor, Qwen2ModelExecutor,
+    Qwen3ModelExecutor, StubModelExecutor,
 };
 pub use hf_download::HfDownloader;
+pub use image_processor::ClipImageProcessor;
 pub use loader::SafeTensorsLoader;
 pub use registry::{
     Architecture, DefaultModelRegistry, ModelAlias, ModelDiscoveryEntry, ModelFormatType,

--- a/crates/ferrum-models/src/registry.rs
+++ b/crates/ferrum-models/src/registry.rs
@@ -26,6 +26,7 @@ pub enum Architecture {
     Phi,
     GPT2,
     Bert,
+    Clip,
     Unknown,
 }
 
@@ -41,6 +42,8 @@ impl Architecture {
             "bert" | "bertmodel" | "bertformaskedlm" | "bertforsequenceclassification" => {
                 Architecture::Bert
             }
+            "clip" | "clipmodel" => Architecture::Clip,
+            "chinese_clip" | "chineseclipmodel" => Architecture::Clip,
             _ => Architecture::Unknown,
         }
     }

--- a/crates/ferrum-models/src/registry.rs
+++ b/crates/ferrum-models/src/registry.rs
@@ -44,6 +44,7 @@ impl Architecture {
             }
             "clip" | "clipmodel" => Architecture::Clip,
             "chinese_clip" | "chineseclipmodel" => Architecture::Clip,
+            "siglip" | "siglipmodel" => Architecture::Clip,
             _ => Architecture::Unknown,
         }
     }

--- a/crates/ferrum-server/src/axum_server.rs
+++ b/crates/ferrum-server/src/axum_server.rs
@@ -440,12 +440,10 @@ async fn embeddings_handler(
                 .await
                 .map_err(|e| ServerError::InternalError(format!("embed_image: {e}")))?
         } else if let Some(ref text) = item.text {
-            // Tokenize text (simple: use bytes as token IDs for now, real tokenizer in engine)
-            let tokens: Vec<u32> = text.encode_utf16().map(|c| c as u32).collect();
-            total_tokens += tokens.len() as u32;
+            total_tokens += text.len() as u32;
             state
                 .engine
-                .embed_text(&tokens)
+                .embed_text(text)
                 .await
                 .map_err(|e| ServerError::InternalError(format!("embed_text: {e}")))?
         } else {

--- a/crates/ferrum-server/src/axum_server.rs
+++ b/crates/ferrum-server/src/axum_server.rs
@@ -69,6 +69,7 @@ impl AxumServer {
             // OpenAI API routes
             .route("/v1/chat/completions", post(chat_completions_handler))
             .route("/v1/completions", post(completions_handler))
+            .route("/v1/embeddings", post(embeddings_handler))
             .route("/v1/models", get(models_handler))
             // Health & observability
             .route("/health", get(health_handler))
@@ -397,6 +398,80 @@ async fn completions_handler(
     Err(ServerError::NotImplemented(
         "Legacy completions not implemented in MVP".to_string(),
     ))
+}
+
+/// Embeddings handler — text and image embedding via OpenAI-compatible API.
+async fn embeddings_handler(
+    State(state): State<AppState>,
+    Json(request): Json<EmbeddingsRequest>,
+) -> std::result::Result<Response, ServerError> {
+    let span = span!(Level::INFO, "embeddings", model = %request.model);
+    let _enter = span.enter();
+
+    // Flatten input into individual items
+    let items: Vec<EmbeddingItem> = match request.input {
+        EmbeddingInput::Single(text) => vec![EmbeddingItem {
+            text: Some(text),
+            image: None,
+        }],
+        EmbeddingInput::Batch(texts) => texts
+            .into_iter()
+            .map(|t| EmbeddingItem {
+                text: Some(t),
+                image: None,
+            })
+            .collect(),
+        EmbeddingInput::SingleObject(item) => vec![item],
+        EmbeddingInput::BatchObjects(items) => items,
+    };
+
+    if items.is_empty() {
+        return Err(ServerError::BadRequest("Empty input".to_string()));
+    }
+
+    let mut data = Vec::with_capacity(items.len());
+    let mut total_tokens = 0u32;
+
+    for (idx, item) in items.iter().enumerate() {
+        let embedding = if let Some(ref image) = item.image {
+            state
+                .engine
+                .embed_image(image)
+                .await
+                .map_err(|e| ServerError::InternalError(format!("embed_image: {e}")))?
+        } else if let Some(ref text) = item.text {
+            // Tokenize text (simple: use bytes as token IDs for now, real tokenizer in engine)
+            let tokens: Vec<u32> = text.encode_utf16().map(|c| c as u32).collect();
+            total_tokens += tokens.len() as u32;
+            state
+                .engine
+                .embed_text(&tokens)
+                .await
+                .map_err(|e| ServerError::InternalError(format!("embed_text: {e}")))?
+        } else {
+            return Err(ServerError::BadRequest(
+                "Each input must have either 'text' or 'image'".to_string(),
+            ));
+        };
+
+        data.push(EmbeddingData {
+            object: "embedding".to_string(),
+            embedding,
+            index: idx,
+        });
+    }
+
+    let response = EmbeddingsResponse {
+        object: "list".to_string(),
+        data,
+        model: request.model,
+        usage: EmbeddingUsage {
+            prompt_tokens: total_tokens,
+            total_tokens,
+        },
+    };
+
+    Ok(Json(response).into_response())
 }
 
 async fn models_handler(

--- a/crates/ferrum-server/src/openai.rs
+++ b/crates/ferrum-server/src/openai.rs
@@ -231,6 +231,74 @@ pub struct ModelPermission {
     pub is_blocking: bool,
 }
 
+// ======================== Embeddings API ========================
+
+/// Embeddings request (OpenAI-compatible, extended for images)
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EmbeddingsRequest {
+    /// Model identifier
+    pub model: String,
+
+    /// Input to embed — text string, array of strings, or objects with text/image fields
+    pub input: EmbeddingInput,
+
+    /// Encoding format: "float" (default) or "base64"
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub encoding_format: Option<String>,
+}
+
+/// Polymorphic embedding input.
+/// Supports: single string, array of strings, single object, array of objects.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum EmbeddingInput {
+    /// Single text string (OpenAI standard)
+    Single(String),
+    /// Batch of text strings (OpenAI standard)
+    Batch(Vec<String>),
+    /// Single multimodal item (Jina-style extension)
+    SingleObject(EmbeddingItem),
+    /// Batch of multimodal items
+    BatchObjects(Vec<EmbeddingItem>),
+}
+
+/// A single embedding input item — text or image.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EmbeddingItem {
+    /// Text to embed
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text: Option<String>,
+    /// Image: file path or base64 data URI
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub image: Option<String>,
+}
+
+/// Embeddings response (OpenAI-compatible)
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EmbeddingsResponse {
+    pub object: String,
+    pub data: Vec<EmbeddingData>,
+    pub model: String,
+    pub usage: EmbeddingUsage,
+}
+
+/// Single embedding result
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EmbeddingData {
+    pub object: String,
+    pub embedding: Vec<f32>,
+    pub index: usize,
+}
+
+/// Token usage for embeddings
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EmbeddingUsage {
+    pub prompt_tokens: u32,
+    pub total_tokens: u32,
+}
+
+// ======================== Error types ========================
+
 /// OpenAI API error
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OpenAiError {

--- a/crates/ferrum-types/src/models.rs
+++ b/crates/ferrum-types/src/models.rs
@@ -19,6 +19,10 @@ pub enum ModelType {
     Gemma,
     /// Code-specific models
     Code(String),
+    /// Embedding models (BERT, etc.)
+    Embedding,
+    /// CLIP vision-language models
+    Clip,
     /// Custom model implementation
     Custom(String),
 }
@@ -31,6 +35,8 @@ impl std::fmt::Display for ModelType {
             ModelType::Qwen => write!(f, "qwen"),
             ModelType::Phi => write!(f, "phi"),
             ModelType::Gemma => write!(f, "gemma"),
+            ModelType::Embedding => write!(f, "embedding"),
+            ModelType::Clip => write!(f, "clip"),
             ModelType::Code(name) => write!(f, "code-{}", name),
             ModelType::Custom(name) => write!(f, "custom-{}", name),
         }


### PR DESCRIPTION
## Summary

- **CLIP model family support**: OpenAI CLIP, Chinese-CLIP, SigLIP
  - `ClipModelWrapper` with unified interface for all variants
  - `ClipImageProcessor`: load → resize → normalize → tensor
  - `ClipModelExecutor`: text + image embedding via `ModelExecutor` trait
- **`/v1/embeddings` API**: OpenAI-compatible, extended for images (Jina-style)
  - Text: `{"input": "hello"}` or `{"input": ["a", "b"]}`
  - Image: `{"input": {"image": "/path/to.jpg"}}` or base64
  - Mixed batch: `{"input": [{"text": "..."}, {"image": "..."}]}`
- **`EmbeddingEngine`**: lightweight `InferenceEngine` impl for embedding models
  - `embed_text`/`embed_image` on trait with default fallback
  - Built-in tokenizer (tokenizer.json or vocab.txt with BERT fallback)
- **CLI**: `ferrum embed <model> --text "..." --image photo.jpg`
  - Auto-detects architecture (BERT vs CLIP)
  - `ferrum serve` auto-detects CLIP → uses EmbeddingEngine
- **README**: split architecture table into generation + embeddings

## Verified

- Chinese-CLIP text embedding: cos=1.000000 vs Python transformers
- Chinese-CLIP image embedding: cos=1.000000 vs Python transformers
- SigLIP text + image: 768-dim vectors via CLI and API
- `ferrum serve` + `curl /v1/embeddings` end-to-end

## Test plan

- [x] `cargo check --workspace --all-targets`
- [x] `cargo test --workspace` — 47 suites pass
- [x] CLI: `ferrum embed` text + image (Chinese-CLIP, SigLIP)
- [x] API: `POST /v1/embeddings` text + image
- [x] Cross-validation: ferrum vs Python transformers (cos=1.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)