### PR TITLE
feat(quantization): GgufLinear<B> (Phase 1B) — wrap GGUF QTensor as Linear<B>

### DIFF
--- a/crates/ferrum-quantization/src/gguf/linear.rs
+++ b/crates/ferrum-quantization/src/gguf/linear.rs
@@ -1,0 +1,133 @@
+//! `GgufLinear<B>`: a GGUF-sourced linear projection that integrates with
+//! ferrum's `Linear<B>` trait.
+//!
+//! Phase 1B uses an **eager-dequant-at-load** strategy: when constructed from
+//! a candle `QTensor`, the quantized payload is decoded to fp32 once on CPU,
+//! then handed to `DenseLinear<B>` so the runtime path goes through the
+//! standard `B::gemm` kernel. This is the simplest correct path that works
+//! uniformly across CPU / Metal / CUDA without per-backend bridging code.
+//!
+//! Trade-off: we lose GGUF's memory advantage (Q4_K_M @ 4.5 bits/weight
+//! becomes fp32 @ 32 bits/weight in RAM) and we don't get fused
+//! dequant-matmul perf. Phase 1D will replace this with a real
+//! quantization-aware Linear that holds the QTensor and dispatches to
+//! Metal / CUDA Q4_K_M kernels.
+//!
+//! Why a dedicated `GgufLinear<B>` type instead of just returning
+//! `DenseLinear<B>`? So Phase 1D can swap the internals (eager dequant →
+//! lazy QMatMul) without churning the public API of any `WeightLoader`
+//! that already returns `Box<dyn Linear<B>>`.
+
+use candle_core::quantized::QTensor;
+use candle_core::{Device, Result as CandleResult};
+use ferrum_kernels::backend::Backend;
+
+use crate::dense::DenseLinear;
+use crate::traits::Linear;
+
+/// Linear projection backed by a GGUF-sourced quantized tensor.
+///
+/// Internally a `DenseLinear<B>` (Phase 1B), so the runtime path is the same
+/// as a plain dense weight. The distinct type lets later phases evolve the
+/// representation without changing call sites.
+pub struct GgufLinear<B: Backend> {
+    inner: DenseLinear<B>,
+}
+
+impl<B: Backend> GgufLinear<B> {
+    /// Build from a candle `QTensor` previously read out of a GGUF file.
+    ///
+    /// Expects a 2-D weight whose shape is `[out_features, in_features]`
+    /// (the GGUF convention for linear projections — rows are output
+    /// neurons). Errors if the rank is wrong or the dequant step fails.
+    pub fn from_qtensor(qt: &QTensor) -> CandleResult<Self> {
+        let dims = qt.shape().dims();
+        if dims.len() != 2 {
+            return Err(candle_core::Error::Msg(format!(
+                "GgufLinear: expected 2-D weight tensor, got rank {} (shape {:?})",
+                dims.len(),
+                dims
+            )));
+        }
+        let out_features = dims[0];
+        let in_features = dims[1];
+        let weights = dequantize_to_vec(qt)?;
+        Ok(Self {
+            inner: DenseLinear::<B>::from_rows(&weights, out_features, in_features),
+        })
+    }
+
+    /// Build with a bias vector. `bias_qt` must be a 1-D `[out_features]`
+    /// tensor — typical for Qwen2.5 / Bert / any model with attention bias.
+    pub fn from_qtensor_with_bias(qt: &QTensor, bias_qt: &QTensor) -> CandleResult<Self> {
+        let weight_dims = qt.shape().dims();
+        if weight_dims.len() != 2 {
+            return Err(candle_core::Error::Msg(format!(
+                "GgufLinear: expected 2-D weight, got rank {}",
+                weight_dims.len()
+            )));
+        }
+        let out_features = weight_dims[0];
+        let in_features = weight_dims[1];
+
+        let bias_dims = bias_qt.shape().dims();
+        if bias_dims.len() != 1 || bias_dims[0] != out_features {
+            return Err(candle_core::Error::Msg(format!(
+                "GgufLinear: bias shape {:?} doesn't match weight out_features {}",
+                bias_dims, out_features
+            )));
+        }
+
+        let weights = dequantize_to_vec(qt)?;
+        let bias = dequantize_to_vec(bias_qt)?;
+        Ok(Self {
+            inner: DenseLinear::<B>::from_rows_with_bias(
+                &weights,
+                &bias,
+                out_features,
+                in_features,
+            ),
+        })
+    }
+
+    /// Build directly from already-dequantized fp32 weights. Useful when the
+    /// caller has already paid the dequant cost (e.g. cached weights, or
+    /// constructing from synthetic data in tests).
+    pub fn from_dense_rows(
+        weight_row_major: &[f32],
+        out_features: usize,
+        in_features: usize,
+    ) -> Self {
+        Self {
+            inner: DenseLinear::<B>::from_rows(weight_row_major, out_features, in_features),
+        }
+    }
+}
+
+impl<B: Backend> Linear<B> for GgufLinear<B> {
+    fn in_features(&self) -> usize {
+        self.inner.in_features()
+    }
+
+    fn out_features(&self) -> usize {
+        self.inner.out_features()
+    }
+
+    fn forward(&self, ctx: &mut B::Context, input: &B::Buffer, out: &mut B::Buffer, m: usize) {
+        self.inner.forward(ctx, input, out, m);
+    }
+}
+
+/// Convenience: build a boxed `Linear<B>` from a `QTensor`. Useful for
+/// `WeightLoader` impls that want a uniform `Box<dyn Linear<B>>` output.
+pub fn linear_from_qtensor<B: Backend>(qt: &QTensor) -> CandleResult<Box<dyn Linear<B>>> {
+    Ok(Box::new(GgufLinear::<B>::from_qtensor(qt)?))
+}
+
+/// Dequantize on CPU, flatten to a contiguous `Vec<f32>` in row-major order.
+/// Pulled out so weight + bias paths share the same conversion.
+fn dequantize_to_vec(qt: &QTensor) -> CandleResult<Vec<f32>> {
+    let dense = qt.dequantize(&Device::Cpu)?;
+    let flat = dense.flatten_all()?;
+    flat.to_vec1::<f32>()
+}

--- a/crates/ferrum-quantization/src/gguf/mod.rs
+++ b/crates/ferrum-quantization/src/gguf/mod.rs
@@ -4,9 +4,10 @@
 //! and load individual tensors as candle `QTensor` (which already handles
 //! dequant for every K-quant variant on CPU / Metal / CUDA).
 //!
-//! Out of scope here (lands in 1B / 1C): mapping the GGUF tensor names
-//! (`blk.0.attn_q.weight`) to ferrum's model-config naming, wrapping `QTensor`
-//! into the project's `Linear<B>` trait, and implementing `WeightLoader`.
+//! Out of scope here (lands in 1C): mapping the GGUF tensor names
+//! (`blk.0.attn_q.weight`) to ferrum's model-config naming and implementing
+//! `WeightLoader`. Phase 1B (this commit) adds `GgufLinear<B>` so model
+//! code can hold a `Box<dyn Linear<B>>` regardless of the source format.
 //!
 //! ## Why wrap candle instead of writing a parser from scratch
 //!
@@ -24,8 +25,10 @@
 //!      (`general.architecture`, `<arch>.block_count`, …) in one place.
 
 pub mod file;
+pub mod linear;
 
 pub use file::GgufFile;
+pub use linear::{linear_from_qtensor, GgufLinear};
 
 // Re-exports — callers can import these from `ferrum_quantization::gguf` rather
 // than reaching into `candle_core::quantized::*` directly. Keeps the dep

--- a/crates/ferrum-quantization/src/lib.rs
+++ b/crates/ferrum-quantization/src/lib.rs
@@ -26,7 +26,7 @@ pub mod traits;
 
 pub use dense::DenseLinear;
 pub use factory::DefaultLinearFactory;
-pub use gguf::GgufFile;
+pub use gguf::{GgufFile, GgufLinear};
 pub use gptq::GptqLinear;
 pub use loader::{PrefixedLoader, WeightLoader};
 pub use native_safetensors::NativeSafetensorsLoader;

--- a/crates/ferrum-quantization/tests/gguf_linear_test.rs
+++ b/crates/ferrum-quantization/tests/gguf_linear_test.rs
@@ -1,0 +1,161 @@
+//! Phase 1B tests: `GgufLinear<B>` constructed from a candle `QTensor`
+//! produces the same forward output as a `DenseLinear<B>` built from
+//! the same dequantized weights.
+//!
+//! Two angles:
+//!   1. **Direct**: build a QTensor in memory, hand to `GgufLinear`, compare
+//!      against `DenseLinear` built from the same fp32 source.
+//!   2. **End-to-end**: synthesize a GGUF tempfile, open via `GgufFile`,
+//!      load tensor, build `GgufLinear`, forward — proves the Phase 1A
+//!      reader and Phase 1B linear compose correctly.
+//!
+//! All tests run on `CpuBackend` (always available, no feature flags).
+
+use std::io::{Cursor, Write};
+
+use candle_core::quantized::gguf_file::{self, Value};
+use candle_core::quantized::{GgmlDType, QTensor};
+use candle_core::{Device, Tensor};
+use ferrum_kernels::backend::cpu::CpuBackend;
+use ferrum_kernels::backend::Backend;
+use ferrum_kernels::Linear;
+use ferrum_quantization::gguf::{GgufFile, GgufLinear};
+use ferrum_quantization::DenseLinear;
+
+/// Run a Linear and return the output vector.
+fn forward<B: Backend<Buffer = Vec<f32>, Context = ()>>(
+    linear: &dyn Linear<B>,
+    input: &[f32],
+    m: usize,
+) -> Vec<f32> {
+    let in_buf = input.to_vec();
+    let mut out_buf = vec![0.0f32; m * linear.out_features()];
+    let mut ctx = ();
+    linear.forward(&mut ctx, &in_buf, &mut out_buf, m);
+    out_buf
+}
+
+#[test]
+fn gguf_linear_matches_dense_linear_on_f32_weights() {
+    let device = Device::Cpu;
+
+    // 4x3 weight matrix — rows are output neurons, cols are inputs.
+    // Output for input [1,1,1] should equal each row's sum.
+    #[rustfmt::skip]
+    let weights: Vec<f32> = vec![
+        1.0, 2.0, 3.0,    // row 0 — sum = 6
+        4.0, 5.0, 6.0,    // row 1 — sum = 15
+        7.0, 8.0, 9.0,    // row 2 — sum = 24
+        10.0, 11.0, 12.0, // row 3 — sum = 33
+    ];
+    let t = Tensor::from_vec(weights.clone(), (4, 3), &device).unwrap();
+    let qt = QTensor::quantize(&t, GgmlDType::F32).unwrap();
+
+    let gguf_linear = GgufLinear::<CpuBackend>::from_qtensor(&qt).unwrap();
+    assert_eq!(gguf_linear.in_features(), 3);
+    assert_eq!(gguf_linear.out_features(), 4);
+
+    let dense_linear = DenseLinear::<CpuBackend>::from_rows(&weights, 4, 3);
+
+    let input = [1.0_f32, 1.0, 1.0];
+    let out_gguf = forward(&gguf_linear, &input, 1);
+    let out_dense = forward(&dense_linear, &input, 1);
+
+    assert_eq!(out_gguf, vec![6.0, 15.0, 24.0, 33.0], "row sums");
+    assert_eq!(
+        out_gguf, out_dense,
+        "GgufLinear and DenseLinear should be bit-exact for F32 weights"
+    );
+}
+
+#[test]
+fn gguf_linear_handles_batch_dimension() {
+    let device = Device::Cpu;
+
+    // 2x3 weight, batch of 5 inputs
+    #[rustfmt::skip]
+    let weights: Vec<f32> = vec![
+        1.0, 0.0, 0.0,  // row 0 — picks input[0]
+        0.0, 1.0, 0.0,  // row 1 — picks input[1]
+    ];
+    let t = Tensor::from_vec(weights, (2, 3), &device).unwrap();
+    let qt = QTensor::quantize(&t, GgmlDType::F32).unwrap();
+    let linear = GgufLinear::<CpuBackend>::from_qtensor(&qt).unwrap();
+
+    // 5 batched inputs, each [a, b, ignored]
+    let input: Vec<f32> = vec![
+        1.0, 7.0, 99.0, // -> [1, 7]
+        2.0, 8.0, 99.0, // -> [2, 8]
+        3.0, 9.0, 99.0, // -> [3, 9]
+        4.0, 10.0, 99.0, // -> [4, 10]
+        5.0, 11.0, 99.0, // -> [5, 11]
+    ];
+    let out = forward(&linear, &input, 5);
+    assert_eq!(
+        out,
+        vec![1.0, 7.0, 2.0, 8.0, 3.0, 9.0, 4.0, 10.0, 5.0, 11.0]
+    );
+}
+
+#[test]
+fn gguf_linear_rejects_non_2d_tensor() {
+    let device = Device::Cpu;
+    let t = Tensor::from_vec(vec![1.0_f32, 2.0, 3.0, 4.0], (2, 2, 1), &device).unwrap();
+    let qt = QTensor::quantize(&t, GgmlDType::F32).unwrap();
+    let result = GgufLinear::<CpuBackend>::from_qtensor(&qt);
+    assert!(result.is_err(), "rank-3 tensor must be rejected");
+    let err = result.err().unwrap().to_string();
+    assert!(err.contains("2-D"), "error mentions rank constraint: {err}");
+}
+
+#[test]
+fn gguf_linear_with_bias_adds_bias() {
+    let device = Device::Cpu;
+    let weights: Vec<f32> = vec![1.0, 0.0, 0.0, 1.0]; // 2x2 identity
+    let t = Tensor::from_vec(weights, (2, 2), &device).unwrap();
+    let qt = QTensor::quantize(&t, GgmlDType::F32).unwrap();
+
+    let bias_v = vec![10.0_f32, -5.0];
+    let bias_t = Tensor::from_vec(bias_v, 2, &device).unwrap();
+    let bias_qt = QTensor::quantize(&bias_t, GgmlDType::F32).unwrap();
+
+    let linear = GgufLinear::<CpuBackend>::from_qtensor_with_bias(&qt, &bias_qt).unwrap();
+    let out = forward(&linear, &[3.0_f32, 7.0], 1);
+    // y = W @ x + b = [3, 7] + [10, -5] = [13, 2]
+    assert_eq!(out, vec![13.0, 2.0]);
+}
+
+#[test]
+fn gguf_linear_round_trip_through_gguf_file() {
+    // Synthesize a GGUF with one tensor, then load it back via GgufFile +
+    // GgufLinear and run a forward — proves Phase 1A and 1B compose.
+    let device = Device::Cpu;
+    #[rustfmt::skip]
+    let weights: Vec<f32> = vec![
+        2.0, 0.0,
+        0.0, 3.0,
+    ];
+    let t = Tensor::from_vec(weights, (2, 2), &device).unwrap();
+    let qt = QTensor::quantize(&t, GgmlDType::F32).unwrap();
+
+    let arch_v = Value::String("test".to_string());
+    let metadata: Vec<(&str, &Value)> = vec![("general.architecture", &arch_v)];
+    let tensors: Vec<(&str, &QTensor)> = vec![("blk.0.attn_q.weight", &qt)];
+
+    let mut buf: Vec<u8> = Vec::new();
+    {
+        let mut cursor = Cursor::new(&mut buf);
+        gguf_file::write(&mut cursor, &metadata, &tensors).unwrap();
+    }
+    let mut tmp = tempfile::NamedTempFile::new().unwrap();
+    tmp.write_all(&buf).unwrap();
+    tmp.flush().unwrap();
+
+    let gguf = GgufFile::open(tmp.path()).unwrap();
+    let loaded = gguf.read_tensor("blk.0.attn_q.weight", &device).unwrap();
+    let linear = GgufLinear::<CpuBackend>::from_qtensor(&loaded).unwrap();
+
+    let out = forward(&linear, &[1.0_f32, 1.0], 1);
+    // Identity-ish: [1,1] * diag(2,3) = [2, 3]
+    assert_eq!(out, vec![2.0, 3.0]);
+}


### PR DESCRIPTION
Phase 1B of the GGUF loader series. Builds on PR #27 (Phase 1A: \`GgufFile\` reader).

## Summary

Adds \`ferrum_quantization::gguf::GgufLinear<B>\`, the bridge between candle's \`QTensor\` (returned by \`GgufFile::read_tensor\`) and ferrum's \`Linear<B>\` trait. Model code can now hold a \`Box<dyn Linear<B>>\` whose weights came from a GGUF file, the same way it already does for dense and GPTQ sources.

## API

\`\`\`rust
let gguf = GgufFile::open(\"qwen3-8b-q4_k_m.gguf\")?;
let qt = gguf.read_tensor(\"blk.0.attn_q.weight\", &device)?;

// Without bias
let q_proj = GgufLinear::<B>::from_qtensor(&qt)?;

// With bias (Qwen2.5 attention)
let bias_qt = gguf.read_tensor(\"blk.0.attn_q.bias\", &device)?;
let q_proj = GgufLinear::<B>::from_qtensor_with_bias(&qt, &bias_qt)?;

// Boxed for loaders
let boxed: Box<dyn Linear<B>> = linear_from_qtensor::<B>(&qt)?;
\`\`\`

## Design

Phase 1B uses an **eager-dequant-at-load** strategy: the QTensor is decoded to fp32 once on CPU, then handed to the existing \`DenseLinear<B>\` so the runtime path goes through the standard \`B::gemm\` kernel. This is the simplest correct path that works uniformly across CPU / Metal / CUDA without per-backend bridging code.

**Trade-off**: we lose GGUF's memory advantage (Q4_K_M @ 4.5 bits/weight becomes fp32 @ 32 bits/weight in RAM) and don't get fused dequant-matmul perf. **Phase 1D** will replace this with a real quantization-aware Linear that holds the QTensor and dispatches to Metal / CUDA Q4_K_M kernels — without changing the public API of this PR.

## Tests

5 unit tests on \`CpuBackend\`:

1. \`gguf_linear_matches_dense_linear_on_f32_weights\` — bit-exact vs DenseLinear
2. \`gguf_linear_handles_batch_dimension\` — m=5 batched forward correct
3. \`gguf_linear_rejects_non_2d_tensor\` — rank check enforced
4. \`gguf_linear_with_bias_adds_bias\` — bias variant numerically correct
5. \`gguf_linear_round_trip_through_gguf_file\` — Phase 1A + 1B compose end-to-end

All pass locally + \`cargo check --workspace --features metal\` + \`-D warnings\` clean.

## Files

- \`crates/ferrum-quantization/src/gguf/linear.rs\` (new)
- \`crates/ferrum-quantization/tests/gguf_linear_test.rs\` (new)
- \`crates/ferrum-quantization/src/gguf/mod.rs\` (re-export \`GgufLinear\`, \`linear_from_qtensor\`)
- \`crates/ferrum-quantization/src/lib.rs\` (top-level re-export)

## Test plan

- [ ] CPU CI green
- [ ] Metal CI green
- [ ] CUDA type check (informational)

## What's next

- **Phase 1C**: \`GgufLoader\` — \`WeightLoader<B>\` impl that opens a GGUF, maps \`blk.{i}.attn_q.weight\` etc. to ferrum's model-config naming, and serves \`load_linear(\"model.layers.0.self_attn.q_proj\")\` calls. Plus metadata-to-config wiring (e.g. \`qwen3.block_count\` → \`LlamaFamilyConfig::num_layers\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)