### PR TITLE
feat(models): MoE config types + Qwen3MoeConfig::from_gguf (Phase 2A)

### DIFF
--- a/crates/ferrum-models/src/gguf_config.rs
+++ b/crates/ferrum-models/src/gguf_config.rs
@@ -26,17 +26,32 @@ use ferrum_quantization::gguf::GgufFile;
 use ferrum_types::{FerrumError, Result};
 
 use crate::models::llama_family::LlamaFamilyConfig;
+use crate::moe_config::Qwen3MoeConfig;
+
+/// Architectures that are known MoE — `LlamaFamilyConfig::from_gguf` rejects
+/// them with a pointer to the appropriate MoE constructor rather than
+/// silently lowering them to a dense config.
+const KNOWN_MOE_ARCHS: &[&str] = &["qwen3moe", "mixtral", "deepseek2"];
 
 impl LlamaFamilyConfig {
     /// Parse a `LlamaFamilyConfig` out of a GGUF file's metadata.
     ///
-    /// Errors if `general.architecture` is missing or unrecognised, or if
-    /// any required architecture-scoped key is absent.
+    /// Errors if `general.architecture` is missing or unrecognised, if
+    /// any required architecture-scoped key is absent, or if the GGUF
+    /// is a known MoE variant — those go through
+    /// [`Qwen3MoeConfig::from_gguf`] instead so the MoE-specific
+    /// hyperparameters aren't silently dropped.
     pub fn from_gguf(gguf: &GgufFile) -> Result<Self> {
         let arch = gguf
             .architecture()
             .map_err(|e| FerrumError::model(format!("read general.architecture: {e}")))?
             .to_string();
+
+        if KNOWN_MOE_ARCHS.contains(&arch.as_str()) {
+            return Err(FerrumError::model(format!(
+                "GGUF arch '{arch}' is MoE — use Qwen3MoeConfig::from_gguf or the matching MoE config builder, not LlamaFamilyConfig::from_gguf"
+            )));
+        }
 
         let block_count = read_u32(gguf, &format!("{arch}.block_count"))? as usize;
         let hidden_size = read_u32(gguf, &format!("{arch}.embedding_length"))? as usize;
@@ -103,6 +118,105 @@ impl LlamaFamilyConfig {
             has_qk_norm,
             sliding_window,
         })
+    }
+}
+
+impl Qwen3MoeConfig {
+    /// Parse a `Qwen3MoeConfig` out of a GGUF file's metadata.
+    ///
+    /// Expects `general.architecture == "qwen3moe"`. Reads the dense fields
+    /// from the `qwen3moe.*` namespace (same shape as `LlamaFamilyConfig`)
+    /// plus the MoE-specific extras. Falls back to sane defaults for
+    /// missing optional fields, matching `LlamaFamilyConfig::from_gguf`.
+    ///
+    /// Qwen3-MoE uses **QK-norm** like dense Qwen3 — that flag is set
+    /// regardless of how `LlamaFamilyConfig::from_gguf` would treat the
+    /// arch, because the dense path explicitly excludes MoE archs.
+    pub fn from_gguf(gguf: &GgufFile) -> Result<Self> {
+        let arch = gguf
+            .architecture()
+            .map_err(|e| FerrumError::model(format!("read general.architecture: {e}")))?
+            .to_string();
+        if arch != "qwen3moe" {
+            return Err(FerrumError::model(format!(
+                "Qwen3MoeConfig::from_gguf: expected arch 'qwen3moe', got '{arch}'"
+            )));
+        }
+
+        // Reuse the same key conventions as the dense path — qwen3moe.*
+        // mirrors qwen3.* exactly for the shared transformer dims.
+        let num_layers = read_u32(gguf, "qwen3moe.block_count")? as usize;
+        let hidden_size = read_u32(gguf, "qwen3moe.embedding_length")? as usize;
+        let num_heads = read_u32(gguf, "qwen3moe.attention.head_count")? as usize;
+        let num_kv_heads = match read_u32(gguf, "qwen3moe.attention.head_count_kv") {
+            Ok(v) => v as usize,
+            Err(_) => num_heads,
+        };
+        let rms_norm_eps = read_f32(gguf, "qwen3moe.attention.layer_norm_rms_epsilon")?;
+        let max_seq_len = read_u32(gguf, "qwen3moe.context_length")
+            .map(|v| v as usize)
+            .unwrap_or(32768);
+        let rope_theta = read_f32(gguf, "qwen3moe.rope.freq_base")
+            .map(|v| v as f64)
+            .unwrap_or(1_000_000.0);
+        let vocab_size = match read_u32(gguf, "qwen3moe.vocab_size") {
+            Ok(v) => v as usize,
+            Err(_) => infer_vocab_from_embed(gguf)?,
+        };
+
+        if num_heads == 0 || hidden_size % num_heads != 0 {
+            return Err(FerrumError::model(format!(
+                "GGUF Qwen3-MoE: hidden_size {hidden_size} not divisible by num_heads {num_heads}"
+            )));
+        }
+        let head_dim = hidden_size / num_heads;
+
+        // MoE-specific keys.
+        let num_experts = read_u32(gguf, "qwen3moe.expert_count")? as usize;
+        let num_experts_per_tok = read_u32(gguf, "qwen3moe.expert_used_count")? as usize;
+        // Per-expert FFN length — distinct from the legacy `feed_forward_length`
+        // (which most qwen3moe GGUFs leave as the dense reference value).
+        let expert_intermediate_size =
+            read_u32(gguf, "qwen3moe.expert_feed_forward_length")? as usize;
+        // Whether the router normalises the top-K logits before combining.
+        // Qwen3-MoE: yes. Some legacy GGUFs omit this key.
+        let norm_topk_prob = match gguf.metadata_bool("qwen3moe.expert_norm_topk_prob") {
+            Ok(v) => v,
+            Err(_) => true,
+        };
+
+        if num_experts_per_tok == 0 || num_experts_per_tok > num_experts {
+            return Err(FerrumError::model(format!(
+                "GGUF Qwen3-MoE: invalid expert_used_count {num_experts_per_tok} (num_experts={num_experts})"
+            )));
+        }
+
+        let base = LlamaFamilyConfig {
+            hidden_size,
+            // Qwen3-MoE has no shared dense FFN; mirror expert size into
+            // base for any code that reads `intermediate_size`.
+            intermediate_size: expert_intermediate_size,
+            num_heads,
+            num_kv_heads,
+            head_dim,
+            num_layers,
+            vocab_size,
+            max_seq_len,
+            rms_norm_eps,
+            rope_theta,
+            // Qwen3-MoE uses QK-norm exactly like dense Qwen3.
+            has_qk_norm: true,
+            // No sliding window in Qwen3-MoE.
+            sliding_window: 0,
+        };
+
+        Ok(Self::from_base(
+            base,
+            num_experts,
+            num_experts_per_tok,
+            expert_intermediate_size,
+            norm_topk_prob,
+        ))
     }
 }
 

--- a/crates/ferrum-models/src/lib.rs
+++ b/crates/ferrum-models/src/lib.rs
@@ -28,6 +28,7 @@ pub mod image_processor;
 pub mod loader;
 pub mod mel;
 pub mod models;
+pub mod moe_config;
 pub mod registry;
 pub mod source;
 pub mod tensor_wrapper;

--- a/crates/ferrum-models/src/models/llama_family.rs
+++ b/crates/ferrum-models/src/models/llama_family.rs
@@ -26,7 +26,7 @@ use crate::common::{DecoderOnlyLLM, LlmRuntimeConfig};
 
 /// Full Qwen3 architecture config (everything the model code needs, not just
 /// the engine-facing subset in `LlmRuntimeConfig`).
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct LlamaFamilyConfig {
     pub hidden_size: usize,
     pub intermediate_size: usize,

--- a/crates/ferrum-models/src/moe_config.rs
+++ b/crates/ferrum-models/src/moe_config.rs
@@ -1,0 +1,85 @@
+//! Mixture-of-Experts (MoE) configuration types.
+//!
+//! Phase 2A: data types only. The runtime (router + expert dispatch) lands
+//! in Phase 2B/2C/2D. This file's job is to give the project a single
+//! unambiguous representation of MoE hyperparameters so subsequent PRs
+//! can wire it into the model code, the loader, and the benchmark suite
+//! without each making up their own shape.
+//!
+//! ## Design choice: composition, not inheritance
+//!
+//! [`Qwen3MoeConfig`] **wraps** [`LlamaFamilyConfig`] rather than adding
+//! `Option<MoeConfig>` fields to it. Reasons:
+//!
+//! 1. Every existing dense call site (Qwen3 / Llama / Mistral / TinyLlama
+//!    via `*_from_def`) keeps working unchanged — no `..Default::default()`
+//!    breakage, no "MoE field always present even for dense" awkwardness.
+//! 2. The MoE forward path is structurally different (per-token router,
+//!    per-token expert subset, weighted sum) — it'll live in a separate
+//!    `Qwen3MoeModel<B>` rather than branching inside `LlamaFamilyModel`.
+//!    Sharing a config type would force the two models to coevolve.
+//! 3. `Qwen3MoeConfig::base` reuses every field that genuinely is the
+//!    same (hidden_size, num_layers, attention dims, RoPE, vocab) so we
+//!    aren't duplicating dense fields.
+//!
+//! Trade-off: callers that just want "either dense or MoE config" will
+//! need an `enum`. We'll add that wrapper if/when it earns its keep.
+
+use crate::models::llama_family::LlamaFamilyConfig;
+
+/// Configuration for Qwen3-MoE family models (Qwen3-30B-A3B and friends).
+///
+/// All MoE-specific hyperparameters live here; dense fields are inherited
+/// via [`Qwen3MoeConfig::base`]. The `base.intermediate_size` is set to
+/// [`Self::expert_intermediate_size`] for compatibility — Qwen3-MoE has
+/// no shared dense FFN, every layer is MoE.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Qwen3MoeConfig {
+    /// Shared transformer hyperparameters (attention, RoPE, vocab, …).
+    pub base: LlamaFamilyConfig,
+
+    /// Total number of experts per MoE layer. Qwen3-30B-A3B = 128.
+    pub num_experts: usize,
+
+    /// Top-K experts activated per token. Qwen3-30B-A3B = 8.
+    pub num_experts_per_tok: usize,
+
+    /// Per-expert FFN inner size. Distinct from `base.intermediate_size`
+    /// (which is the *shared* FFN size for dense layers; for MoE we
+    /// duplicate this value into base for downstream sanity but the real
+    /// number lives here). Qwen3-30B-A3B per-expert = 768.
+    pub expert_intermediate_size: usize,
+
+    /// Whether the router output is normalised across the top-K experts
+    /// (softmax over selected logits) before the weighted combine.
+    /// Qwen3-MoE: true. Mixtral: also true. Older variants: false.
+    pub norm_topk_prob: bool,
+}
+
+impl Qwen3MoeConfig {
+    /// Construct from an already-built `LlamaFamilyConfig` plus the MoE
+    /// hyperparameters. Mostly useful for tests and synthetic scenarios;
+    /// real models go through [`Self::from_gguf`] in `gguf_config`.
+    pub fn from_base(
+        base: LlamaFamilyConfig,
+        num_experts: usize,
+        num_experts_per_tok: usize,
+        expert_intermediate_size: usize,
+        norm_topk_prob: bool,
+    ) -> Self {
+        Self {
+            base,
+            num_experts,
+            num_experts_per_tok,
+            expert_intermediate_size,
+            norm_topk_prob,
+        }
+    }
+
+    /// True iff the router is configured to activate `< num_experts` experts
+    /// per token. (Sanity guard — a config with `top_k == num_experts` is
+    /// equivalent to a dense layer with extra dispatch cost.)
+    pub fn is_truly_sparse(&self) -> bool {
+        self.num_experts_per_tok > 0 && self.num_experts_per_tok < self.num_experts
+    }
+}

--- a/crates/ferrum-models/tests/moe_config_test.rs
+++ b/crates/ferrum-models/tests/moe_config_test.rs
@@ -1,0 +1,257 @@
+//! `Qwen3MoeConfig::from_gguf` — verify MoE metadata parsing for the
+//! qwen3moe architecture, plus interaction with `LlamaFamilyConfig::from_gguf`
+//! (which must reject MoE archs rather than silently lowering them).
+
+use std::io::{Cursor, Write};
+
+use candle_core::quantized::gguf_file::{self, Value};
+use candle_core::quantized::{GgmlDType, QTensor};
+use candle_core::{Device, Tensor};
+use ferrum_models::models::llama_family::LlamaFamilyConfig;
+use ferrum_models::moe_config::Qwen3MoeConfig;
+use ferrum_quantization::gguf::GgufFile;
+
+/// Build a metadata-only GGUF (with a placeholder embed table). Mirrors the
+/// helper from `gguf_config_test.rs` but takes pre-built `Value` entries
+/// and a custom architecture string.
+fn build_gguf(
+    arch: &str,
+    extra_keys: &[(&str, Value)],
+    vocab_rows: usize,
+    hidden_size: usize,
+) -> tempfile::NamedTempFile {
+    let device = Device::Cpu;
+    let n = vocab_rows * hidden_size;
+    let raw: Vec<f32> = (0..n).map(|i| i as f32 * 0.001).collect();
+    let t = Tensor::from_vec(raw, (vocab_rows, hidden_size), &device).unwrap();
+    let embed = QTensor::quantize(&t, GgmlDType::F32).unwrap();
+
+    let arch_v = Value::String(arch.to_string());
+    let mut metadata: Vec<(&str, &Value)> = vec![("general.architecture", &arch_v)];
+    for (k, v) in extra_keys {
+        metadata.push((k, v));
+    }
+    let tensors: Vec<(&str, &QTensor)> = vec![("token_embd.weight", &embed)];
+
+    let mut buf: Vec<u8> = Vec::new();
+    {
+        let mut cursor = Cursor::new(&mut buf);
+        gguf_file::write(&mut cursor, &metadata, &tensors).unwrap();
+    }
+    let mut tmp = tempfile::NamedTempFile::new().unwrap();
+    tmp.write_all(&buf).unwrap();
+    tmp.flush().unwrap();
+    tmp
+}
+
+#[test]
+fn qwen3moe_config_from_gguf_full() {
+    // Qwen3-30B-A3B numbers: 48 layers, hidden 2048, 32 heads, 4 kv heads,
+    // 128 experts, top-8 routing, expert FFN 768.
+    let extra = [
+        ("qwen3moe.block_count", Value::U32(48)),
+        ("qwen3moe.embedding_length", Value::U32(2048)),
+        ("qwen3moe.feed_forward_length", Value::U32(6144)), // legacy field
+        ("qwen3moe.attention.head_count", Value::U32(32)),
+        ("qwen3moe.attention.head_count_kv", Value::U32(4)),
+        (
+            "qwen3moe.attention.layer_norm_rms_epsilon",
+            Value::F32(1.0e-6),
+        ),
+        ("qwen3moe.context_length", Value::U32(32768)),
+        ("qwen3moe.rope.freq_base", Value::F32(1.0e6)),
+        ("qwen3moe.vocab_size", Value::U32(151_936)),
+        ("qwen3moe.expert_count", Value::U32(128)),
+        ("qwen3moe.expert_used_count", Value::U32(8)),
+        ("qwen3moe.expert_feed_forward_length", Value::U32(768)),
+        ("qwen3moe.expert_norm_topk_prob", Value::Bool(true)),
+    ];
+
+    let tmp = build_gguf("qwen3moe", &extra, 32, 2048);
+    let gguf = GgufFile::open(tmp.path()).unwrap();
+    let cfg = Qwen3MoeConfig::from_gguf(&gguf).expect("Qwen3MoeConfig::from_gguf");
+
+    // MoE-specific
+    assert_eq!(cfg.num_experts, 128);
+    assert_eq!(cfg.num_experts_per_tok, 8);
+    assert_eq!(cfg.expert_intermediate_size, 768);
+    assert!(cfg.norm_topk_prob);
+    assert!(cfg.is_truly_sparse());
+
+    // Inherited dense fields
+    assert_eq!(cfg.base.num_layers, 48);
+    assert_eq!(cfg.base.hidden_size, 2048);
+    assert_eq!(cfg.base.num_heads, 32);
+    assert_eq!(cfg.base.num_kv_heads, 4);
+    assert_eq!(cfg.base.head_dim, 64); // 2048 / 32
+    assert_eq!(cfg.base.intermediate_size, 768); // mirrored from expert size
+    assert_eq!(cfg.base.vocab_size, 151_936);
+    assert_eq!(cfg.base.max_seq_len, 32768);
+    assert!(cfg.base.has_qk_norm, "Qwen3-MoE has QK-norm");
+    assert_eq!(cfg.base.sliding_window, 0);
+    assert!((cfg.base.rope_theta - 1.0e6).abs() < 1.0);
+    assert!((cfg.base.rms_norm_eps - 1.0e-6).abs() < 1e-12);
+}
+
+#[test]
+fn qwen3moe_norm_topk_prob_defaults_true_when_missing() {
+    // Some older GGUF dumps don't include `expert_norm_topk_prob` —
+    // helper should default to true (Qwen3-MoE convention).
+    let extra = [
+        ("qwen3moe.block_count", Value::U32(4)),
+        ("qwen3moe.embedding_length", Value::U32(64)),
+        ("qwen3moe.attention.head_count", Value::U32(2)),
+        (
+            "qwen3moe.attention.layer_norm_rms_epsilon",
+            Value::F32(1.0e-6),
+        ),
+        ("qwen3moe.expert_count", Value::U32(8)),
+        ("qwen3moe.expert_used_count", Value::U32(2)),
+        ("qwen3moe.expert_feed_forward_length", Value::U32(128)),
+    ];
+    let tmp = build_gguf("qwen3moe", &extra, 32, 64);
+    let gguf = GgufFile::open(tmp.path()).unwrap();
+    let cfg = Qwen3MoeConfig::from_gguf(&gguf).unwrap();
+    assert!(cfg.norm_topk_prob);
+}
+
+#[test]
+fn invalid_topk_count_returns_err() {
+    // expert_used_count > expert_count is structurally invalid.
+    let extra = [
+        ("qwen3moe.block_count", Value::U32(4)),
+        ("qwen3moe.embedding_length", Value::U32(64)),
+        ("qwen3moe.attention.head_count", Value::U32(2)),
+        (
+            "qwen3moe.attention.layer_norm_rms_epsilon",
+            Value::F32(1.0e-6),
+        ),
+        ("qwen3moe.expert_count", Value::U32(4)),
+        ("qwen3moe.expert_used_count", Value::U32(8)), // > 4
+        ("qwen3moe.expert_feed_forward_length", Value::U32(128)),
+    ];
+    let tmp = build_gguf("qwen3moe", &extra, 32, 64);
+    let gguf = GgufFile::open(tmp.path()).unwrap();
+    let result = Qwen3MoeConfig::from_gguf(&gguf);
+    assert!(result.is_err());
+    let err = result.err().unwrap().to_string();
+    assert!(err.contains("expert_used_count"), "{err}");
+}
+
+#[test]
+fn missing_expert_fields_returns_err() {
+    let extra = [
+        ("qwen3moe.block_count", Value::U32(4)),
+        ("qwen3moe.embedding_length", Value::U32(64)),
+        ("qwen3moe.attention.head_count", Value::U32(2)),
+        (
+            "qwen3moe.attention.layer_norm_rms_epsilon",
+            Value::F32(1.0e-6),
+        ),
+        // No expert_count / expert_used_count / expert_feed_forward_length
+    ];
+    let tmp = build_gguf("qwen3moe", &extra, 32, 64);
+    let gguf = GgufFile::open(tmp.path()).unwrap();
+    let result = Qwen3MoeConfig::from_gguf(&gguf);
+    assert!(result.is_err());
+    let err = result.err().unwrap().to_string();
+    assert!(
+        err.contains("expert_count"),
+        "should mention missing key: {err}"
+    );
+}
+
+#[test]
+fn wrong_architecture_returns_err() {
+    // Dense qwen3 GGUF passed to MoE constructor should reject upfront.
+    let extra = [
+        ("qwen3.block_count", Value::U32(28)),
+        ("qwen3.embedding_length", Value::U32(1024)),
+        ("qwen3.attention.head_count", Value::U32(16)),
+        ("qwen3.attention.layer_norm_rms_epsilon", Value::F32(1.0e-6)),
+    ];
+    let tmp = build_gguf("qwen3", &extra, 32, 1024);
+    let gguf = GgufFile::open(tmp.path()).unwrap();
+    let result = Qwen3MoeConfig::from_gguf(&gguf);
+    assert!(result.is_err());
+    let err = result.err().unwrap().to_string();
+    assert!(err.contains("expected arch 'qwen3moe'"), "{err}");
+}
+
+#[test]
+fn dense_from_gguf_rejects_moe_archs_with_redirect() {
+    // LlamaFamilyConfig::from_gguf should NOT silently lower a qwen3moe
+    // file to a dense config (would lose all MoE info). It must error
+    // and point callers at the MoE constructor.
+    let extra = [
+        ("qwen3moe.block_count", Value::U32(48)),
+        ("qwen3moe.embedding_length", Value::U32(2048)),
+        ("qwen3moe.attention.head_count", Value::U32(32)),
+        (
+            "qwen3moe.attention.layer_norm_rms_epsilon",
+            Value::F32(1.0e-6),
+        ),
+    ];
+    let tmp = build_gguf("qwen3moe", &extra, 32, 2048);
+    let gguf = GgufFile::open(tmp.path()).unwrap();
+    let result = LlamaFamilyConfig::from_gguf(&gguf);
+    assert!(result.is_err(), "dense from_gguf must reject MoE arch");
+    let err = result.err().unwrap().to_string();
+    assert!(
+        err.contains("MoE") && err.contains("Qwen3MoeConfig::from_gguf"),
+        "redirect points to MoE constructor: {err}"
+    );
+
+    // mixtral and deepseek2 should also be rejected.
+    for arch in ["mixtral", "deepseek2"] {
+        let arch_extra = [
+            (format!("{arch}.block_count"), Value::U32(32)),
+            (format!("{arch}.embedding_length"), Value::U32(4096)),
+            (format!("{arch}.attention.head_count"), Value::U32(32)),
+            (
+                format!("{arch}.attention.layer_norm_rms_epsilon"),
+                Value::F32(1.0e-5),
+            ),
+        ];
+        // Convert to (&str, Value) tuples for build_gguf.
+        let extras_owned: Vec<(String, Value)> = arch_extra.into_iter().collect();
+        let extras_ref: Vec<(&str, Value)> = extras_owned
+            .iter()
+            .map(|(k, v)| (k.as_str(), v.clone()))
+            .collect();
+        let tmp = build_gguf(arch, &extras_ref, 32, 4096);
+        let gguf = GgufFile::open(tmp.path()).unwrap();
+        let result = LlamaFamilyConfig::from_gguf(&gguf);
+        assert!(
+            result.is_err(),
+            "dense from_gguf must reject {arch}, got {:?}",
+            result.is_ok()
+        );
+    }
+}
+
+#[test]
+fn from_base_round_trips_correctly() {
+    // Construct a dense LlamaFamilyConfig (any arch) then wrap in MoE.
+    // Verifies the constructor does what it says without going through GGUF.
+    let extra = [
+        ("qwen3.block_count", Value::U32(28)),
+        ("qwen3.embedding_length", Value::U32(1024)),
+        ("qwen3.feed_forward_length", Value::U32(3072)),
+        ("qwen3.attention.head_count", Value::U32(16)),
+        ("qwen3.attention.layer_norm_rms_epsilon", Value::F32(1.0e-6)),
+    ];
+    let tmp = build_gguf("qwen3", &extra, 32, 1024);
+    let gguf = GgufFile::open(tmp.path()).unwrap();
+    let dense = LlamaFamilyConfig::from_gguf(&gguf).unwrap();
+
+    let moe = Qwen3MoeConfig::from_base(dense.clone(), 64, 4, 256, true);
+    assert_eq!(moe.base, dense);
+    assert_eq!(moe.num_experts, 64);
+    assert_eq!(moe.num_experts_per_tok, 4);
+    assert!(moe.is_truly_sparse());
+
+    // Edge: top_k == num_experts → not sparse.
+    let dense_eq = Qwen3MoeConfig::from_base(dense, 4, 4, 256, true);
+    assert!(!dense_eq.is_truly_sparse());
+}


### PR DESCRIPTION
First step of the Qwen MoE series. Phase 2A is **data types only** — runtime (router + expert dispatch + MoE forward path) lands in 2B/2C/2D. This PR locks the MoE config shape so the rest of the series can be self-contained diffs.

## What

### \`Qwen3MoeConfig\` (new)
Wraps \`LlamaFamilyConfig\` (composition, not field addition) with four MoE-specific fields:
- \`num_experts\` (Qwen3-30B-A3B = 128)
- \`num_experts_per_tok\` (= 8, top-K routing)
- \`expert_intermediate_size\` (= 768, per-expert FFN)
- \`norm_topk_prob\` (Qwen3 convention: true)

Plus \`from_base(...)\` constructor and \`is_truly_sparse()\` predicate.

### \`Qwen3MoeConfig::from_gguf\` (new)
Reads \`qwen3moe.*\` keys including \`expert_count\` / \`expert_used_count\` / \`expert_feed_forward_length\` / \`expert_norm_topk_prob\`. Per-expert FFN size is mirrored into \`base.intermediate_size\` (Qwen3-MoE has no shared dense FFN). Forces \`has_qk_norm = true\` since Qwen3-MoE inherits the QK-norm trick from dense Qwen3.

### \`LlamaFamilyConfig::from_gguf\` updated
Now rejects MoE archs (\`qwen3moe\` / \`mixtral\` / \`deepseek2\`) with a clear redirect to the MoE constructor — silent lowering of MoE → dense (which would drop \`expert_count\` etc.) can't happen.

## Why composition over field addition

| Choice | Pro | Con |
|---|---|---|
| **Wrap LlamaFamilyConfig** (this PR) | Zero churn for every existing dense call site (qwen3_from_def, llama_from_def, four TTS struct literals). Matches the design where MoE will live in a separate \`Qwen3MoeModel<B>\` rather than branching inside \`LlamaFamilyModel::forward_layer\`. | Future "either dense or MoE" callers will want an enum wrapper. |
| Add \`Option<MoeConfig>\` to LlamaFamilyConfig | One type. | Every existing constructor needs \`moe: None\`. Field is dead weight on dense paths. |

Composition wins for now; an enum wrapper can be added when a real consumer exists.

## Tests (7 new)

- Full Qwen3-30B-A3B-shaped GGUF parses correctly
- \`expert_norm_topk_prob\` defaults to true when missing
- \`expert_used_count > expert_count\` rejected
- Missing required MoE keys rejected
- Wrong arch passed to MoE constructor rejected
- Dense \`from_gguf\` rejects MoE archs with redirect message
- \`from_base\` round-trips, \`is_truly_sparse\` edge case (top_k == num_experts)

Plus 6 existing \`gguf_config_test\`s still pass — \`LlamaFamilyConfig::from_gguf\` redirect logic doesn't break dense parsing.

\`RUSTFLAGS=\"-D warnings\" cargo check --workspace --all-targets [--features metal]\` clean.

## Files

- \`crates/ferrum-models/src/moe_config.rs\` (new)
- \`crates/ferrum-models/src/gguf_config.rs\` (extended with \`Qwen3MoeConfig::from_gguf\` + MoE arch rejection)
- \`crates/ferrum-models/src/models/llama_family.rs\` (\`#[derive(PartialEq)]\` for round-trip tests)
- \`crates/ferrum-models/src/lib.rs\` (\`pub mod moe_config\`)
- \`crates/ferrum-models/tests/moe_config_test.rs\` (new, 7 tests)

## Test plan

- [ ] CPU CI green
- [ ] Metal CI green
- [ ] CUDA type check (informational)

## What's next

- **Phase 2B**: \`GgufLoader\` extension — read MoE-stacked tensors (\`blk.{i}.ffn_gate_inp.weight\` for the router, \`blk.{i}.ffn_{gate,up,down}_exps.weight\` for stacked expert weights). Adds tensor-name mapping for \`model.layers.{i}.mlp.{gate,experts.{e}.{gate,up,down}_proj}\` etc.
- **Phase 2C**: Router (gating) runtime — softmax → top-K selection → optional norm
- **Phase 2D**: Expert dispatch using candle's existing \`QMatMul::indexed_moe_forward\`
- **Phase 2E**: Wire into a new \`Qwen3MoeModel<B>\` (sibling to \`LlamaFamilyModel<B>\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)