### PR TITLE
feat(quantization): GgufLoader<B> + LlamaFamilyConfig::from_gguf (Phase 1C)

### DIFF
--- a/crates/ferrum-models/src/gguf_config.rs
+++ b/crates/ferrum-models/src/gguf_config.rs
@@ -1,0 +1,134 @@
+//! Build a `LlamaFamilyConfig` from a GGUF file's metadata.
+//!
+//! GGUF model files store the architecture as `general.architecture` (string)
+//! and namespace the actual hyperparameters under that prefix:
+//!   `qwen3.block_count`, `qwen3.embedding_length`, `qwen3.attention.head_count`, …
+//!   `llama.block_count`, `llama.attention.head_count_kv`, …
+//!
+//! This helper reads those metadata fields and produces the same
+//! `LlamaFamilyConfig` you would otherwise build via `qwen3_from_def` /
+//! `llama_from_def` from a HuggingFace `config.json`. Returning the same
+//! type means downstream model construction (`LlamaFamilyModel::load`) is
+//! unchanged regardless of source format.
+//!
+//! Phase 1C scope: dense Llama-family architectures (qwen3 / qwen2 / llama /
+//! mistral / tinyllama). MoE-specific fields (`expert_count`, `expert_used_count`)
+//! are deferred to Phase 2 alongside the MoE runtime.
+//!
+//! Architecture-specific notes:
+//!   - **qwen3**: has QK-norm by convention; rope_theta default 1e6.
+//!   - **qwen2 / qwen2.5**: no QK-norm; rope_theta default 1e6.
+//!   - **llama**: no QK-norm; rope_theta default 5e5 (Llama-3.x).
+//!   - **mistral**: no QK-norm; rope_theta default 1e7; reads
+//!     `mistral.attention.sliding_window` if present.
+
+use ferrum_quantization::gguf::GgufFile;
+use ferrum_types::{FerrumError, Result};
+
+use crate::models::llama_family::LlamaFamilyConfig;
+
+impl LlamaFamilyConfig {
+    /// Parse a `LlamaFamilyConfig` out of a GGUF file's metadata.
+    ///
+    /// Errors if `general.architecture` is missing or unrecognised, or if
+    /// any required architecture-scoped key is absent.
+    pub fn from_gguf(gguf: &GgufFile) -> Result<Self> {
+        let arch = gguf
+            .architecture()
+            .map_err(|e| FerrumError::model(format!("read general.architecture: {e}")))?
+            .to_string();
+
+        let block_count = read_u32(gguf, &format!("{arch}.block_count"))? as usize;
+        let hidden_size = read_u32(gguf, &format!("{arch}.embedding_length"))? as usize;
+        let intermediate_size = read_u32(gguf, &format!("{arch}.feed_forward_length"))? as usize;
+        let num_heads = read_u32(gguf, &format!("{arch}.attention.head_count"))? as usize;
+        // GQA models put kv-head count here; older ones omit it (= num_heads)
+        let num_kv_heads = match read_u32(gguf, &format!("{arch}.attention.head_count_kv")) {
+            Ok(v) => v as usize,
+            Err(_) => num_heads,
+        };
+        let rms_norm_eps =
+            read_f32(gguf, &format!("{arch}.attention.layer_norm_rms_epsilon"))? as f32;
+        // Some GGUFs store context length, some don't — fall back to a sane
+        // default rather than failing the whole config.
+        let max_seq_len = read_u32(gguf, &format!("{arch}.context_length"))
+            .map(|v| v as usize)
+            .unwrap_or(4096);
+
+        // rope_theta: optional; per-arch defaults.
+        let default_rope = match arch.as_str() {
+            "qwen3" | "qwen2" => 1_000_000.0_f64,
+            "llama" => 500_000.0,
+            "mistral" => 10_000_000.0,
+            _ => 10_000.0,
+        };
+        let rope_theta = read_f32(gguf, &format!("{arch}.rope.freq_base"))
+            .map(|v| v as f64)
+            .unwrap_or(default_rope);
+
+        // QK-norm: only Qwen3 has it among supported architectures.
+        let has_qk_norm = matches!(arch.as_str(), "qwen3");
+
+        // Sliding window: only Mistral v0.1 sets it; missing → 0 (disabled).
+        let sliding_window = read_u32(gguf, &format!("{arch}.attention.sliding_window"))
+            .map(|v| v as usize)
+            .unwrap_or(0);
+
+        // Vocab size: prefer arch-scoped, fall back to embed-table row count.
+        let vocab_size = match read_u32(gguf, &format!("{arch}.vocab_size")) {
+            Ok(v) => v as usize,
+            Err(_) => infer_vocab_from_embed(gguf)?,
+        };
+
+        // head_dim: GGUF doesn't always store it; derive from hidden / heads.
+        // (All known Llama-family checkpoints satisfy hidden_size % num_heads == 0.)
+        if num_heads == 0 || hidden_size % num_heads != 0 {
+            return Err(FerrumError::model(format!(
+                "GGUF config: hidden_size {hidden_size} not divisible by num_heads {num_heads}"
+            )));
+        }
+        let head_dim = hidden_size / num_heads;
+
+        Ok(LlamaFamilyConfig {
+            hidden_size,
+            intermediate_size,
+            num_heads,
+            num_kv_heads,
+            head_dim,
+            num_layers: block_count,
+            vocab_size,
+            max_seq_len,
+            rms_norm_eps,
+            rope_theta,
+            has_qk_norm,
+            sliding_window,
+        })
+    }
+}
+
+fn read_u32(gguf: &GgufFile, key: &str) -> Result<u32> {
+    gguf.metadata_u32(key)
+        .map_err(|e| FerrumError::model(format!("GGUF {key}: {e}")))
+}
+
+fn read_f32(gguf: &GgufFile, key: &str) -> Result<f32> {
+    gguf.metadata_f32(key)
+        .map_err(|e| FerrumError::model(format!("GGUF {key}: {e}")))
+}
+
+/// Vocab size ≈ rows of the embedding table. Used when `<arch>.vocab_size`
+/// isn't recorded in metadata (older GGUF dumps).
+fn infer_vocab_from_embed(gguf: &GgufFile) -> Result<usize> {
+    let info = gguf.tensor_info("token_embd.weight").ok_or_else(|| {
+        FerrumError::model(
+            "GGUF: cannot infer vocab — neither <arch>.vocab_size nor token_embd.weight present",
+        )
+    })?;
+    let dims = info.shape.dims();
+    if dims.is_empty() {
+        return Err(FerrumError::model(
+            "GGUF: token_embd.weight has empty shape",
+        ));
+    }
+    Ok(dims[0])
+}

--- a/crates/ferrum-models/src/lib.rs
+++ b/crates/ferrum-models/src/lib.rs
@@ -22,6 +22,7 @@ pub mod builder;
 pub mod common;
 pub mod definition;
 pub mod executor;
+pub mod gguf_config;
 pub mod hf_download;
 pub mod image_processor;
 pub mod loader;

--- a/crates/ferrum-models/tests/gguf_config_test.rs
+++ b/crates/ferrum-models/tests/gguf_config_test.rs
@@ -1,0 +1,213 @@
+//! `LlamaFamilyConfig::from_gguf` — verify metadata parsing for the four
+//! Llama-family architectures (qwen3 / qwen2 / llama / mistral) plus
+//! fallback paths (missing optional fields, vocab inferred from embed).
+
+use std::io::{Cursor, Write};
+
+use candle_core::quantized::gguf_file::{self, Value};
+use candle_core::quantized::{GgmlDType, QTensor};
+use candle_core::{Device, Tensor};
+use ferrum_models::models::llama_family::LlamaFamilyConfig;
+use ferrum_quantization::gguf::GgufFile;
+
+/// Build a GGUF that contains only metadata + a fake embed table — enough
+/// to drive `from_gguf` end-to-end without needing real weights.
+fn build_metadata_gguf(
+    arch: &str,
+    extra_keys: &[(&str, Value)],
+    vocab_rows: usize,
+    hidden_size: usize,
+) -> tempfile::NamedTempFile {
+    // Required: a token_embd.weight tensor — `from_gguf` falls back to it
+    // if `<arch>.vocab_size` isn't set, and it has to dequantize without
+    // shape errors. Use F32 so any size works.
+    let device = Device::Cpu;
+    let n = vocab_rows * hidden_size;
+    let raw: Vec<f32> = (0..n).map(|i| i as f32 * 0.001).collect();
+    let t = Tensor::from_vec(raw, (vocab_rows, hidden_size), &device).unwrap();
+    let embed = QTensor::quantize(&t, GgmlDType::F32).unwrap();
+
+    let arch_v = Value::String(arch.to_string());
+    let mut metadata: Vec<(&str, &Value)> = vec![("general.architecture", &arch_v)];
+    for (k, v) in extra_keys {
+        metadata.push((k, v));
+    }
+    let tensors: Vec<(&str, &QTensor)> = vec![("token_embd.weight", &embed)];
+
+    let mut buf: Vec<u8> = Vec::new();
+    {
+        let mut cursor = Cursor::new(&mut buf);
+        gguf_file::write(&mut cursor, &metadata, &tensors).unwrap();
+    }
+    let mut tmp = tempfile::NamedTempFile::new().unwrap();
+    tmp.write_all(&buf).unwrap();
+    tmp.flush().unwrap();
+    tmp
+}
+
+#[test]
+fn qwen3_config_from_gguf() {
+    // Qwen3-0.6B-ish numbers: 28 layers, hidden 1024, ffn 3072, 16 heads,
+    // 8 kv heads (GQA 2:1), rms eps 1e-6, rope 1e6, ctx 32768.
+    let block_count = Value::U32(28);
+    let hidden = Value::U32(1024);
+    let ffn = Value::U32(3072);
+    let heads = Value::U32(16);
+    let kv_heads = Value::U32(8);
+    let rms_eps = Value::F32(1.0e-6);
+    let ctx = Value::U32(32768);
+    let rope = Value::F32(1.0e6);
+    let vocab = Value::U32(151_936);
+
+    let extra = [
+        ("qwen3.block_count", block_count),
+        ("qwen3.embedding_length", hidden),
+        ("qwen3.feed_forward_length", ffn),
+        ("qwen3.attention.head_count", heads),
+        ("qwen3.attention.head_count_kv", kv_heads),
+        ("qwen3.attention.layer_norm_rms_epsilon", rms_eps),
+        ("qwen3.context_length", ctx),
+        ("qwen3.rope.freq_base", rope),
+        ("qwen3.vocab_size", vocab),
+    ];
+
+    let tmp = build_metadata_gguf("qwen3", &extra, 32, 1024);
+    let gguf = GgufFile::open(tmp.path()).unwrap();
+    let cfg = LlamaFamilyConfig::from_gguf(&gguf).expect("from_gguf");
+
+    assert_eq!(cfg.num_layers, 28);
+    assert_eq!(cfg.hidden_size, 1024);
+    assert_eq!(cfg.intermediate_size, 3072);
+    assert_eq!(cfg.num_heads, 16);
+    assert_eq!(cfg.num_kv_heads, 8);
+    assert_eq!(cfg.head_dim, 64); // 1024 / 16
+    assert_eq!(cfg.max_seq_len, 32768);
+    assert!((cfg.rms_norm_eps - 1.0e-6).abs() < 1e-12);
+    assert!((cfg.rope_theta - 1.0e6).abs() < 1.0);
+    assert_eq!(cfg.vocab_size, 151_936);
+    assert!(cfg.has_qk_norm, "Qwen3 must enable QK-norm");
+    assert_eq!(cfg.sliding_window, 0);
+}
+
+#[test]
+fn llama_config_from_gguf_uses_default_rope() {
+    // Llama-3.2-1B-ish, but omit rope_theta — helper should fall back to
+    // the Llama default of 5e5.
+    let extra = [
+        ("llama.block_count", Value::U32(16)),
+        ("llama.embedding_length", Value::U32(2048)),
+        ("llama.feed_forward_length", Value::U32(8192)),
+        ("llama.attention.head_count", Value::U32(32)),
+        ("llama.attention.head_count_kv", Value::U32(8)),
+        ("llama.attention.layer_norm_rms_epsilon", Value::F32(1.0e-5)),
+        ("llama.context_length", Value::U32(131072)),
+        ("llama.vocab_size", Value::U32(128_256)),
+    ];
+
+    let tmp = build_metadata_gguf("llama", &extra, 32, 2048);
+    let gguf = GgufFile::open(tmp.path()).unwrap();
+    let cfg = LlamaFamilyConfig::from_gguf(&gguf).unwrap();
+
+    assert_eq!(cfg.num_layers, 16);
+    assert_eq!(cfg.hidden_size, 2048);
+    assert_eq!(cfg.head_dim, 64); // 2048 / 32
+    assert!(!cfg.has_qk_norm);
+    assert!(
+        (cfg.rope_theta - 500_000.0).abs() < 1.0,
+        "Llama default rope is 5e5 when not in metadata"
+    );
+    assert_eq!(cfg.sliding_window, 0);
+}
+
+#[test]
+fn mistral_config_from_gguf_reads_sliding_window() {
+    let extra = [
+        ("mistral.block_count", Value::U32(32)),
+        ("mistral.embedding_length", Value::U32(4096)),
+        ("mistral.feed_forward_length", Value::U32(14336)),
+        ("mistral.attention.head_count", Value::U32(32)),
+        ("mistral.attention.head_count_kv", Value::U32(8)),
+        (
+            "mistral.attention.layer_norm_rms_epsilon",
+            Value::F32(1.0e-5),
+        ),
+        ("mistral.attention.sliding_window", Value::U32(4096)),
+        ("mistral.context_length", Value::U32(32768)),
+        ("mistral.vocab_size", Value::U32(32_000)),
+    ];
+
+    let tmp = build_metadata_gguf("mistral", &extra, 32, 4096);
+    let gguf = GgufFile::open(tmp.path()).unwrap();
+    let cfg = LlamaFamilyConfig::from_gguf(&gguf).unwrap();
+
+    assert_eq!(cfg.sliding_window, 4096, "Mistral v0.1 sliding window read");
+    assert!(!cfg.has_qk_norm);
+    // Default mistral rope is 1e7
+    assert!(
+        (cfg.rope_theta - 10_000_000.0).abs() < 10.0,
+        "Mistral default rope = 1e7"
+    );
+}
+
+#[test]
+fn vocab_falls_back_to_embed_table_rows() {
+    // Don't set <arch>.vocab_size; from_gguf should infer from token_embd
+    // shape (vocab_rows passed to build_metadata_gguf).
+    let extra = [
+        ("qwen3.block_count", Value::U32(4)),
+        ("qwen3.embedding_length", Value::U32(64)),
+        ("qwen3.feed_forward_length", Value::U32(128)),
+        ("qwen3.attention.head_count", Value::U32(2)),
+        ("qwen3.attention.layer_norm_rms_epsilon", Value::F32(1.0e-6)),
+    ];
+    let tmp = build_metadata_gguf("qwen3", &extra, 999, 64);
+    let gguf = GgufFile::open(tmp.path()).unwrap();
+    let cfg = LlamaFamilyConfig::from_gguf(&gguf).unwrap();
+    assert_eq!(cfg.vocab_size, 999);
+    // num_kv_heads also missing → falls back to num_heads
+    assert_eq!(cfg.num_kv_heads, 2);
+}
+
+#[test]
+fn missing_required_field_returns_err() {
+    // No block_count → must error
+    let extra = [
+        ("qwen3.embedding_length", Value::U32(1024)),
+        ("qwen3.feed_forward_length", Value::U32(3072)),
+        ("qwen3.attention.head_count", Value::U32(16)),
+        ("qwen3.attention.layer_norm_rms_epsilon", Value::F32(1.0e-6)),
+    ];
+    let tmp = build_metadata_gguf("qwen3", &extra, 32, 1024);
+    let gguf = GgufFile::open(tmp.path()).unwrap();
+    let result = LlamaFamilyConfig::from_gguf(&gguf);
+    assert!(result.is_err());
+    let err = result.err().unwrap().to_string();
+    assert!(
+        err.contains("block_count"),
+        "error mentions missing field: {err}"
+    );
+}
+
+#[test]
+fn unknown_architecture_works_with_safe_defaults() {
+    // Unknown arch — has_qk_norm should default to false, rope_theta to 10k.
+    let extra = [
+        ("custom.block_count", Value::U32(4)),
+        ("custom.embedding_length", Value::U32(32)),
+        ("custom.feed_forward_length", Value::U32(64)),
+        ("custom.attention.head_count", Value::U32(2)),
+        (
+            "custom.attention.layer_norm_rms_epsilon",
+            Value::F32(1.0e-6),
+        ),
+        ("custom.vocab_size", Value::U32(100)),
+    ];
+    let tmp = build_metadata_gguf("custom", &extra, 32, 32);
+    let gguf = GgufFile::open(tmp.path()).unwrap();
+    let cfg = LlamaFamilyConfig::from_gguf(&gguf).unwrap();
+    assert!(!cfg.has_qk_norm, "unknown arch defaults to no QK-norm");
+    assert!(
+        (cfg.rope_theta - 10_000.0).abs() < 1.0,
+        "unknown arch defaults to 10k rope"
+    );
+}

--- a/crates/ferrum-quantization/src/gguf/loader.rs
+++ b/crates/ferrum-quantization/src/gguf/loader.rs
@@ -1,0 +1,236 @@
+//! `GgufLoader<B>`: implements `WeightLoader<B>` against a GGUF file.
+//!
+//! Bridges the model layer (which addresses weights by ferrum's HuggingFace-
+//! style names) to the on-disk GGUF format (llama.cpp's `blk.{i}.attn_q.weight`
+//! shorthand). Three responsibilities:
+//!
+//!   1. **Name translation** — delegates to `gguf::names::ferrum_to_gguf`
+//!   2. **Tensor materialisation** — uses Phase 1A's `GgufFile::read_tensor`
+//!      then dequant on CPU into `B::Buffer` for `load_tensor`, or wraps
+//!      the QTensor in `GgufLinear<B>` for `load_linear`.
+//!   3. **Fusion** — reproduces the `qkv_proj` / `gate_up_proj` shims the
+//!      model expects: q/k/v split tensors are concatenated row-wise into
+//!      a single fused weight before the Linear is built.
+//!
+//! All paths go through eager dequant-to-fp32 (Phase 1B's strategy).
+//! Phase 1D will add a quant-aware shortcut so Q4_K_M weights can stay
+//! quantised in backend memory; the public `WeightLoader<B>` API stays
+//! the same.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use candle_core::Device;
+use ferrum_kernels::backend::Backend;
+use ferrum_types::{FerrumError, Result};
+
+use crate::config::QuantConfig;
+use crate::gguf::file::GgufFile;
+use crate::gguf::linear::GgufLinear;
+use crate::gguf::names::{ferrum_to_gguf, gate_up_split_parts, qkv_split_parts};
+use crate::loader::WeightLoader;
+use crate::traits::Linear;
+
+/// Backend-generic weight loader for GGUF files.
+///
+/// Build with [`GgufLoader::open`]. The underlying file stays mmap'd for
+/// the lifetime of the loader so per-tensor reads only do byte slicing,
+/// not file I/O.
+pub struct GgufLoader<B: Backend> {
+    gguf: Arc<GgufFile>,
+    /// Decode device for `QTensor::dequantize`. We always use CPU here:
+    /// the dequant is followed by `B::from_slice`, which uploads to the
+    /// backend's preferred memory. Going through Metal/CUDA candle paths
+    /// would add a cross-allocator hop with no benefit (Phase 1D revisits).
+    decode_device: Device,
+    _marker: std::marker::PhantomData<B>,
+}
+
+impl<B: Backend> GgufLoader<B> {
+    /// Open and parse a `.gguf` file. Tensor payloads stay on disk (mmap'd)
+    /// until each `load_tensor` / `load_linear` call.
+    pub fn open(path: impl AsRef<Path>) -> Result<Self> {
+        let gguf = GgufFile::open(path).map_err(candle_to_ferrum)?;
+        Ok(Self {
+            gguf: Arc::new(gguf),
+            decode_device: Device::Cpu,
+            _marker: std::marker::PhantomData,
+        })
+    }
+
+    /// Build from an already-opened [`GgufFile`] (test helper, also useful
+    /// when several loaders share the same mmap).
+    pub fn from_file(gguf: Arc<GgufFile>) -> Self {
+        Self {
+            gguf,
+            decode_device: Device::Cpu,
+            _marker: std::marker::PhantomData,
+        }
+    }
+
+    /// Direct access to the underlying file — exposes metadata + tensor
+    /// descriptor lookups for callers that need them (e.g. a config helper
+    /// that reads `general.architecture` and `<arch>.block_count`).
+    pub fn gguf(&self) -> &GgufFile {
+        &self.gguf
+    }
+
+    // ── Internals ────────────────────────────────────────────────────────
+
+    /// Look up a ferrum-named tensor in the GGUF, returning the GGUF tensor
+    /// name on success.
+    fn locate(&self, ferrum_name: &str) -> Result<String> {
+        let gguf_name = ferrum_to_gguf(ferrum_name).ok_or_else(|| {
+            FerrumError::model(format!(
+                "GgufLoader: unrecognised tensor name '{ferrum_name}' (no GGUF mapping)"
+            ))
+        })?;
+        if !self.gguf.has_tensor(&gguf_name) {
+            return Err(FerrumError::model(format!(
+                "GgufLoader: tensor '{ferrum_name}' (mapped to '{gguf_name}') not present in GGUF"
+            )));
+        }
+        Ok(gguf_name)
+    }
+
+    /// Read a quantized tensor and dequantize to fp32 row-major. Used by
+    /// both `load_tensor` (raw buffer) and the fusion path (concat sources).
+    fn read_dequant(&self, gguf_name: &str) -> Result<Vec<f32>> {
+        let qt = self
+            .gguf
+            .read_tensor(gguf_name, &self.decode_device)
+            .map_err(candle_to_ferrum)?;
+        let dense = qt
+            .dequantize(&self.decode_device)
+            .map_err(candle_to_ferrum)?;
+        let flat = dense.flatten_all().map_err(candle_to_ferrum)?;
+        flat.to_vec1::<f32>().map_err(candle_to_ferrum)
+    }
+
+    /// Look up a tensor's `[rows, cols]` (2-D) without reading the payload.
+    /// Errors if the tensor isn't 2-D — fusion needs row counts to compute
+    /// the combined output dim.
+    fn rows_cols(&self, gguf_name: &str) -> Result<(usize, usize)> {
+        let info = self
+            .gguf
+            .tensor_info(gguf_name)
+            .ok_or_else(|| FerrumError::model(format!("tensor info missing for '{gguf_name}'")))?;
+        let dims = info.shape.dims();
+        if dims.len() != 2 {
+            return Err(FerrumError::model(format!(
+                "expected 2-D tensor for '{gguf_name}', got rank {}",
+                dims.len()
+            )));
+        }
+        Ok((dims[0], dims[1]))
+    }
+
+    /// Build a fused `Linear<B>` by row-concatenating several sub-tensors.
+    /// All parts must share `cols` (in_features); rows (out_features) sum.
+    fn load_fused(&self, parts: &[String]) -> Result<Box<dyn Linear<B>>> {
+        let mut fused: Vec<f32> = Vec::new();
+        let mut total_rows = 0usize;
+        let mut cols_check: Option<usize> = None;
+
+        for stem in parts {
+            let weight_name = format!("{stem}.weight");
+            let gguf_name = ferrum_to_gguf(&weight_name).ok_or_else(|| {
+                FerrumError::model(format!(
+                    "GgufLoader: fusion source '{weight_name}' has no GGUF mapping"
+                ))
+            })?;
+            if !self.gguf.has_tensor(&gguf_name) {
+                return Err(FerrumError::model(format!(
+                    "GgufLoader: fusion source '{weight_name}' (gguf '{gguf_name}') missing"
+                )));
+            }
+            let (rows, cols) = self.rows_cols(&gguf_name)?;
+            match cols_check {
+                Some(c) if c != cols => {
+                    return Err(FerrumError::model(format!(
+                        "GgufLoader: fusion in_features mismatch ({c} vs {cols} for '{stem}')"
+                    )))
+                }
+                _ => cols_check = Some(cols),
+            }
+            let data = self.read_dequant(&gguf_name)?;
+            debug_assert_eq!(data.len(), rows * cols);
+            fused.extend_from_slice(&data);
+            total_rows += rows;
+        }
+
+        let cols = cols_check.ok_or_else(|| FerrumError::model("fusion: no parts"))?;
+        Ok(Box::new(GgufLinear::<B>::from_dense_rows(
+            &fused, total_rows, cols,
+        )))
+    }
+}
+
+impl<B: Backend> WeightLoader<B> for GgufLoader<B> {
+    fn load_tensor(&self, name: &str) -> Result<B::Buffer> {
+        let gguf_name = self.locate(name)?;
+        let raw = self.read_dequant(&gguf_name)?;
+        Ok(B::from_slice(&raw))
+    }
+
+    fn load_linear(&self, name: &str) -> Result<Box<dyn Linear<B>>> {
+        // 1) Direct path: <name>.weight exists as a single GGUF tensor.
+        if let Some(gguf_weight) = ferrum_to_gguf(&format!("{name}.weight")) {
+            if self.gguf.has_tensor(&gguf_weight) {
+                let qt = self
+                    .gguf
+                    .read_tensor(&gguf_weight, &self.decode_device)
+                    .map_err(candle_to_ferrum)?;
+                // Optional bias (Qwen2.5 / Bert variants)
+                if let Some(gguf_bias) = ferrum_to_gguf(&format!("{name}.bias")) {
+                    if self.gguf.has_tensor(&gguf_bias) {
+                        let bqt = self
+                            .gguf
+                            .read_tensor(&gguf_bias, &self.decode_device)
+                            .map_err(candle_to_ferrum)?;
+                        let linear = GgufLinear::<B>::from_qtensor_with_bias(&qt, &bqt)
+                            .map_err(candle_to_ferrum)?;
+                        return Ok(Box::new(linear));
+                    }
+                }
+                let linear = GgufLinear::<B>::from_qtensor(&qt).map_err(candle_to_ferrum)?;
+                return Ok(Box::new(linear));
+            }
+        }
+
+        // 2) Fusion path: qkv_proj from q_proj/k_proj/v_proj
+        if let Some(layer_prefix) = name.strip_suffix("self_attn.qkv_proj") {
+            let parts = qkv_split_parts(layer_prefix);
+            return self.load_fused(&parts);
+        }
+        // 3) Fusion path: gate_up_proj from gate_proj/up_proj
+        if let Some(layer_prefix) = name.strip_suffix("mlp.gate_up_proj") {
+            let parts = gate_up_split_parts(layer_prefix);
+            return self.load_fused(&parts);
+        }
+
+        Err(FerrumError::model(format!(
+            "GgufLoader: could not load Linear '{name}' — no direct weight, no split components"
+        )))
+    }
+
+    fn has_tensor(&self, name: &str) -> bool {
+        match ferrum_to_gguf(name) {
+            Some(g) => self.gguf.has_tensor(&g),
+            None => false,
+        }
+    }
+
+    fn quant_config(&self) -> Option<&QuantConfig> {
+        // Phase 1C doesn't surface a QuantConfig — every tensor in a GGUF
+        // declares its own dtype (`GgmlDType`) per descriptor, so the
+        // model's existing branching on QuantConfig::method isn't useful
+        // here. Phase 1D may add a derived config if downstream code grows
+        // a need for it.
+        None
+    }
+}
+
+fn candle_to_ferrum(e: candle_core::Error) -> FerrumError {
+    FerrumError::model(format!("candle: {e}"))
+}

--- a/crates/ferrum-quantization/src/gguf/mod.rs
+++ b/crates/ferrum-quantization/src/gguf/mod.rs
@@ -4,10 +4,11 @@
 //! and load individual tensors as candle `QTensor` (which already handles
 //! dequant for every K-quant variant on CPU / Metal / CUDA).
 //!
-//! Out of scope here (lands in 1C): mapping the GGUF tensor names
-//! (`blk.0.attn_q.weight`) to ferrum's model-config naming and implementing
-//! `WeightLoader`. Phase 1B (this commit) adds `GgufLinear<B>` so model
-//! code can hold a `Box<dyn Linear<B>>` regardless of the source format.
+//! Phase 1A added the `GgufFile` reader. Phase 1B added `GgufLinear<B>`.
+//! Phase 1C (this commit) adds `GgufLoader<B>` — implements `WeightLoader<B>`
+//! against ferrum's HuggingFace-style tensor names by translating to GGUF's
+//! `blk.{i}.attn_q.weight` shorthand and handling `qkv_proj` / `gate_up_proj`
+//! fusion on the fly.
 //!
 //! ## Why wrap candle instead of writing a parser from scratch
 //!
@@ -26,9 +27,13 @@
 
 pub mod file;
 pub mod linear;
+pub mod loader;
+pub mod names;
 
 pub use file::GgufFile;
 pub use linear::{linear_from_qtensor, GgufLinear};
+pub use loader::GgufLoader;
+pub use names::{ferrum_to_gguf, gate_up_split_parts, qkv_split_parts};
 
 // Re-exports — callers can import these from `ferrum_quantization::gguf` rather
 // than reaching into `candle_core::quantized::*` directly. Keeps the dep

--- a/crates/ferrum-quantization/src/gguf/names.rs
+++ b/crates/ferrum-quantization/src/gguf/names.rs
@@ -1,0 +1,225 @@
+//! GGUF ↔ ferrum tensor-name translation.
+//!
+//! Ferrum models address weights using HuggingFace-style names
+//! (`model.layers.0.self_attn.q_proj.weight`). GGUF files use llama.cpp's
+//! shorthand (`blk.0.attn_q.weight`). This module is the single source of
+//! truth for that mapping; both `GgufLoader` and any future tooling go
+//! through `ferrum_to_gguf`.
+//!
+//! Scope (Phase 1C): dense Llama-family models — Qwen3, Qwen2.x, Llama-3.x,
+//! Mistral, TinyLlama. MoE-specific names (`ffn_gate_inp`, `ffn_*_exps`)
+//! land in Phase 2 alongside the MoE runtime.
+
+/// Translate a ferrum tensor name to its GGUF equivalent.
+///
+/// Returns `None` for names that have no GGUF counterpart (yet) or aren't
+/// recognised — caller treats this as "tensor not found".
+///
+/// Accepts both bare stems (`"lm_head"`, `"model.layers.0.self_attn.o_proj"`)
+/// and fully-qualified names (`"...weight"`, `"...bias"`). The `.weight` /
+/// `.bias` suffix passes through unchanged.
+pub fn ferrum_to_gguf(name: &str) -> Option<String> {
+    // Top-level tensors first — they don't fit the layer pattern.
+    if let Some(out) = map_top_level(name) {
+        return Some(out);
+    }
+
+    // Layer-scoped: must be "model.layers.{idx}.<rest>"
+    let rest = name.strip_prefix("model.layers.")?;
+    let (idx_str, after_idx) = rest.split_once('.')?;
+    let idx: usize = idx_str.parse().ok()?;
+    let mapped = map_layer_scoped(after_idx)?;
+    Some(format!("blk.{idx}.{mapped}"))
+}
+
+fn map_top_level(name: &str) -> Option<String> {
+    let mapped = match name {
+        "model.embed_tokens" => "token_embd",
+        "model.embed_tokens.weight" => "token_embd.weight",
+        "model.norm" => "output_norm",
+        "model.norm.weight" => "output_norm.weight",
+        "lm_head" => "output",
+        "lm_head.weight" => "output.weight",
+        _ => return None,
+    };
+    Some(mapped.to_string())
+}
+
+fn map_layer_scoped(rest: &str) -> Option<String> {
+    // Peel off the .weight / .bias suffix, map the stem, then re-attach.
+    let (stem, suffix) = if let Some(s) = rest.strip_suffix(".weight") {
+        (s, ".weight")
+    } else if let Some(s) = rest.strip_suffix(".bias") {
+        (s, ".bias")
+    } else {
+        (rest, "")
+    };
+
+    let mapped_stem = match stem {
+        // RMSNorms
+        "input_layernorm" => "attn_norm",
+        "post_attention_layernorm" => "ffn_norm",
+        // Attention projections
+        "self_attn.q_proj" => "attn_q",
+        "self_attn.k_proj" => "attn_k",
+        "self_attn.v_proj" => "attn_v",
+        "self_attn.o_proj" => "attn_output",
+        // Qwen3 QK-norm — only present on that family
+        "self_attn.q_norm" => "attn_q_norm",
+        "self_attn.k_norm" => "attn_k_norm",
+        // MLP projections
+        "mlp.gate_proj" => "ffn_gate",
+        "mlp.up_proj" => "ffn_up",
+        "mlp.down_proj" => "ffn_down",
+        _ => return None,
+    };
+
+    Some(format!("{mapped_stem}{suffix}"))
+}
+
+/// The three sub-tensor names that fuse into `qkv_proj`, in the order the
+/// model expects them stacked along axis 0 (rows = output neurons).
+pub fn qkv_split_parts(layer_prefix: &str) -> [String; 3] {
+    [
+        format!("{layer_prefix}self_attn.q_proj"),
+        format!("{layer_prefix}self_attn.k_proj"),
+        format!("{layer_prefix}self_attn.v_proj"),
+    ]
+}
+
+/// The two sub-tensor names that fuse into `gate_up_proj`, stacked along
+/// axis 0 (gate first, then up).
+pub fn gate_up_split_parts(layer_prefix: &str) -> [String; 2] {
+    [
+        format!("{layer_prefix}mlp.gate_proj"),
+        format!("{layer_prefix}mlp.up_proj"),
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maps_top_level_tensors() {
+        assert_eq!(
+            ferrum_to_gguf("model.embed_tokens.weight"),
+            Some("token_embd.weight".into())
+        );
+        assert_eq!(
+            ferrum_to_gguf("model.embed_tokens"),
+            Some("token_embd".into())
+        );
+        assert_eq!(
+            ferrum_to_gguf("model.norm.weight"),
+            Some("output_norm.weight".into())
+        );
+        assert_eq!(ferrum_to_gguf("lm_head"), Some("output".into()));
+        assert_eq!(
+            ferrum_to_gguf("lm_head.weight"),
+            Some("output.weight".into())
+        );
+    }
+
+    #[test]
+    fn maps_layer_attention_weights() {
+        assert_eq!(
+            ferrum_to_gguf("model.layers.0.self_attn.q_proj.weight"),
+            Some("blk.0.attn_q.weight".into())
+        );
+        assert_eq!(
+            ferrum_to_gguf("model.layers.27.self_attn.k_proj.weight"),
+            Some("blk.27.attn_k.weight".into())
+        );
+        assert_eq!(
+            ferrum_to_gguf("model.layers.5.self_attn.v_proj.weight"),
+            Some("blk.5.attn_v.weight".into())
+        );
+        assert_eq!(
+            ferrum_to_gguf("model.layers.0.self_attn.o_proj.weight"),
+            Some("blk.0.attn_output.weight".into())
+        );
+        // bare stem (load_linear-style)
+        assert_eq!(
+            ferrum_to_gguf("model.layers.0.self_attn.o_proj"),
+            Some("blk.0.attn_output".into())
+        );
+    }
+
+    #[test]
+    fn maps_qwen3_qk_norm() {
+        assert_eq!(
+            ferrum_to_gguf("model.layers.0.self_attn.q_norm.weight"),
+            Some("blk.0.attn_q_norm.weight".into())
+        );
+        assert_eq!(
+            ferrum_to_gguf("model.layers.0.self_attn.k_norm.weight"),
+            Some("blk.0.attn_k_norm.weight".into())
+        );
+    }
+
+    #[test]
+    fn maps_attention_bias() {
+        assert_eq!(
+            ferrum_to_gguf("model.layers.0.self_attn.q_proj.bias"),
+            Some("blk.0.attn_q.bias".into())
+        );
+    }
+
+    #[test]
+    fn maps_layer_norms() {
+        assert_eq!(
+            ferrum_to_gguf("model.layers.0.input_layernorm.weight"),
+            Some("blk.0.attn_norm.weight".into())
+        );
+        assert_eq!(
+            ferrum_to_gguf("model.layers.0.post_attention_layernorm.weight"),
+            Some("blk.0.ffn_norm.weight".into())
+        );
+    }
+
+    #[test]
+    fn maps_mlp_projections() {
+        assert_eq!(
+            ferrum_to_gguf("model.layers.0.mlp.gate_proj.weight"),
+            Some("blk.0.ffn_gate.weight".into())
+        );
+        assert_eq!(
+            ferrum_to_gguf("model.layers.0.mlp.up_proj.weight"),
+            Some("blk.0.ffn_up.weight".into())
+        );
+        assert_eq!(
+            ferrum_to_gguf("model.layers.0.mlp.down_proj.weight"),
+            Some("blk.0.ffn_down.weight".into())
+        );
+    }
+
+    #[test]
+    fn rejects_unknown_names() {
+        assert_eq!(ferrum_to_gguf("totally_made_up"), None);
+        assert_eq!(ferrum_to_gguf("model.layers.0.unknown_part.weight"), None);
+        assert_eq!(
+            ferrum_to_gguf("model.layers.bad_idx.input_layernorm.weight"),
+            None
+        );
+    }
+
+    #[test]
+    fn split_parts_helpers() {
+        assert_eq!(
+            qkv_split_parts("model.layers.3."),
+            [
+                "model.layers.3.self_attn.q_proj".to_string(),
+                "model.layers.3.self_attn.k_proj".into(),
+                "model.layers.3.self_attn.v_proj".into(),
+            ]
+        );
+        assert_eq!(
+            gate_up_split_parts("model.layers.3."),
+            [
+                "model.layers.3.mlp.gate_proj".to_string(),
+                "model.layers.3.mlp.up_proj".into(),
+            ]
+        );
+    }
+}

--- a/crates/ferrum-quantization/src/lib.rs
+++ b/crates/ferrum-quantization/src/lib.rs
@@ -26,7 +26,7 @@ pub mod traits;
 
 pub use dense::DenseLinear;
 pub use factory::DefaultLinearFactory;
-pub use gguf::{GgufFile, GgufLinear};
+pub use gguf::{GgufFile, GgufLinear, GgufLoader};
 pub use gptq::GptqLinear;
 pub use loader::{PrefixedLoader, WeightLoader};
 pub use native_safetensors::NativeSafetensorsLoader;

--- a/crates/ferrum-quantization/tests/gguf_loader_test.rs
+++ b/crates/ferrum-quantization/tests/gguf_loader_test.rs
@@ -1,0 +1,248 @@
+//! Phase 1C integration tests: synthesize a GGUF that covers every tensor
+//! shape a Llama-family decoder layer asks for, build a `GgufLoader<B>`
+//! over it, and exercise the `WeightLoader<B>` API the model actually
+//! uses (load_tensor / load_linear / qkv fusion / gate_up fusion / bias).
+//!
+//! All tests run on `CpuBackend` — no GGUF model file required.
+
+use std::io::{Cursor, Write};
+use std::sync::Arc;
+
+use candle_core::quantized::gguf_file::{self, Value};
+use candle_core::quantized::{GgmlDType, QTensor};
+use candle_core::{Device, Tensor};
+use ferrum_kernels::backend::cpu::CpuBackend;
+use ferrum_quantization::gguf::{GgufFile, GgufLoader};
+use ferrum_quantization::WeightLoader;
+
+/// Build a tensor of given shape filled with a deterministic ramp so we can
+/// later verify which sub-tensor ended up where in a fused weight.
+fn ramp_tensor(rows: usize, cols: usize, base: f32) -> QTensor {
+    let device = Device::Cpu;
+    let n = rows * cols;
+    let raw: Vec<f32> = (0..n).map(|i| base + (i as f32) * 0.001).collect();
+    let t = Tensor::from_vec(raw, (rows, cols), &device).unwrap();
+    QTensor::quantize(&t, GgmlDType::F32).unwrap()
+}
+
+fn vec_tensor(n: usize, base: f32) -> QTensor {
+    let device = Device::Cpu;
+    let raw: Vec<f32> = (0..n).map(|i| base + (i as f32) * 0.01).collect();
+    let t = Tensor::from_vec(raw, n, &device).unwrap();
+    QTensor::quantize(&t, GgmlDType::F32).unwrap()
+}
+
+/// Build a GGUF tempfile containing the full set of Llama-family layer
+/// tensors (one decoder layer + embed/output) — minimal but exercising
+/// every name-mapping and fusion path.
+fn build_full_layer_gguf() -> tempfile::NamedTempFile {
+    // Toy dimensions: hidden=4, head_dim=4 (1 head), ffn=8.
+    // q/k/v all 4x4 — combined qkv = 12x4.
+    // gate/up both 8x4 — combined gate_up = 16x4.
+    let token_embd = ramp_tensor(8, 4, 0.0); // vocab=8, hidden=4
+    let output_norm = vec_tensor(4, 0.5);
+    let output = ramp_tensor(8, 4, 1.0); // lm_head, vocab=8, hidden=4
+    let attn_norm = vec_tensor(4, 0.6);
+    let attn_q = ramp_tensor(4, 4, 2.0);
+    let attn_k = ramp_tensor(4, 4, 3.0);
+    let attn_v = ramp_tensor(4, 4, 4.0);
+    let attn_output = ramp_tensor(4, 4, 5.0);
+    let ffn_norm = vec_tensor(4, 0.7);
+    let ffn_gate = ramp_tensor(8, 4, 6.0);
+    let ffn_up = ramp_tensor(8, 4, 7.0);
+    let ffn_down = ramp_tensor(4, 8, 8.0);
+
+    let arch_v = Value::String("qwen3".to_string());
+    let metadata: Vec<(&str, &Value)> = vec![("general.architecture", &arch_v)];
+    let tensors: Vec<(&str, &QTensor)> = vec![
+        ("token_embd.weight", &token_embd),
+        ("output_norm.weight", &output_norm),
+        ("output.weight", &output),
+        ("blk.0.attn_norm.weight", &attn_norm),
+        ("blk.0.attn_q.weight", &attn_q),
+        ("blk.0.attn_k.weight", &attn_k),
+        ("blk.0.attn_v.weight", &attn_v),
+        ("blk.0.attn_output.weight", &attn_output),
+        ("blk.0.ffn_norm.weight", &ffn_norm),
+        ("blk.0.ffn_gate.weight", &ffn_gate),
+        ("blk.0.ffn_up.weight", &ffn_up),
+        ("blk.0.ffn_down.weight", &ffn_down),
+    ];
+
+    let mut buf: Vec<u8> = Vec::new();
+    {
+        let mut cursor = Cursor::new(&mut buf);
+        gguf_file::write(&mut cursor, &metadata, &tensors).unwrap();
+    }
+    let mut tmp = tempfile::NamedTempFile::new().unwrap();
+    tmp.write_all(&buf).unwrap();
+    tmp.flush().unwrap();
+    tmp
+}
+
+fn build_loader(tmp: &tempfile::NamedTempFile) -> GgufLoader<CpuBackend> {
+    let gguf = GgufFile::open(tmp.path()).unwrap();
+    GgufLoader::<CpuBackend>::from_file(Arc::new(gguf))
+}
+
+#[test]
+fn has_tensor_translates_ferrum_names() {
+    let tmp = build_full_layer_gguf();
+    let loader = build_loader(&tmp);
+
+    assert!(loader.has_tensor("model.embed_tokens.weight"));
+    assert!(loader.has_tensor("model.norm.weight"));
+    assert!(loader.has_tensor("lm_head.weight"));
+    assert!(loader.has_tensor("model.layers.0.input_layernorm.weight"));
+    assert!(loader.has_tensor("model.layers.0.self_attn.q_proj.weight"));
+    assert!(loader.has_tensor("model.layers.0.mlp.down_proj.weight"));
+
+    // Unknown ferrum name → false (no GGUF mapping)
+    assert!(!loader.has_tensor("totally_made_up.weight"));
+    // Mapped, but not in this file (no second layer)
+    assert!(!loader.has_tensor("model.layers.1.self_attn.q_proj.weight"));
+}
+
+#[test]
+fn load_tensor_returns_dequantized_values() {
+    let tmp = build_full_layer_gguf();
+    let loader = build_loader(&tmp);
+
+    // attn_norm was vec_tensor(4, 0.6) → [0.60, 0.61, 0.62, 0.63]
+    let raw = loader
+        .load_tensor("model.layers.0.input_layernorm.weight")
+        .unwrap();
+    assert_eq!(raw.len(), 4);
+    let expected: Vec<f32> = (0..4).map(|i| 0.6 + (i as f32) * 0.01).collect();
+    assert_eq!(raw, expected);
+
+    // embed table 8x4 = 32 elems, base 0.0 step 0.001
+    let embed = loader.load_tensor("model.embed_tokens.weight").unwrap();
+    assert_eq!(embed.len(), 32);
+    assert!((embed[0] - 0.0).abs() < 1e-6);
+    assert!((embed[31] - 0.031).abs() < 1e-5);
+}
+
+#[test]
+fn load_tensor_unknown_name_errors() {
+    let tmp = build_full_layer_gguf();
+    let loader = build_loader(&tmp);
+
+    let err = loader
+        .load_tensor("model.layers.99.self_attn.q_proj.weight")
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("not present"), "error mentions missing: {err}");
+
+    let err = loader
+        .load_tensor("nonsense.thing")
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("unrecognised") || err.contains("no GGUF mapping"));
+}
+
+#[test]
+fn load_linear_direct_path() {
+    let tmp = build_full_layer_gguf();
+    let loader = build_loader(&tmp);
+
+    let o = loader
+        .load_linear("model.layers.0.self_attn.o_proj")
+        .unwrap();
+    assert_eq!(o.in_features(), 4);
+    assert_eq!(o.out_features(), 4);
+
+    // lm_head is 8x4 (vocab=8, hidden=4)
+    let lm = loader.load_linear("lm_head").unwrap();
+    assert_eq!(lm.in_features(), 4);
+    assert_eq!(lm.out_features(), 8);
+
+    let down = loader.load_linear("model.layers.0.mlp.down_proj").unwrap();
+    assert_eq!(down.in_features(), 8);
+    assert_eq!(down.out_features(), 4);
+}
+
+#[test]
+fn load_linear_fuses_qkv() {
+    let tmp = build_full_layer_gguf();
+    let loader = build_loader(&tmp);
+
+    let qkv = loader
+        .load_linear("model.layers.0.self_attn.qkv_proj")
+        .unwrap();
+    // Each part is 4x4; fused = 12x4
+    assert_eq!(qkv.in_features(), 4);
+    assert_eq!(qkv.out_features(), 12);
+
+    // Forward verification: feed [1,1,1,1] (all-ones), expect each output
+    // row = sum of that row's weights. Construct expected from the ramp.
+    use ferrum_kernels::backend::Backend;
+    let input: Vec<f32> = vec![1.0; 4];
+    let mut out: Vec<f32> = vec![0.0; 12];
+    let mut ctx = <CpuBackend as Backend>::new_context();
+    qkv.forward(&mut ctx, &input, &mut out, 1);
+
+    // q ramp base 2.0, k base 3.0, v base 4.0; each row of 4 has step 0.001.
+    // row r within q (r=0..3) sums to 4*(2.0 + 0.001*(4*r)) + 0.001*(0+1+2+3) =
+    //   for ramp(rows=4, cols=4, base=B), row r sum = 4*B + 0.001*(4*r*4 + 0+1+2+3)
+    // Simpler: just compute expected via the same ramp logic.
+    let mut expected = Vec::with_capacity(12);
+    for &(rows_so_far, base) in &[(0usize, 2.0_f32), (4, 3.0), (8, 4.0)] {
+        for r in 0..4 {
+            // row r in this ramp_tensor(4,4,base): elements = base + 0.001*(r*4 + c) for c in 0..4
+            let row_sum: f32 = (0..4)
+                .map(|c| base + 0.001 * ((r * 4 + c) as f32))
+                .sum::<f32>();
+            expected.push(row_sum);
+            let _ = rows_so_far; // unused; just here to clarify ordering
+        }
+    }
+    for (i, (got, exp)) in out.iter().zip(expected.iter()).enumerate() {
+        assert!(
+            (got - exp).abs() < 1e-4,
+            "qkv row {i}: got {got}, expected {exp}"
+        );
+    }
+}
+
+#[test]
+fn load_linear_fuses_gate_up() {
+    let tmp = build_full_layer_gguf();
+    let loader = build_loader(&tmp);
+
+    let gu = loader
+        .load_linear("model.layers.0.mlp.gate_up_proj")
+        .unwrap();
+    // gate (8x4) + up (8x4) → 16x4
+    assert_eq!(gu.in_features(), 4);
+    assert_eq!(gu.out_features(), 16);
+}
+
+#[test]
+fn load_linear_unknown_returns_err() {
+    let tmp = build_full_layer_gguf();
+    let loader = build_loader(&tmp);
+
+    let result = loader.load_linear("model.layers.0.unknown_proj");
+    assert!(result.is_err());
+    let err = result.err().unwrap().to_string();
+    assert!(
+        err.contains("could not load Linear"),
+        "error explains failure: {err}"
+    );
+}
+
+#[test]
+fn open_path_constructor_works() {
+    let tmp = build_full_layer_gguf();
+    let loader = GgufLoader::<CpuBackend>::open(tmp.path()).unwrap();
+    assert!(loader.has_tensor("model.embed_tokens.weight"));
+    assert_eq!(loader.gguf().architecture().unwrap(), "qwen3");
+}
+
+#[test]
+fn quant_config_returns_none_in_phase_1c() {
+    let tmp = build_full_layer_gguf();
+    let loader = build_loader(&tmp);
+    assert!(loader.quant_config().is_none());
+}


### PR DESCRIPTION
Closes the GGUF loader trilogy. Phase 1A (#27) added the file reader, Phase 1B (#28) the \`Linear<B>\` wrapper; this PR plugs them into ferrum's \`WeightLoader\` and adds the metadata helper that lets \`LlamaFamilyModel::load\` consume GGUF the same way it already consumes safetensors.

## Three pieces

### 1. Name translation — \`gguf::names\` (new module)

\`ferrum_to_gguf(name: &str) -> Option<String>\` is the canonical translator. Handles:

| ferrum (HuggingFace style) | GGUF (llama.cpp shorthand) |
|---|---|
| \`model.embed_tokens.weight\` | \`token_embd.weight\` |
| \`model.norm.weight\` | \`output_norm.weight\` |
| \`lm_head.weight\` (or bare \`lm_head\`) | \`output.weight\` |
| \`model.layers.{i}.input_layernorm.weight\` | \`blk.{i}.attn_norm.weight\` |
| \`model.layers.{i}.self_attn.q_proj.weight\` (+ \`.bias\`) | \`blk.{i}.attn_q.weight\` |
| \`model.layers.{i}.self_attn.{k,v,o}_proj.weight\` | \`blk.{i}.attn_{k,v,output}.weight\` |
| \`model.layers.{i}.self_attn.{q,k}_norm.weight\` (Qwen3) | \`blk.{i}.attn_{q,k}_norm.weight\` |
| \`model.layers.{i}.post_attention_layernorm.weight\` | \`blk.{i}.ffn_norm.weight\` |
| \`model.layers.{i}.mlp.{gate,up,down}_proj.weight\` | \`blk.{i}.ffn_{gate,up,down}.weight\` |

Both \`.weight\` and bare-stem forms are accepted (the latter for \`load_linear\`-style callers).

### 2. \`GgufLoader<B>\` — implements \`WeightLoader<B>\`

\`\`\`rust
let loader = GgufLoader::<MetalBackend>::open(\"qwen3-8b-q4_k_m.gguf\")?;
let model = LlamaFamilyModel::<MetalBackend>::load(&loader, &cfg)?;
\`\`\`

- mmaps the file once at construction; per-tensor reads slice the mmap.
- \`load_tensor(name)\` → translates name, dequant to fp32, \`B::from_slice\`.
- \`load_linear(name)\` → direct path (with optional bias for Qwen2.5 attention) OR fusion path (q/k/v → qkv_proj, gate/up → gate_up_proj). Fusion row-concatenates the dequantized components into a single \`GgufLinear<B>\`.
- \`has_tensor(name)\` checks the translated name's presence.

### 3. \`LlamaFamilyConfig::from_gguf(&GgufFile)\`

Reads \`general.architecture\` and the arch-scoped hyperparameter keys (\`<arch>.block_count\`, \`<arch>.embedding_length\`, \`<arch>.attention.head_count\`, etc.) and produces the same \`LlamaFamilyConfig\` you'd build via \`qwen3_from_def\` / \`llama_from_def\` from a HuggingFace \`config.json\`.

- **rope_theta defaults**: qwen3/qwen2 → 1e6, llama → 5e5, mistral → 1e7, unknown → 10k
- **QK-norm**: enabled iff arch is \`qwen3\`
- **sliding_window**: from \`mistral.attention.sliding_window\` if present, else 0
- **vocab_size**: prefers \`<arch>.vocab_size\`, falls back to \`token_embd\` row count

## Tests (31 total, all CPU)

- \`gguf::names::tests\` — 8 unit tests (every mapping rule + rejection)
- \`gguf_loader_test.rs\` — 9 integration tests (translation / dequant / direct Linear / qkv fusion with numerical correctness check / gate_up fusion / errors / open-from-path)
- \`gguf_config_test.rs\` (in ferrum-models) — 6 tests (qwen3 / llama default rope / mistral sliding window / vocab fallback / missing field error / unknown arch defaults)
- Phase 1A's 3 + Phase 1B's 5 still pass

\`RUSTFLAGS=\"-D warnings\" cargo check --workspace --all-targets [--features metal]\` clean.

## Files

- \`crates/ferrum-quantization/src/gguf/loader.rs\` (new)
- \`crates/ferrum-quantization/src/gguf/names.rs\` (new)
- \`crates/ferrum-quantization/src/gguf/mod.rs\` (re-exports)
- \`crates/ferrum-quantization/src/lib.rs\` (top-level re-export of \`GgufLoader\`)
- \`crates/ferrum-quantization/tests/gguf_loader_test.rs\` (new)
- \`crates/ferrum-models/src/gguf_config.rs\` (new)
- \`crates/ferrum-models/src/lib.rs\` (\`pub mod gguf_config\`)
- \`crates/ferrum-models/tests/gguf_config_test.rs\` (new)

## Test plan

- [ ] CPU CI green
- [ ] Metal CI green
- [ ] CUDA type check (informational)

## What's next

Phase 1C completes the loader. Phase 1D will add a Metal Q4_K_M dequant kernel (or use candle's existing \`QMatMul::forward\` on Metal) so weights can stay quantised at runtime — the public \`WeightLoader<B>\` API is intentionally stable through that change. After Phase 1D, the M1 Max benchmark harness can drive ferrum on Q4_K_M models head-to-head with mistral.rs and llama.cpp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)