### PR TITLE
feat(quantization): GGUF reader (Phase 1A) — header parse + tensor enumeration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1458,6 +1458,7 @@ dependencies = [
 name = "ferrum-quantization"
 version = "0.7.0"
 dependencies = [
+ "candle-core",
  "ferrum-kernels",
  "ferrum-types",
  "half",
@@ -1465,6 +1466,7 @@ dependencies = [
  "safetensors 0.4.5",
  "serde",
  "serde_json",
+ "tempfile",
  "tracing",
 ]
 

--- a/crates/ferrum-quantization/Cargo.toml
+++ b/crates/ferrum-quantization/Cargo.toml
@@ -10,12 +10,16 @@ readme = "../../README.md"
 [dependencies]
 ferrum-types = { workspace = true }
 ferrum-kernels = { workspace = true }
+candle-core = { workspace = true }
 tracing = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 safetensors = { workspace = true }
 memmap2 = "0.9"
 half = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3.8"
 
 [features]
 default = []

--- a/crates/ferrum-quantization/src/gguf/file.rs
+++ b/crates/ferrum-quantization/src/gguf/file.rs
@@ -1,0 +1,161 @@
+//! `GgufFile`: mmap-backed reader for a single GGUF file.
+//!
+//! Lifecycle:
+//!   1. `GgufFile::open(path)` — mmaps the file and parses the header.
+//!      No tensor payloads are read at this stage.
+//!   2. `architecture()`, `metadata_*()`, `tensor_names()`, `tensor_info()` —
+//!      cheap lookups, all served from the parsed header in memory.
+//!   3. `read_tensor(name, device)` — slices the mmap at the right offset
+//!      and asks candle to materialise a `QTensor` (still quantized).
+//!
+//! Tensor reads only need a shared `&self` because the mmap is immutable; the
+//! file is safe to share across threads. (Candle's `Content::tensor` wants
+//! a `&mut R: Read + Seek`, but we satisfy it with a fresh `Cursor<&[u8]>`
+//! on each call — the cursor's mutable state is local to the call.)
+
+use std::fs::File;
+use std::io::Cursor;
+use std::path::Path;
+
+use candle_core::quantized::gguf_file::{Content, TensorInfo, Value};
+use candle_core::quantized::QTensor;
+use candle_core::{Device, Error as CandleError, Result as CandleResult};
+use memmap2::Mmap;
+
+/// Read-only handle to a memory-mapped GGUF file.
+pub struct GgufFile {
+    /// memory-mapped file payload. Kept alive for the lifetime of `self`
+    /// because `read_tensor` slices into it.
+    mmap: Mmap,
+    /// Parsed header / metadata / tensor descriptors. No payload bytes.
+    content: Content,
+}
+
+impl GgufFile {
+    /// Open and parse the header of a GGUF file.
+    ///
+    /// Returns immediately after the descriptor table is read — no tensor
+    /// data is materialised. `read_tensor` lazy-loads individual tensors.
+    pub fn open(path: impl AsRef<Path>) -> CandleResult<Self> {
+        let path_ref = path.as_ref();
+        let file = File::open(path_ref).map_err(|e| {
+            CandleError::Msg(format!(
+                "failed to open GGUF file '{}': {e}",
+                path_ref.display()
+            ))
+        })?;
+        // SAFETY: `Mmap::map` requires that the underlying file is not modified
+        // while the mapping is live. We treat the file as read-only for the
+        // entire lifetime of `self`. `Mmap` itself only exposes `&[u8]`.
+        let mmap = unsafe { Mmap::map(&file) }.map_err(|e| {
+            CandleError::Msg(format!(
+                "failed to mmap GGUF file '{}': {e}",
+                path_ref.display()
+            ))
+        })?;
+        let mut cursor = Cursor::new(&mmap[..]);
+        let content = Content::read(&mut cursor)?;
+        Ok(Self { mmap, content })
+    }
+
+    /// Raw access to candle's parsed header — for callers that need the full
+    /// `metadata` / `tensor_infos` maps. Prefer the typed accessors below.
+    pub fn content(&self) -> &Content {
+        &self.content
+    }
+
+    // ── Metadata: typed accessors ─────────────────────────────────────────
+    //
+    // GGUF metadata keys are conventionally `<scope>.<field>` strings, e.g.
+    // `general.architecture` or `qwen3.block_count`. Different model families
+    // namespace under their architecture id. `architecture()` is the one key
+    // that's always present and tells you which scope to read the rest from.
+
+    /// Architecture string, e.g. `"qwen3"`, `"llama"`. Read from
+    /// `general.architecture`. Errors if the key is missing or non-string.
+    pub fn architecture(&self) -> CandleResult<&str> {
+        self.metadata_string("general.architecture")
+    }
+
+    /// Raw metadata value lookup. Returns `None` if the key is absent.
+    pub fn metadata(&self, key: &str) -> Option<&Value> {
+        self.content.metadata.get(key)
+    }
+
+    /// Read a string-typed metadata field. Errors if missing or wrong type.
+    pub fn metadata_string(&self, key: &str) -> CandleResult<&str> {
+        self.require_metadata(key)?.to_string().map(|s| s.as_str())
+    }
+
+    /// Read a u32-typed metadata field. Errors if missing or wrong type.
+    pub fn metadata_u32(&self, key: &str) -> CandleResult<u32> {
+        self.require_metadata(key)?.to_u32()
+    }
+
+    /// Read a u64-typed metadata field. Errors if missing or wrong type.
+    pub fn metadata_u64(&self, key: &str) -> CandleResult<u64> {
+        self.require_metadata(key)?.to_u64()
+    }
+
+    /// Read an f32-typed metadata field. Errors if missing or wrong type.
+    pub fn metadata_f32(&self, key: &str) -> CandleResult<f32> {
+        self.require_metadata(key)?.to_f32()
+    }
+
+    /// Read a bool-typed metadata field. Errors if missing or wrong type.
+    pub fn metadata_bool(&self, key: &str) -> CandleResult<bool> {
+        self.require_metadata(key)?.to_bool()
+    }
+
+    fn require_metadata(&self, key: &str) -> CandleResult<&Value> {
+        self.metadata(key)
+            .ok_or_else(|| CandleError::Msg(format!("GGUF metadata key missing: '{key}'")))
+    }
+
+    // ── Tensor enumeration ────────────────────────────────────────────────
+
+    /// Total number of tensors declared in the header.
+    pub fn tensor_count(&self) -> usize {
+        self.content.tensor_infos.len()
+    }
+
+    /// Iterate over every tensor name in the file. Order is whatever the
+    /// underlying `HashMap` yields — do not rely on it being deterministic.
+    pub fn tensor_names(&self) -> impl Iterator<Item = &str> {
+        self.content.tensor_infos.keys().map(|s| s.as_str())
+    }
+
+    /// Look up a tensor descriptor (shape, dtype, byte offset) without
+    /// touching the payload. `None` if the tensor isn't in the file.
+    pub fn tensor_info(&self, name: &str) -> Option<&TensorInfo> {
+        self.content.tensor_infos.get(name)
+    }
+
+    /// Whether a tensor with `name` is declared in the header.
+    pub fn has_tensor(&self, name: &str) -> bool {
+        self.content.tensor_infos.contains_key(name)
+    }
+
+    // ── Tensor read ───────────────────────────────────────────────────────
+
+    /// Materialise a tensor as a candle `QTensor` on the target device.
+    ///
+    /// The returned tensor is **still quantized** — no dequant happens here.
+    /// Wrap it in `QMatMul::from_qtensor` for inference, or call
+    /// `QTensor::dequantize(device)` to get a fp32 `Tensor`.
+    pub fn read_tensor(&self, name: &str, device: &Device) -> CandleResult<QTensor> {
+        let mut cursor = Cursor::new(&self.mmap[..]);
+        self.content.tensor(&mut cursor, name, device)
+    }
+}
+
+impl std::fmt::Debug for GgufFile {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("GgufFile")
+            .field("size_bytes", &self.mmap.len())
+            .field("metadata_keys", &self.content.metadata.len())
+            .field("tensor_count", &self.content.tensor_infos.len())
+            .field("tensor_data_offset", &self.content.tensor_data_offset)
+            .finish()
+    }
+}

--- a/crates/ferrum-quantization/src/gguf/mod.rs
+++ b/crates/ferrum-quantization/src/gguf/mod.rs
@@ -1,0 +1,35 @@
+//! GGUF (GGML Universal Format) reader.
+//!
+//! Phase 1A scope: parse the file header, expose metadata + tensor descriptors,
+//! and load individual tensors as candle `QTensor` (which already handles
+//! dequant for every K-quant variant on CPU / Metal / CUDA).
+//!
+//! Out of scope here (lands in 1B / 1C): mapping the GGUF tensor names
+//! (`blk.0.attn_q.weight`) to ferrum's model-config naming, wrapping `QTensor`
+//! into the project's `Linear<B>` trait, and implementing `WeightLoader`.
+//!
+//! ## Why wrap candle instead of writing a parser from scratch
+//!
+//! `candle_core::quantized::gguf_file::Content` already implements the full
+//! GGUF v1/v2/v3 spec, including all current GGML K-quant variants and
+//! Metal/CUDA/CPU dequant kernels. Re-implementing that for ferrum would be
+//! 3-5 weeks of work duplicating well-tested code. Instead this module
+//! provides a small adapter that:
+//!
+//!   1. Adds an `mmap`-backed `open(path)` constructor (candle's API takes
+//!      a generic `Read + Seek` and pushes file handling to the caller).
+//!   2. Provides typed metadata accessors keyed by string (`metadata_string`,
+//!      `metadata_u32`, …) so callers don't pattern-match on `Value` everywhere.
+//!   3. Documents the GGUF metadata key conventions ferrum relies on
+//!      (`general.architecture`, `<arch>.block_count`, …) in one place.
+
+pub mod file;
+
+pub use file::GgufFile;
+
+// Re-exports — callers can import these from `ferrum_quantization::gguf` rather
+// than reaching into `candle_core::quantized::*` directly. Keeps the dep
+// surface explicit and lets us swap in a native parser later without churning
+// downstream call sites.
+pub use candle_core::quantized::gguf_file::{TensorInfo, Value, ValueType};
+pub use candle_core::quantized::{GgmlDType, QTensor};

--- a/crates/ferrum-quantization/src/lib.rs
+++ b/crates/ferrum-quantization/src/lib.rs
@@ -18,6 +18,7 @@
 
 pub mod dense;
 pub mod factory;
+pub mod gguf;
 pub mod gptq;
 pub mod loader;
 pub mod native_safetensors;
@@ -25,6 +26,7 @@ pub mod traits;
 
 pub use dense::DenseLinear;
 pub use factory::DefaultLinearFactory;
+pub use gguf::GgufFile;
 pub use gptq::GptqLinear;
 pub use loader::{PrefixedLoader, WeightLoader};
 pub use native_safetensors::NativeSafetensorsLoader;

--- a/crates/ferrum-quantization/tests/gguf_parse_test.rs
+++ b/crates/ferrum-quantization/tests/gguf_parse_test.rs
@@ -1,0 +1,146 @@
+//! Phase 1A smoke tests: build a tiny GGUF in a tempfile, then verify the
+//! adapter can parse the header, look up metadata + tensor descriptors, and
+//! materialise the tensor on CPU.
+//!
+//! No external model files needed — we use candle's `Content::write` to
+//! synthesize a 2-tensor GGUF in memory and dump it to a tempfile.
+
+use std::io::{Cursor, Write};
+
+use candle_core::quantized::gguf_file::{self, Value};
+use candle_core::quantized::{GgmlDType, QTensor};
+use candle_core::{Device, Tensor};
+use ferrum_quantization::gguf::GgufFile;
+
+/// Build a minimal-but-realistic GGUF on disk:
+///   - architecture string: "qwen3"
+///   - one metadata u32 ("qwen3.block_count")
+///   - one metadata f32 ("qwen3.attention.layer_norm_rms_epsilon")
+///   - one F32 tensor "embed_tokens" shape (8, 4)
+///   - one Q4_0 tensor "blk.0.attn_q" shape (32, 32)  — exercises K-quant path
+fn build_test_gguf() -> tempfile::NamedTempFile {
+    let device = Device::Cpu;
+
+    // Tensor 1: small F32 (no quant) so we can round-trip values exactly.
+    let raw_a = (0..32).map(|i| i as f32 * 0.5).collect::<Vec<_>>();
+    let t_a = Tensor::from_vec(raw_a, (8, 4), &device).unwrap();
+    let qt_a = QTensor::quantize(&t_a, GgmlDType::F32).unwrap();
+
+    // Tensor 2: Q4_0 over a larger tensor so block math is non-trivial.
+    // 32x32 = 1024 elements = 32 blocks of 32 elements each (Q4_0 block size).
+    let raw_b = (0..1024)
+        .map(|i| ((i % 13) as f32 - 6.0) * 0.1)
+        .collect::<Vec<_>>();
+    let t_b = Tensor::from_vec(raw_b, (32, 32), &device).unwrap();
+    let qt_b = QTensor::quantize(&t_b, GgmlDType::Q4_0).unwrap();
+
+    // metadata + tensors must outlive the write call (slice of refs)
+    let arch_v = Value::String("qwen3".to_string());
+    let block_count_v = Value::U32(28);
+    let rms_eps_v = Value::F32(1.0e-6);
+    let metadata: Vec<(&str, &Value)> = vec![
+        ("general.architecture", &arch_v),
+        ("qwen3.block_count", &block_count_v),
+        ("qwen3.attention.layer_norm_rms_epsilon", &rms_eps_v),
+    ];
+    let tensors: Vec<(&str, &QTensor)> = vec![("embed_tokens", &qt_a), ("blk.0.attn_q", &qt_b)];
+
+    // Write to in-memory buffer first, then dump to a NamedTempFile.
+    // Going via Vec keeps Content::write happy (it wants Seek + Write).
+    let mut buf: Vec<u8> = Vec::new();
+    {
+        let mut cursor = Cursor::new(&mut buf);
+        gguf_file::write(&mut cursor, &metadata, &tensors).unwrap();
+    }
+
+    let mut tmp = tempfile::NamedTempFile::new().unwrap();
+    tmp.write_all(&buf).unwrap();
+    tmp.flush().unwrap();
+    tmp
+}
+
+#[test]
+fn gguf_open_and_parse_header() {
+    let tmp = build_test_gguf();
+
+    let gguf = GgufFile::open(tmp.path()).expect("GgufFile::open");
+
+    // Architecture is the well-known key
+    assert_eq!(gguf.architecture().unwrap(), "qwen3");
+
+    // Typed metadata accessors round-trip the values we wrote.
+    assert_eq!(gguf.metadata_u32("qwen3.block_count").unwrap(), 28);
+    assert!(
+        (gguf
+            .metadata_f32("qwen3.attention.layer_norm_rms_epsilon")
+            .unwrap()
+            - 1.0e-6)
+            .abs()
+            < 1.0e-12,
+        "rms_eps round-trip mismatch"
+    );
+
+    // Wrong-type access returns Err rather than panicking.
+    assert!(
+        gguf.metadata_u32("general.architecture").is_err(),
+        "u32 access on a string field should error"
+    );
+
+    // Missing key returns Err with a helpful message
+    let err = gguf.metadata_u32("does.not.exist").unwrap_err().to_string();
+    assert!(
+        err.contains("does.not.exist"),
+        "error mentions missing key: {err}"
+    );
+
+    // Tensor descriptor table
+    assert_eq!(gguf.tensor_count(), 2);
+    assert!(gguf.has_tensor("embed_tokens"));
+    assert!(gguf.has_tensor("blk.0.attn_q"));
+    assert!(!gguf.has_tensor("nope"));
+
+    let names: std::collections::HashSet<&str> = gguf.tensor_names().collect();
+    assert_eq!(names.len(), 2);
+    assert!(names.contains("embed_tokens"));
+    assert!(names.contains("blk.0.attn_q"));
+
+    let info_a = gguf.tensor_info("embed_tokens").unwrap();
+    assert_eq!(info_a.shape.dims(), &[8, 4]);
+    assert_eq!(info_a.ggml_dtype, GgmlDType::F32);
+
+    let info_b = gguf.tensor_info("blk.0.attn_q").unwrap();
+    assert_eq!(info_b.shape.dims(), &[32, 32]);
+    assert_eq!(info_b.ggml_dtype, GgmlDType::Q4_0);
+}
+
+#[test]
+fn gguf_read_tensor_payload_round_trip() {
+    let tmp = build_test_gguf();
+    let gguf = GgufFile::open(tmp.path()).unwrap();
+    let device = Device::Cpu;
+
+    // F32 tensor: round-trip should be bit-exact.
+    let qt = gguf.read_tensor("embed_tokens", &device).unwrap();
+    assert_eq!(qt.dtype(), GgmlDType::F32);
+    assert_eq!(qt.shape().dims(), &[8, 4]);
+
+    let dequant = qt.dequantize(&device).unwrap();
+    let values: Vec<f32> = dequant.flatten_all().unwrap().to_vec1().unwrap();
+    let expected: Vec<f32> = (0..32).map(|i| i as f32 * 0.5).collect();
+    assert_eq!(values, expected, "F32 round-trip mismatch");
+
+    // Q4_0 tensor: round-trip is lossy (~5% rel error tolerable for this test);
+    // we only assert shape + dtype here, not values.
+    let qt_b = gguf.read_tensor("blk.0.attn_q", &device).unwrap();
+    assert_eq!(qt_b.dtype(), GgmlDType::Q4_0);
+    assert_eq!(qt_b.shape().dims(), &[32, 32]);
+    let _ = qt_b.dequantize(&device).unwrap(); // just verify dequant succeeds
+}
+
+#[test]
+fn gguf_open_missing_file_returns_err() {
+    let err = GgufFile::open("/no/such/path/to/model.gguf")
+        .expect_err("opening non-existent file must error");
+    let s = err.to_string();
+    assert!(s.contains("/no/such/path"), "error includes path: {s}");
+}


### PR DESCRIPTION
First PR of the GGUF loader series. Phase 1A is intentionally narrow: open a \`.gguf\`, expose typed metadata, enumerate tensors, load individual tensors as \`QTensor\`. **No \`Linear<B>\` integration yet** — that's Phase 1B.

## Summary

\`ferrum_quantization::gguf::GgufFile\` is an mmap-backed adapter over \`candle_core::quantized::gguf_file::Content\`. Wraps candle rather than writing a parser from scratch — candle already implements GGUF v1/v2/v3 + every K-quant + CPU/Metal/CUDA dequant kernels. Wrapper localises the coupling so a future native-parser swap only changes this module.

## API

\`\`\`rust
let gguf = GgufFile::open(\"qwen3-8b-q4_k_m.gguf\")?;

// Typed metadata
let arch = gguf.architecture()?;                       // \"qwen3\"
let layers = gguf.metadata_u32(\"qwen3.block_count\")?; // 28
let eps = gguf.metadata_f32(\"qwen3.attention.layer_norm_rms_epsilon\")?;

// Tensor enumeration
for name in gguf.tensor_names() {
    let info = gguf.tensor_info(name).unwrap();
    println!(\"{name}: {:?} {:?}\", info.shape.dims(), info.ggml_dtype);
}

// Lazy tensor load (still quantized)
let qweight = gguf.read_tensor(\"blk.0.attn_q.weight\", &device)?;
\`\`\`

## Tests

Synthesise a 2-tensor GGUF (F32 + Q4_0) in a tempfile, then verify:

1. \`gguf_open_and_parse_header\` — architecture / metadata typed access / missing-key + wrong-type errors / tensor descriptor table
2. \`gguf_read_tensor_payload_round_trip\` — F32 bit-exact round-trip, Q4_0 dequant succeeds
3. \`gguf_open_missing_file_returns_err\` — error path includes the bad path

No external models needed. All on CPU.

## Files

- \`crates/ferrum-quantization/src/gguf/{mod.rs, file.rs}\` (new)
- \`crates/ferrum-quantization/tests/gguf_parse_test.rs\` (new)
- \`crates/ferrum-quantization/src/lib.rs\` (re-export \`GgufFile\`)
- \`crates/ferrum-quantization/Cargo.toml\` (+candle-core, +tempfile dev-dep)

## Test plan

- [ ] CPU CI green (cargo fmt, cargo check workspace, cargo test workspace)
- [ ] Metal CI green (cargo check + tests with --features metal)
- [ ] CUDA type check (informational)

## What's next

- **Phase 1B**: \`GgufLinear<B>\` — wrap candle's \`QMatMul\` into ferrum's \`Linear<B>\` trait so model code doesn't branch on quant type.
- **Phase 1C**: \`GgufLoader\` — implement \`WeightLoader<B>\` + GGUF-name-to-ferrum-name remap (\`blk.0.attn_q.weight\` → \`model.layers.0.self_attn.q_proj.weight\`) + metadata-to-config wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)