### PR TITLE
Release v0.5.0 — CLIP/SigLIP Embeddings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1182,7 +1182,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-cli"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1223,7 +1223,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-cuda-kernels"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "bindgen_cuda",
  "candle-core",
@@ -1235,7 +1235,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-engine"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1284,7 +1284,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-interfaces"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1301,7 +1301,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-kv"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1322,7 +1322,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-models"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1365,7 +1365,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-runtime"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1396,7 +1396,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-sampler"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1416,7 +1416,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-scheduler"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1444,7 +1444,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-server"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1479,7 +1479,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-testkit"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1494,7 +1494,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-tokenizer"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1519,7 +1519,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-types"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "chrono",
  "rand 0.9.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ resolver = "2"
 
 
 [workspace.package]
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 authors = ["Ferrum Team"]
 license = "MIT"
@@ -125,25 +125,25 @@ candle-flash-attn = "0.9.2"
 candle-metal-kernels = "0.9.2"
 
 # Internal crates - New refactored crates
-ferrum-types = { path = "crates/ferrum-types", version = "0.4.0" }
-ferrum-interfaces = { path = "crates/ferrum-interfaces", version = "0.4.0" }
+ferrum-types = { path = "crates/ferrum-types", version = "0.5.0" }
+ferrum-interfaces = { path = "crates/ferrum-interfaces", version = "0.5.0" }
 
 # Internal crates - Implementation crates
-ferrum-runtime = { path = "crates/ferrum-runtime", version = "0.4.0" }
-ferrum-scheduler = { path = "crates/ferrum-scheduler", version = "0.4.0" }
-ferrum-tokenizer = { path = "crates/ferrum-tokenizer", version = "0.4.0" }
-ferrum-sampler = { path = "crates/ferrum-sampler", version = "0.4.0" }
-ferrum-kv = { path = "crates/ferrum-kv", version = "0.4.0" }
+ferrum-runtime = { path = "crates/ferrum-runtime", version = "0.5.0" }
+ferrum-scheduler = { path = "crates/ferrum-scheduler", version = "0.5.0" }
+ferrum-tokenizer = { path = "crates/ferrum-tokenizer", version = "0.5.0" }
+ferrum-sampler = { path = "crates/ferrum-sampler", version = "0.5.0" }
+ferrum-kv = { path = "crates/ferrum-kv", version = "0.5.0" }
 
 # CUDA kernel crate
-ferrum-cuda-kernels = { path = "crates/ferrum-cuda-kernels", version = "0.4.0" }
+ferrum-cuda-kernels = { path = "crates/ferrum-cuda-kernels", version = "0.5.0" }
 
 # Internal crates - Existing crates (to be refactored)
-ferrum-engine = { path = "crates/ferrum-engine", version = "0.4.0" }
-ferrum-models = { path = "crates/ferrum-models", version = "0.4.0" }
-ferrum-server = { path = "crates/ferrum-server", version = "0.4.0" }
-ferrum-cli = { path = "crates/ferrum-cli", version = "0.4.0" }
-ferrum-testkit = { path = "crates/ferrum-testkit", version = "0.4.0" }
+ferrum-engine = { path = "crates/ferrum-engine", version = "0.5.0" }
+ferrum-models = { path = "crates/ferrum-models", version = "0.5.0" }
+ferrum-server = { path = "crates/ferrum-server", version = "0.5.0" }
+ferrum-cli = { path = "crates/ferrum-cli", version = "0.5.0" }
+ferrum-testkit = { path = "crates/ferrum-testkit", version = "0.5.0" }
 
 
 [profile.release]


### PR DESCRIPTION
## Summary

- CLIP model family: OpenAI CLIP, Chinese-CLIP, SigLIP
- `/v1/embeddings` API (OpenAI-compatible, image extension)
- `ferrum embed` CLI with `--image` flag
- `EmbeddingEngine` for embedding model serving
- Bump all crates to v0.5.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)