### PR TITLE
feat(models): MoE foundation — GGUF tensor mappings + router + dispatch + Qwen3MoeLayer (Phase 2B/C/D/E)

### DIFF
--- a/crates/ferrum-models/src/lib.rs
+++ b/crates/ferrum-models/src/lib.rs
@@ -28,6 +28,7 @@ pub mod image_processor;
 pub mod loader;
 pub mod mel;
 pub mod models;
+pub mod moe;
 pub mod moe_config;
 pub mod registry;
 pub mod source;

--- a/crates/ferrum-models/src/moe/dispatch.rs
+++ b/crates/ferrum-models/src/moe/dispatch.rs
@@ -1,0 +1,297 @@
+//! Expert dispatch — load per-layer expert weights from a GGUF file and run
+//! the per-token MoE forward (top-K experts per token, weighted combine).
+//!
+//! Phase 2 ships a CPU-only implementation (`moe_forward_cpu`). The
+//! algorithm is:
+//!
+//! ```text
+//! for each token b in batch:
+//!     route token b → (expert_ids[K], weights[K])
+//!     out[b] = 0
+//!     for each (expert_id, weight) pair:
+//!         gate_up = experts.gate_up[expert_id].forward(x[b])     # [2*ffn]
+//!         silu_mul = silu(gate_up[..ffn]) * gate_up[ffn..]       # [ffn]
+//!         contribution = experts.down[expert_id].forward(silu_mul) # [hidden]
+//!         out[b] += weight * contribution
+//! ```
+//!
+//! The fused `gate || up` per-expert layout means we can call
+//! `Backend::fused_silu_mul_split` directly on the projection's output
+//! — same kernel ferrum already uses for dense Llama-family models.
+
+use std::path::Path;
+
+use candle_core::{Device, Result as CandleResult};
+use ferrum_kernels::backend::cpu::CpuBackend;
+use ferrum_kernels::backend::Backend;
+use ferrum_kernels::Linear;
+use ferrum_quantization::gguf::GgufFile;
+use ferrum_quantization::DenseLinear;
+use ferrum_types::{FerrumError, Result};
+
+use crate::moe::router::RouterOutput;
+
+/// Per-layer expert weights, materialised as `[num_experts]`-long vectors
+/// of `Box<dyn Linear<B>>`. Each entry runs the corresponding expert's
+/// fused `[gate; up]` projection or its `down` projection.
+///
+/// `B::Buffer` is hidden behind `Linear<B>` so this struct is generic
+/// over backend, but Phase 2's only consumer (`moe_forward_cpu`) is CPU-
+/// only — generic `moe_forward<B>` is deferred until the trait gains
+/// scaled-accumulate + cheap buffer slicing.
+pub struct ExpertStack<B: Backend> {
+    /// Fused `[gate; up]` projection per expert. Output shape per token:
+    /// `[2 * expert_intermediate]` — the lower half is gate, upper is up.
+    pub gate_up: Vec<Box<dyn Linear<B>>>,
+    /// `down` projection per expert. Output shape per token: `[hidden_size]`.
+    pub down: Vec<Box<dyn Linear<B>>>,
+}
+
+impl<B: Backend> ExpertStack<B> {
+    /// Build from raw fp32 stacked tensors (test helper). Caller has
+    /// already dequantised and laid out the data:
+    ///   `gate_stack`: `[num_experts * expert_inter * hidden]`
+    ///   `up_stack`:   `[num_experts * expert_inter * hidden]`
+    ///   `down_stack`: `[num_experts * hidden * expert_inter]`
+    /// Each per-expert slice is row-major in the natural Linear shape.
+    pub fn from_dense_stacks(
+        gate_stack: &[f32],
+        up_stack: &[f32],
+        down_stack: &[f32],
+        num_experts: usize,
+        hidden_size: usize,
+        expert_intermediate: usize,
+    ) -> Result<Self> {
+        let gate_up_per_expert = expert_intermediate * hidden_size;
+        let down_per_expert = hidden_size * expert_intermediate;
+
+        check_size(
+            gate_stack.len(),
+            num_experts * gate_up_per_expert,
+            "gate_stack",
+        )?;
+        check_size(up_stack.len(), num_experts * gate_up_per_expert, "up_stack")?;
+        check_size(
+            down_stack.len(),
+            num_experts * down_per_expert,
+            "down_stack",
+        )?;
+
+        let mut gate_up = Vec::with_capacity(num_experts);
+        let mut down = Vec::with_capacity(num_experts);
+        for e in 0..num_experts {
+            let g_off = e * gate_up_per_expert;
+            let g_slice = &gate_stack[g_off..g_off + gate_up_per_expert];
+            let u_slice = &up_stack[g_off..g_off + gate_up_per_expert];
+
+            // Fused [gate; up] is [2 * expert_inter, hidden] row-major.
+            // We concatenate row-blocks so the first expert_inter rows are
+            // gate, the next expert_inter rows are up — the layout
+            // fused_silu_mul_split expects.
+            let mut fused = Vec::with_capacity(2 * gate_up_per_expert);
+            fused.extend_from_slice(g_slice);
+            fused.extend_from_slice(u_slice);
+            gate_up.push(Box::new(DenseLinear::<B>::from_rows(
+                &fused,
+                2 * expert_intermediate,
+                hidden_size,
+            )) as Box<dyn Linear<B>>);
+
+            let d_off = e * down_per_expert;
+            let d_slice = &down_stack[d_off..d_off + down_per_expert];
+            down.push(Box::new(DenseLinear::<B>::from_rows(
+                d_slice,
+                hidden_size,
+                expert_intermediate,
+            )) as Box<dyn Linear<B>>);
+        }
+        Ok(Self { gate_up, down })
+    }
+
+    /// Load all experts for one MoE layer from a GGUF file. Names follow
+    /// the GGUF convention: `blk.{layer_idx}.ffn_{gate,up,down}_exps.weight`.
+    /// Tensors are dequantised on CPU (Phase 2 dispatch is CPU-only).
+    pub fn load_from_gguf(
+        gguf: &GgufFile,
+        layer_idx: usize,
+        num_experts: usize,
+        hidden_size: usize,
+        expert_intermediate: usize,
+    ) -> Result<Self> {
+        let device = Device::Cpu;
+        let gate = read_dequant_flat(
+            gguf,
+            &format!("blk.{layer_idx}.ffn_gate_exps.weight"),
+            &device,
+        )?;
+        let up = read_dequant_flat(
+            gguf,
+            &format!("blk.{layer_idx}.ffn_up_exps.weight"),
+            &device,
+        )?;
+        let down = read_dequant_flat(
+            gguf,
+            &format!("blk.{layer_idx}.ffn_down_exps.weight"),
+            &device,
+        )?;
+        Self::from_dense_stacks(
+            &gate,
+            &up,
+            &down,
+            num_experts,
+            hidden_size,
+            expert_intermediate,
+        )
+    }
+
+    /// Convenience: open a GGUF and load layer `layer_idx`. The GGUF
+    /// stays open inside this call only — for multi-layer loads use
+    /// [`Self::load_from_gguf`] with a shared [`GgufFile`].
+    pub fn open_and_load(
+        path: impl AsRef<Path>,
+        layer_idx: usize,
+        num_experts: usize,
+        hidden_size: usize,
+        expert_intermediate: usize,
+    ) -> Result<Self> {
+        let gguf = GgufFile::open(path).map_err(candle_to_ferrum)?;
+        Self::load_from_gguf(
+            &gguf,
+            layer_idx,
+            num_experts,
+            hidden_size,
+            expert_intermediate,
+        )
+    }
+
+    /// `num_experts` for the layer (consistency check helper).
+    pub fn num_experts(&self) -> usize {
+        debug_assert_eq!(
+            self.gate_up.len(),
+            self.down.len(),
+            "ExpertStack: gate_up and down disagree on expert count"
+        );
+        self.gate_up.len()
+    }
+}
+
+/// Run MoE forward on CPU.
+///
+/// Inputs:
+///   - `x`: `[batch, hidden_size]` row-major hidden states (post-attention,
+///          post-residual — i.e. what the dense MLP would normally see).
+///   - `router`: top-K assignments + weights from [`super::router::route`].
+///   - `experts`: per-layer expert weights from [`ExpertStack::load_from_gguf`].
+///
+/// Output:
+///   - `out`: `[batch, hidden_size]`. Resized + zero-initialised.
+///
+/// The function recomputes its scratch buffers each call. For tight
+/// inner loops, callers will eventually want a pre-allocated workspace
+/// (Phase 2F refactor). For now, this is the readable reference.
+pub fn moe_forward_cpu(
+    x: &[f32],
+    batch: usize,
+    hidden_size: usize,
+    expert_intermediate: usize,
+    top_k: usize,
+    router: &RouterOutput,
+    experts: &ExpertStack<CpuBackend>,
+    out: &mut Vec<f32>,
+) -> Result<()> {
+    let n_experts = experts.num_experts();
+
+    if x.len() != batch * hidden_size {
+        return Err(FerrumError::model(format!(
+            "moe_forward_cpu: x len {} doesn't match batch*hidden = {}*{} = {}",
+            x.len(),
+            batch,
+            hidden_size,
+            batch * hidden_size
+        )));
+    }
+    if router.expert_ids.len() != batch * top_k {
+        return Err(FerrumError::model(format!(
+            "moe_forward_cpu: router has {} expert_ids but expected batch*top_k = {}*{} = {}",
+            router.expert_ids.len(),
+            batch,
+            top_k,
+            batch * top_k
+        )));
+    }
+
+    out.clear();
+    out.resize(batch * hidden_size, 0.0);
+
+    let mut ctx = <CpuBackend as Backend>::new_context();
+    let mut x_b: Vec<f32> = vec![0.0; hidden_size];
+    let mut gate_up_buf: Vec<f32> = vec![0.0; 2 * expert_intermediate];
+    let mut silu_mul_buf: Vec<f32> = vec![0.0; expert_intermediate];
+    let mut down_out: Vec<f32> = vec![0.0; hidden_size];
+
+    for b in 0..batch {
+        x_b.copy_from_slice(&x[b * hidden_size..(b + 1) * hidden_size]);
+
+        for k in 0..top_k {
+            let pair_idx = b * top_k + k;
+            let expert_id = router.expert_ids[pair_idx] as usize;
+            let weight = router.expert_weights[pair_idx];
+
+            if expert_id >= n_experts {
+                return Err(FerrumError::model(format!(
+                    "moe_forward_cpu: router selected expert {expert_id} >= num_experts {n_experts}"
+                )));
+            }
+
+            // Gate||Up projection (fused) → [1, 2*expert_inter]
+            experts.gate_up[expert_id].forward(&mut ctx, &x_b, &mut gate_up_buf, 1);
+
+            // SiLU(gate) * up → [1, expert_inter]
+            <CpuBackend as Backend>::fused_silu_mul_split(
+                &mut ctx,
+                &gate_up_buf,
+                &mut silu_mul_buf,
+                1,
+                expert_intermediate,
+            );
+
+            // Down projection → [1, hidden]
+            experts.down[expert_id].forward(&mut ctx, &silu_mul_buf, &mut down_out, 1);
+
+            // Weighted accumulate into out[b, :]. Done host-side because
+            // CpuBackend::Buffer = Vec<f32> and the trait doesn't yet
+            // expose scaled-add.
+            let out_row = &mut out[b * hidden_size..(b + 1) * hidden_size];
+            for (o, d) in out_row.iter_mut().zip(down_out.iter()) {
+                *o += weight * *d;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn check_size(actual: usize, expected: usize, label: &str) -> Result<()> {
+    if actual != expected {
+        return Err(FerrumError::model(format!(
+            "ExpertStack: {label} size mismatch (got {actual}, expected {expected})"
+        )));
+    }
+    Ok(())
+}
+
+fn read_dequant_flat(gguf: &GgufFile, name: &str, device: &Device) -> Result<Vec<f32>> {
+    let qt = gguf.read_tensor(name, device).map_err(candle_to_ferrum)?;
+    let dense = qt.dequantize(device).map_err(candle_to_ferrum)?;
+    let flat = dense.flatten_all().map_err(candle_to_ferrum)?;
+    flat.to_vec1::<f32>().map_err(candle_to_ferrum)
+}
+
+fn candle_to_ferrum(e: candle_core::Error) -> FerrumError {
+    FerrumError::model(format!("candle: {e}"))
+}
+
+// Suppress unused-import warning when this module compiles standalone in
+// the lib (the candle Result alias is only used via map_err in Phase 2).
+#[allow(dead_code)]
+type _CandleResult<T> = CandleResult<T>;

--- a/crates/ferrum-models/src/moe/layer.rs
+++ b/crates/ferrum-models/src/moe/layer.rs
@@ -1,0 +1,149 @@
+//! `Qwen3MoeLayer` — bundles the three pieces a single MoE layer needs
+//! (router linear, expert weight stack, top-K configuration) into a
+//! struct with one ergonomic `forward()` method. Drop-in replacement for
+//! a dense MLP layer in the wider transformer body.
+//!
+//! Phase 2 ships a CPU-only forward via [`moe_forward_cpu`]. Generic
+//! `Backend<B>` support is deferred (see `dispatch.rs` for why).
+
+use ferrum_kernels::backend::cpu::CpuBackend;
+use ferrum_kernels::backend::Backend;
+use ferrum_kernels::Linear;
+use ferrum_quantization::gguf::{GgufFile, GgufLinear};
+use ferrum_types::{FerrumError, Result};
+
+use crate::moe::dispatch::{moe_forward_cpu, ExpertStack};
+use crate::moe::router::route;
+use crate::moe_config::Qwen3MoeConfig;
+
+/// Per-layer Qwen3-MoE state: router + expert weights + config knobs.
+///
+/// Construct with [`Self::load_from_gguf`] (or its convenience wrappers).
+/// Call [`Self::forward_cpu`] to run one MoE layer's forward pass.
+pub struct Qwen3MoeLayer<B: Backend> {
+    /// Gating linear: `[hidden] → [num_experts]` per token.
+    pub router: Box<dyn Linear<B>>,
+    /// Per-expert MLP weights.
+    pub experts: ExpertStack<B>,
+    /// Number of experts to activate per token.
+    pub top_k: usize,
+    /// Whether to renormalise the K selected probs to sum to 1.
+    pub norm_topk_prob: bool,
+    /// Hidden size (= `router.in_features()`, kept here to avoid pointer
+    /// chasing in tight loops).
+    pub hidden_size: usize,
+    /// Per-expert FFN inner size (= `experts.gate_up[e].out_features() / 2`).
+    pub expert_intermediate: usize,
+    /// Total expert count (= `experts.num_experts()`).
+    pub num_experts: usize,
+}
+
+impl<B: Backend> Qwen3MoeLayer<B> {
+    /// Load both router and expert weights for layer `layer_idx` from a
+    /// GGUF file. Convenience wrapper around the lower-level GGUF reader
+    /// + `ExpertStack::load_from_gguf` + manual router construction.
+    pub fn load_from_gguf(gguf: &GgufFile, layer_idx: usize, cfg: &Qwen3MoeConfig) -> Result<Self> {
+        // Router lives at `blk.{i}.ffn_gate_inp.weight` — 2-D, fits the
+        // standard Linear path. Build via GgufLinear directly to avoid
+        // pulling a full WeightLoader into the dependency surface here.
+        let router_name = format!("blk.{layer_idx}.ffn_gate_inp.weight");
+        if !gguf.has_tensor(&router_name) {
+            return Err(FerrumError::model(format!(
+                "Qwen3MoeLayer: router tensor '{router_name}' not in GGUF"
+            )));
+        }
+        let router_qt = gguf
+            .read_tensor(&router_name, &candle_core::Device::Cpu)
+            .map_err(|e| FerrumError::model(format!("read router: {e}")))?;
+        let router = GgufLinear::<B>::from_qtensor(&router_qt)
+            .map_err(|e| FerrumError::model(format!("router from_qtensor: {e}")))?;
+        let router: Box<dyn Linear<B>> = Box::new(router);
+
+        // Expert weight stack — three 3-D tensors.
+        let experts = ExpertStack::<B>::load_from_gguf(
+            gguf,
+            layer_idx,
+            cfg.num_experts,
+            cfg.base.hidden_size,
+            cfg.expert_intermediate_size,
+        )?;
+
+        // Sanity: dimensions should agree with the config.
+        if router.in_features() != cfg.base.hidden_size {
+            return Err(FerrumError::model(format!(
+                "router in_features {} != hidden_size {}",
+                router.in_features(),
+                cfg.base.hidden_size
+            )));
+        }
+        if router.out_features() != cfg.num_experts {
+            return Err(FerrumError::model(format!(
+                "router out_features {} != num_experts {}",
+                router.out_features(),
+                cfg.num_experts
+            )));
+        }
+
+        Ok(Self {
+            router,
+            experts,
+            top_k: cfg.num_experts_per_tok,
+            norm_topk_prob: cfg.norm_topk_prob,
+            hidden_size: cfg.base.hidden_size,
+            expert_intermediate: cfg.expert_intermediate_size,
+            num_experts: cfg.num_experts,
+        })
+    }
+}
+
+impl Qwen3MoeLayer<CpuBackend> {
+    /// Run one MoE layer's forward pass on CPU.
+    ///
+    /// `x`: `[batch, hidden_size]` — typically the hidden state after the
+    /// post-attention RMSNorm in the surrounding transformer block.
+    /// `out`: same shape as `x`. Resized + zero-initialised.
+    ///
+    /// Internally:
+    ///   1. Run `router.forward(x)` → router_logits `[batch, num_experts]`
+    ///   2. Call `route(...)` to pick top-K and weights per token.
+    ///   3. Call `moe_forward_cpu(...)` for the per-expert MLP loop.
+    pub fn forward_cpu(&self, x: &[f32], batch: usize, out: &mut Vec<f32>) -> Result<()> {
+        if x.len() != batch * self.hidden_size {
+            return Err(FerrumError::model(format!(
+                "Qwen3MoeLayer::forward_cpu: x len {} != batch*hidden = {}*{} = {}",
+                x.len(),
+                batch,
+                self.hidden_size,
+                batch * self.hidden_size
+            )));
+        }
+
+        // Step 1: router logits
+        let mut router_logits: Vec<f32> = vec![0.0; batch * self.num_experts];
+        let mut ctx = <CpuBackend as Backend>::new_context();
+        let x_buf: Vec<f32> = x.to_vec();
+        self.router
+            .forward(&mut ctx, &x_buf, &mut router_logits, batch);
+
+        // Step 2: top-K + softmax + (optional) renorm
+        let router_out = route(
+            &router_logits,
+            batch,
+            self.num_experts,
+            self.top_k,
+            self.norm_topk_prob,
+        );
+
+        // Step 3: per-token, per-expert MLP dispatch and weighted combine
+        moe_forward_cpu(
+            x,
+            batch,
+            self.hidden_size,
+            self.expert_intermediate,
+            self.top_k,
+            &router_out,
+            &self.experts,
+            out,
+        )
+    }
+}

--- a/crates/ferrum-models/src/moe/mod.rs
+++ b/crates/ferrum-models/src/moe/mod.rs
@@ -1,0 +1,22 @@
+//! Mixture-of-Experts runtime primitives.
+//!
+//! Three pieces, each in its own file:
+//!   - [`router`] — softmax + top-K + optional re-norm to pick which experts
+//!     handle each token, and what weight to combine their outputs with.
+//!   - [`dispatch`] — load the per-layer expert weight stack from a GGUF
+//!     file and run the per-token expert MLPs (gate / up / SiLU·mul /
+//!     down) into a weighted sum.
+//!
+//! Phase 2 scope: CPU implementation only. Generic `Backend<B>` support is
+//! a follow-up — the per-token, per-expert dispatch loop wants buffer
+//! slicing and scaled accumulate, which the trait surface doesn't yet
+//! expose cleanly. CPU first lets us validate the algorithm + numerics
+//! against reference impls before committing to a backend-specific path.
+
+pub mod dispatch;
+pub mod layer;
+pub mod router;
+
+pub use dispatch::{moe_forward_cpu, ExpertStack};
+pub use layer::Qwen3MoeLayer;
+pub use router::{route, RouterOutput};

--- a/crates/ferrum-models/src/moe/router.rs
+++ b/crates/ferrum-models/src/moe/router.rs
@@ -1,0 +1,139 @@
+//! MoE router (gating) — pick top-K experts per token.
+//!
+//! Given router logits of shape `[batch, num_experts]` (output of the small
+//! gating linear), produce per-token expert indices + combine weights:
+//!
+//!   1. Softmax over each row (so all probs are non-negative and sum to 1).
+//!   2. Take the K highest-probability experts.
+//!   3. Optionally renormalise those K probs so they sum back to 1
+//!      (Qwen3-MoE / Mixtral default; some legacy variants don't).
+//!
+//! Output layout is **flat with stride `top_k`**: `expert_ids[b*K + k]`
+//! is the k-th selected expert for token b, and `expert_weights[b*K + k]`
+//! is its combine weight. That matches how the dispatch loop iterates.
+
+/// Result of routing one batch: parallel arrays indexed `[b * top_k + k]`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RouterOutput {
+    /// Selected expert indices. `expert_ids[b * top_k + k] ∈ [0, num_experts)`.
+    pub expert_ids: Vec<u32>,
+    /// Combine weights. Same shape as `expert_ids`. If
+    /// `norm_topk_prob` was true, the K weights for each token sum to 1;
+    /// otherwise they're the raw (post-softmax) probabilities of the
+    /// selected experts.
+    pub expert_weights: Vec<f32>,
+}
+
+impl RouterOutput {
+    /// Number of tokens routed.
+    pub fn batch(&self) -> usize {
+        // `top_k` is the second dimension; we don't store it explicitly,
+        // so derive it from the assumption that the caller passed
+        // consistent sizes. Length checks belong upstream.
+        self.expert_ids.len() / self.batch_top_k_pair_count()
+    }
+
+    fn batch_top_k_pair_count(&self) -> usize {
+        // Defensive: avoid divide-by-zero for the empty-router case.
+        self.expert_ids.len().max(1)
+    }
+}
+
+/// Route a batch of tokens to top-K experts.
+///
+/// `logits`: row-major `[batch, num_experts]`. Each row is the raw output
+/// of the gating linear for one token.
+///
+/// `norm_topk_prob`: if true, the K returned weights for each token are
+/// renormalised to sum to 1 (after the masked softmax) — Qwen3-MoE and
+/// Mixtral both do this. If false, they're the raw softmax probabilities,
+/// which leaves probability mass "on the floor" for unselected experts.
+///
+/// Panics if `top_k == 0` or `top_k > num_experts` or
+/// `logits.len() != batch * num_experts` — these are programming errors,
+/// not runtime conditions.
+pub fn route(
+    logits: &[f32],
+    batch: usize,
+    num_experts: usize,
+    top_k: usize,
+    norm_topk_prob: bool,
+) -> RouterOutput {
+    assert_eq!(
+        logits.len(),
+        batch * num_experts,
+        "router logits shape mismatch: expected {batch}×{num_experts}, got {}",
+        logits.len()
+    );
+    assert!(top_k > 0, "top_k must be > 0");
+    assert!(
+        top_k <= num_experts,
+        "top_k {top_k} exceeds num_experts {num_experts}"
+    );
+
+    let mut expert_ids = Vec::with_capacity(batch * top_k);
+    let mut expert_weights = Vec::with_capacity(batch * top_k);
+
+    for b in 0..batch {
+        let row = &logits[b * num_experts..(b + 1) * num_experts];
+        let probs = softmax(row);
+        let topk = top_k_indices(&probs, top_k);
+
+        // Optionally renorm the K selected weights. If norm is off we
+        // emit the raw post-softmax probs (unselected mass discarded).
+        let combine_weights = if norm_topk_prob {
+            renormalise(&topk, &probs)
+        } else {
+            topk.iter().map(|&i| probs[i]).collect::<Vec<_>>()
+        };
+
+        for (i, &exp_id) in topk.iter().enumerate() {
+            expert_ids.push(exp_id as u32);
+            expert_weights.push(combine_weights[i]);
+        }
+    }
+
+    RouterOutput {
+        expert_ids,
+        expert_weights,
+    }
+}
+
+/// Numerically-stable softmax over a single row.
+fn softmax(row: &[f32]) -> Vec<f32> {
+    let max = row.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
+    let mut exp: Vec<f32> = row.iter().map(|&x| (x - max).exp()).collect();
+    let sum: f32 = exp.iter().sum();
+    // sum is guaranteed > 0 because at least one term is exp(max-max) = 1.
+    for v in &mut exp {
+        *v /= sum;
+    }
+    exp
+}
+
+/// Return the indices of the K largest entries, sorted by value descending,
+/// breaking ties by smaller index first (stable / reproducible).
+fn top_k_indices(probs: &[f32], top_k: usize) -> Vec<usize> {
+    // Pair each prob with its index, sort by (-prob, index) then truncate.
+    let mut indexed: Vec<(usize, f32)> = probs.iter().enumerate().map(|(i, &p)| (i, p)).collect();
+    indexed.sort_by(|a, b| {
+        b.1.partial_cmp(&a.1)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.0.cmp(&b.0))
+    });
+    indexed.truncate(top_k);
+    indexed.into_iter().map(|(i, _)| i).collect()
+}
+
+/// Renormalise the K selected probabilities so they sum to 1.
+fn renormalise(selected: &[usize], probs: &[f32]) -> Vec<f32> {
+    let sum: f32 = selected.iter().map(|&i| probs[i]).sum();
+    // Guard against degenerate sum=0 (shouldn't happen with finite logits).
+    if sum > 0.0 {
+        selected.iter().map(|&i| probs[i] / sum).collect()
+    } else {
+        // Fallback: uniform 1/K.
+        let k = selected.len() as f32;
+        vec![1.0 / k; selected.len()]
+    }
+}

--- a/crates/ferrum-models/tests/moe_dispatch_test.rs
+++ b/crates/ferrum-models/tests/moe_dispatch_test.rs
@@ -1,0 +1,371 @@
+//! Expert dispatch tests — `ExpertStack` construction (from raw stacks
+//! and from a synthesized GGUF) plus `moe_forward_cpu` numerical checks.
+//!
+//! All hand-computed expected values use `silu(x) = x * sigmoid(x)` —
+//! the same SwiGLU formulation `Backend::fused_silu_mul_split` implements.
+
+use std::io::{Cursor, Write};
+
+use candle_core::quantized::gguf_file::{self, Value};
+use candle_core::quantized::{GgmlDType, QTensor};
+use candle_core::{Device, Tensor};
+use ferrum_kernels::backend::cpu::CpuBackend;
+use ferrum_models::moe::{moe_forward_cpu, route, ExpertStack, RouterOutput};
+
+fn silu(x: f32) -> f32 {
+    x * (1.0 / (1.0 + (-x).exp()))
+}
+
+/// Identity matrix flattened row-major: `[1 0 0; 0 1 0; 0 0 1]` etc.
+fn identity_rows(n: usize) -> Vec<f32> {
+    let mut v = vec![0.0_f32; n * n];
+    for i in 0..n {
+        v[i * n + i] = 1.0;
+    }
+    v
+}
+
+/// `scale * I_n` flattened row-major.
+fn scaled_identity_rows(n: usize, scale: f32) -> Vec<f32> {
+    let mut v = vec![0.0_f32; n * n];
+    for i in 0..n {
+        v[i * n + i] = scale;
+    }
+    v
+}
+
+#[test]
+fn from_dense_stacks_builds_correct_linear_count() {
+    // 3 experts, hidden=4, expert_inter=8.
+    let n_experts = 3;
+    let hidden = 4;
+    let ffn = 8;
+
+    let gate = vec![0.5_f32; n_experts * ffn * hidden];
+    let up = vec![0.6_f32; n_experts * ffn * hidden];
+    let down = vec![0.7_f32; n_experts * hidden * ffn];
+
+    let stack: ExpertStack<CpuBackend> =
+        ExpertStack::from_dense_stacks(&gate, &up, &down, n_experts, hidden, ffn).unwrap();
+    assert_eq!(stack.num_experts(), n_experts);
+    for e in 0..n_experts {
+        // gate_up Linear: out=2*ffn, in=hidden
+        assert_eq!(stack.gate_up[e].in_features(), hidden);
+        assert_eq!(stack.gate_up[e].out_features(), 2 * ffn);
+        // down Linear: out=hidden, in=ffn
+        assert_eq!(stack.down[e].in_features(), ffn);
+        assert_eq!(stack.down[e].out_features(), hidden);
+    }
+}
+
+#[test]
+fn from_dense_stacks_rejects_size_mismatch() {
+    let n_experts = 2;
+    let hidden = 2;
+    let ffn = 2;
+    let good = vec![0.0_f32; n_experts * ffn * hidden];
+    let bad_short = vec![0.0_f32; 4]; // wrong size
+    let result = ExpertStack::<CpuBackend>::from_dense_stacks(
+        &bad_short, &good, &good, n_experts, hidden, ffn,
+    );
+    assert!(result.is_err());
+    let err = result.err().unwrap().to_string();
+    assert!(err.contains("gate_stack"), "{err}");
+}
+
+#[test]
+fn moe_forward_single_expert_gives_that_experts_output() {
+    // Two experts. Expert 0 is identity; expert 1 is 2× identity.
+    // hidden=2, expert_inter=2, num_experts=2. Input x = [1, 0].
+    // Router selects only expert 0 (top_k=1, weight 1.0).
+    // Expected: silu(1)*1=silu(1), and second component=0 (since x[1]=0).
+    let hidden = 2;
+    let ffn = 2;
+    let n_experts = 2;
+
+    let mut gate = Vec::new();
+    let mut up = Vec::new();
+    let mut down = Vec::new();
+    // Expert 0: identity
+    gate.extend_from_slice(&identity_rows(2));
+    up.extend_from_slice(&identity_rows(2));
+    down.extend_from_slice(&identity_rows(2));
+    // Expert 1: 2× identity
+    gate.extend_from_slice(&scaled_identity_rows(2, 2.0));
+    up.extend_from_slice(&scaled_identity_rows(2, 2.0));
+    down.extend_from_slice(&scaled_identity_rows(2, 2.0));
+
+    let stack =
+        ExpertStack::<CpuBackend>::from_dense_stacks(&gate, &up, &down, n_experts, hidden, ffn)
+            .unwrap();
+
+    let x = vec![1.0_f32, 0.0];
+    let router = RouterOutput {
+        expert_ids: vec![0],
+        expert_weights: vec![1.0],
+    };
+    let mut out = Vec::new();
+    moe_forward_cpu(&x, 1, hidden, ffn, 1, &router, &stack, &mut out).unwrap();
+
+    // x=[1,0]; expert 0 (identity): gate=[1,0], up=[1,0]
+    // silu(gate)*up = [silu(1)*1, silu(0)*0] = [silu(1), 0]
+    // down(identity) = [silu(1), 0]
+    // weight 1.0 → out = [silu(1), 0]
+    let expected = vec![silu(1.0), 0.0];
+    for (got, exp) in out.iter().zip(expected.iter()) {
+        assert!(
+            (got - exp).abs() < 1e-5,
+            "expected {exp}, got {got} (diff {})",
+            (got - exp).abs()
+        );
+    }
+}
+
+#[test]
+fn moe_forward_two_experts_combines_weighted() {
+    // hidden=2, expert_inter=2, num_experts=2. Input x=[1, 0].
+    // Expert 0: identity. Expert 1: 2× identity.
+    // Router: top_k=2, weights [0.3, 0.7].
+    let hidden = 2;
+    let ffn = 2;
+    let n_experts = 2;
+
+    let mut gate = Vec::new();
+    let mut up = Vec::new();
+    let mut down = Vec::new();
+    gate.extend_from_slice(&identity_rows(2));
+    up.extend_from_slice(&identity_rows(2));
+    down.extend_from_slice(&identity_rows(2));
+    gate.extend_from_slice(&scaled_identity_rows(2, 2.0));
+    up.extend_from_slice(&scaled_identity_rows(2, 2.0));
+    down.extend_from_slice(&scaled_identity_rows(2, 2.0));
+
+    let stack =
+        ExpertStack::<CpuBackend>::from_dense_stacks(&gate, &up, &down, n_experts, hidden, ffn)
+            .unwrap();
+
+    let x = vec![1.0_f32, 0.0];
+    let router = RouterOutput {
+        expert_ids: vec![0, 1],
+        expert_weights: vec![0.3, 0.7],
+    };
+    let mut out = Vec::new();
+    moe_forward_cpu(&x, 1, hidden, ffn, 2, &router, &stack, &mut out).unwrap();
+
+    // Expert 0 forward (computed above): [silu(1), 0]
+    // Expert 1: gate=[2, 0], up=[2, 0]; silu(2)*2 = [silu(2)*2, 0]
+    //   down (2× identity) → [2 * silu(2)*2, 0] = [4*silu(2), 0]
+    // Combined: 0.3 * [silu(1), 0] + 0.7 * [4*silu(2), 0]
+    let expected = vec![0.3 * silu(1.0) + 0.7 * 4.0 * silu(2.0), 0.0];
+
+    for (got, exp) in out.iter().zip(expected.iter()) {
+        assert!(
+            (got - exp).abs() < 1e-4,
+            "expected {exp}, got {got} (diff {})",
+            (got - exp).abs()
+        );
+    }
+}
+
+#[test]
+fn moe_forward_handles_batch_with_independent_routing() {
+    // Two tokens, top_k=1 each. Token 0 routed to expert 0, token 1 to expert 1.
+    let hidden = 2;
+    let ffn = 2;
+    let n_experts = 2;
+
+    let mut gate = Vec::new();
+    let mut up = Vec::new();
+    let mut down = Vec::new();
+    gate.extend_from_slice(&identity_rows(2));
+    up.extend_from_slice(&identity_rows(2));
+    down.extend_from_slice(&identity_rows(2));
+    gate.extend_from_slice(&scaled_identity_rows(2, 2.0));
+    up.extend_from_slice(&scaled_identity_rows(2, 2.0));
+    down.extend_from_slice(&scaled_identity_rows(2, 2.0));
+
+    let stack =
+        ExpertStack::<CpuBackend>::from_dense_stacks(&gate, &up, &down, n_experts, hidden, ffn)
+            .unwrap();
+
+    // Token 0: x=[1, 0]; Token 1: x=[1, 0] (same input, different expert)
+    let x = vec![1.0_f32, 0.0, 1.0, 0.0];
+    let router = RouterOutput {
+        expert_ids: vec![0, 1],
+        expert_weights: vec![1.0, 1.0],
+    };
+    let mut out = Vec::new();
+    moe_forward_cpu(&x, 2, hidden, ffn, 1, &router, &stack, &mut out).unwrap();
+
+    // Token 0 (expert 0): [silu(1), 0]
+    // Token 1 (expert 1): [4*silu(2), 0]
+    let expected = vec![silu(1.0), 0.0, 4.0 * silu(2.0), 0.0];
+    for (i, (got, exp)) in out.iter().zip(expected.iter()).enumerate() {
+        assert!((got - exp).abs() < 1e-4, "[{i}] expected {exp}, got {got}");
+    }
+}
+
+#[test]
+fn moe_forward_rejects_invalid_expert_id() {
+    let hidden = 2;
+    let ffn = 2;
+    let n_experts = 2;
+
+    let zeros = vec![0.0_f32; n_experts * ffn * hidden];
+    let stack = ExpertStack::<CpuBackend>::from_dense_stacks(
+        &zeros, &zeros, &zeros, n_experts, hidden, ffn,
+    )
+    .unwrap();
+
+    let x = vec![1.0_f32; hidden];
+    let router = RouterOutput {
+        expert_ids: vec![99], // out of range
+        expert_weights: vec![1.0],
+    };
+    let mut out = Vec::new();
+    let result = moe_forward_cpu(&x, 1, hidden, ffn, 1, &router, &stack, &mut out);
+    assert!(result.is_err());
+    let err = result.err().unwrap().to_string();
+    assert!(err.contains("99"), "{err}");
+}
+
+#[test]
+fn moe_forward_rejects_shape_mismatch() {
+    let hidden = 2;
+    let ffn = 2;
+    let n_experts = 2;
+    let zeros = vec![0.0_f32; n_experts * ffn * hidden];
+    let stack = ExpertStack::<CpuBackend>::from_dense_stacks(
+        &zeros, &zeros, &zeros, n_experts, hidden, ffn,
+    )
+    .unwrap();
+
+    let x = vec![1.0_f32; 5]; // wrong size
+    let router = RouterOutput {
+        expert_ids: vec![0],
+        expert_weights: vec![1.0],
+    };
+    let mut out = Vec::new();
+    let r = moe_forward_cpu(&x, 1, hidden, ffn, 1, &router, &stack, &mut out);
+    assert!(r.is_err());
+}
+
+#[test]
+fn router_plus_dispatch_end_to_end_softmax_to_combine() {
+    // The integration the production code will use: hand-built logits
+    // → route(...) → moe_forward_cpu(...). Verifies the two pieces
+    // compose with consistent strides.
+    let hidden = 2;
+    let ffn = 2;
+    let n_experts = 2;
+    let top_k = 1;
+
+    // Identical experts (both identity) so we don't depend on which is picked.
+    let weights = identity_rows(2);
+    let gate = [&weights[..], &weights[..]].concat();
+    let up = gate.clone();
+    let down = gate.clone();
+    let stack =
+        ExpertStack::<CpuBackend>::from_dense_stacks(&gate, &up, &down, n_experts, hidden, ffn)
+            .unwrap();
+
+    // Router logits favour expert 0 strongly.
+    let logits = vec![5.0_f32, 0.0];
+    let router = route(&logits, 1, n_experts, top_k, true);
+    assert_eq!(router.expert_ids, vec![0]);
+
+    let x = vec![1.5_f32, -0.5];
+    let mut out = Vec::new();
+    moe_forward_cpu(&x, 1, hidden, ffn, top_k, &router, &stack, &mut out).unwrap();
+
+    // Both experts identity: silu(x[i])*x[i] elementwise; weight 1.0
+    let expected = vec![silu(1.5) * 1.5, silu(-0.5) * -0.5];
+    for (got, exp) in out.iter().zip(expected.iter()) {
+        assert!(
+            (got - exp).abs() < 1e-4,
+            "end-to-end mismatch: expected {exp}, got {got}"
+        );
+    }
+}
+
+// ── End-to-end via synthesized GGUF ────────────────────────────────────
+
+fn ramp_3d(d0: usize, d1: usize, d2: usize, base: f32) -> QTensor {
+    let device = Device::Cpu;
+    let n = d0 * d1 * d2;
+    let raw: Vec<f32> = (0..n).map(|i| base + (i as f32) * 0.001).collect();
+    let t = Tensor::from_vec(raw, (d0, d1, d2), &device).unwrap();
+    QTensor::quantize(&t, GgmlDType::F32).unwrap()
+}
+
+fn build_minimal_moe_gguf(n_experts: usize, hidden: usize, ffn: usize) -> tempfile::NamedTempFile {
+    let gate_exps = ramp_3d(n_experts, ffn, hidden, 0.1);
+    let up_exps = ramp_3d(n_experts, ffn, hidden, 0.2);
+    let down_exps = ramp_3d(n_experts, hidden, ffn, 0.3);
+
+    let arch_v = Value::String("qwen3moe".to_string());
+    let metadata: Vec<(&str, &Value)> = vec![("general.architecture", &arch_v)];
+    let tensors: Vec<(&str, &QTensor)> = vec![
+        ("blk.0.ffn_gate_exps.weight", &gate_exps),
+        ("blk.0.ffn_up_exps.weight", &up_exps),
+        ("blk.0.ffn_down_exps.weight", &down_exps),
+    ];
+
+    let mut buf: Vec<u8> = Vec::new();
+    {
+        let mut cursor = Cursor::new(&mut buf);
+        gguf_file::write(&mut cursor, &metadata, &tensors).unwrap();
+    }
+    let mut tmp = tempfile::NamedTempFile::new().unwrap();
+    tmp.write_all(&buf).unwrap();
+    tmp.flush().unwrap();
+    tmp
+}
+
+#[test]
+fn expert_stack_loads_from_synthesized_gguf() {
+    let n_experts = 3;
+    let hidden = 4;
+    let ffn = 6;
+    let tmp = build_minimal_moe_gguf(n_experts, hidden, ffn);
+
+    let stack: ExpertStack<CpuBackend> =
+        ExpertStack::open_and_load(tmp.path(), 0, n_experts, hidden, ffn).unwrap();
+
+    assert_eq!(stack.num_experts(), n_experts);
+    for e in 0..n_experts {
+        assert_eq!(stack.gate_up[e].in_features(), hidden);
+        assert_eq!(stack.gate_up[e].out_features(), 2 * ffn);
+        assert_eq!(stack.down[e].in_features(), ffn);
+        assert_eq!(stack.down[e].out_features(), hidden);
+    }
+}
+
+#[test]
+fn full_pipeline_synthesized_gguf_router_dispatch() {
+    // The reason the GGUF series matters: load real-shaped MoE weights
+    // and run forward end-to-end. Numerical correctness is harder to
+    // assert with ramp tensors (would need to reproduce silu+gemm in
+    // the test) so we just check shape + finiteness.
+    let n_experts = 4;
+    let hidden = 4;
+    let ffn = 8;
+    let top_k = 2;
+
+    let tmp = build_minimal_moe_gguf(n_experts, hidden, ffn);
+    let stack: ExpertStack<CpuBackend> =
+        ExpertStack::open_and_load(tmp.path(), 0, n_experts, hidden, ffn).unwrap();
+
+    // Random-ish logits; route with norm.
+    let logits = vec![0.1_f32, 1.5, -0.3, 0.8];
+    let router = route(&logits, 1, n_experts, top_k, true);
+
+    let x = vec![0.5_f32, -0.25, 0.1, 0.0];
+    let mut out = Vec::new();
+    moe_forward_cpu(&x, 1, hidden, ffn, top_k, &router, &stack, &mut out).unwrap();
+
+    assert_eq!(out.len(), hidden);
+    for (i, &v) in out.iter().enumerate() {
+        assert!(v.is_finite(), "out[{i}] = {v} is not finite");
+    }
+}

--- a/crates/ferrum-models/tests/moe_layer_test.rs
+++ b/crates/ferrum-models/tests/moe_layer_test.rs
@@ -1,0 +1,303 @@
+//! `Qwen3MoeLayer::load_from_gguf` + `forward_cpu` end-to-end:
+//! synthesise a complete one-layer Qwen3-MoE GGUF (router + three
+//! stacked-expert tensors + arch metadata) and verify a single forward
+//! pass produces finite output of the right shape.
+
+use std::io::{Cursor, Write};
+
+use candle_core::quantized::gguf_file::{self, Value};
+use candle_core::quantized::{GgmlDType, QTensor};
+use candle_core::{Device, Tensor};
+use ferrum_kernels::backend::cpu::CpuBackend;
+use ferrum_models::moe::Qwen3MoeLayer;
+use ferrum_models::moe_config::Qwen3MoeConfig;
+use ferrum_quantization::gguf::GgufFile;
+
+fn ramp_3d(d0: usize, d1: usize, d2: usize, base: f32) -> QTensor {
+    let device = Device::Cpu;
+    let n = d0 * d1 * d2;
+    let raw: Vec<f32> = (0..n).map(|i| base + (i as f32) * 0.001).collect();
+    let t = Tensor::from_vec(raw, (d0, d1, d2), &device).unwrap();
+    QTensor::quantize(&t, GgmlDType::F32).unwrap()
+}
+
+fn ramp_2d(rows: usize, cols: usize, base: f32) -> QTensor {
+    let device = Device::Cpu;
+    let n = rows * cols;
+    let raw: Vec<f32> = (0..n).map(|i| base + (i as f32) * 0.001).collect();
+    let t = Tensor::from_vec(raw, (rows, cols), &device).unwrap();
+    QTensor::quantize(&t, GgmlDType::F32).unwrap()
+}
+
+/// Build a single-layer Qwen3-MoE GGUF with the four MoE-specific tensors
+/// (router + gate_exps + up_exps + down_exps). Returns the tempfile.
+fn build_one_layer_moe_gguf(
+    n_experts: usize,
+    hidden: usize,
+    ffn: usize,
+) -> tempfile::NamedTempFile {
+    // Router weights (`[num_experts, hidden]`).
+    let router = ramp_2d(n_experts, hidden, 0.05);
+    // Stacked experts.
+    let gate_exps = ramp_3d(n_experts, ffn, hidden, 0.1);
+    let up_exps = ramp_3d(n_experts, ffn, hidden, 0.2);
+    let down_exps = ramp_3d(n_experts, hidden, ffn, 0.3);
+
+    let arch_v = Value::String("qwen3moe".to_string());
+    let metadata: Vec<(&str, &Value)> = vec![("general.architecture", &arch_v)];
+    let tensors: Vec<(&str, &QTensor)> = vec![
+        ("blk.0.ffn_gate_inp.weight", &router),
+        ("blk.0.ffn_gate_exps.weight", &gate_exps),
+        ("blk.0.ffn_up_exps.weight", &up_exps),
+        ("blk.0.ffn_down_exps.weight", &down_exps),
+    ];
+
+    let mut buf: Vec<u8> = Vec::new();
+    {
+        let mut cursor = Cursor::new(&mut buf);
+        gguf_file::write(&mut cursor, &metadata, &tensors).unwrap();
+    }
+    let mut tmp = tempfile::NamedTempFile::new().unwrap();
+    tmp.write_all(&buf).unwrap();
+    tmp.flush().unwrap();
+    tmp
+}
+
+/// Toy MoE config matching the GGUF shapes above.
+fn toy_config(n_experts: usize, hidden: usize, ffn: usize, top_k: usize) -> Qwen3MoeConfig {
+    use ferrum_models::models::llama_family::LlamaFamilyConfig;
+    let base = LlamaFamilyConfig {
+        hidden_size: hidden,
+        intermediate_size: ffn, // mirrored from per-expert
+        num_heads: 1,
+        num_kv_heads: 1,
+        head_dim: hidden,
+        num_layers: 1,
+        vocab_size: 8,
+        max_seq_len: 32,
+        rms_norm_eps: 1.0e-6,
+        rope_theta: 1.0e6,
+        has_qk_norm: true,
+        sliding_window: 0,
+    };
+    Qwen3MoeConfig::from_base(base, n_experts, top_k, ffn, true)
+}
+
+#[test]
+fn loads_layer_from_synthesized_moe_gguf() {
+    let n_experts = 4;
+    let hidden = 4;
+    let ffn = 8;
+    let cfg = toy_config(n_experts, hidden, ffn, 2);
+    let tmp = build_one_layer_moe_gguf(n_experts, hidden, ffn);
+    let gguf = GgufFile::open(tmp.path()).unwrap();
+
+    let layer = Qwen3MoeLayer::<CpuBackend>::load_from_gguf(&gguf, 0, &cfg).unwrap();
+
+    // Router shape sanity
+    assert_eq!(layer.router.in_features(), hidden);
+    assert_eq!(layer.router.out_features(), n_experts);
+    // Expert stack
+    assert_eq!(layer.num_experts, n_experts);
+    assert_eq!(layer.experts.num_experts(), n_experts);
+    // Routing config carried through
+    assert_eq!(layer.top_k, 2);
+    assert!(layer.norm_topk_prob);
+}
+
+#[test]
+fn forward_cpu_produces_finite_output_of_correct_shape() {
+    let n_experts = 4;
+    let hidden = 4;
+    let ffn = 6;
+    let top_k = 2;
+    let cfg = toy_config(n_experts, hidden, ffn, top_k);
+    let tmp = build_one_layer_moe_gguf(n_experts, hidden, ffn);
+    let gguf = GgufFile::open(tmp.path()).unwrap();
+    let layer = Qwen3MoeLayer::<CpuBackend>::load_from_gguf(&gguf, 0, &cfg).unwrap();
+
+    // Two tokens, deliberate non-trivial inputs.
+    let x: Vec<f32> = vec![0.5, -0.25, 0.1, 0.0, 0.7, 0.3, -0.4, 0.2];
+    let mut out = Vec::new();
+    layer.forward_cpu(&x, 2, &mut out).unwrap();
+
+    assert_eq!(out.len(), 2 * hidden);
+    for (i, &v) in out.iter().enumerate() {
+        assert!(v.is_finite(), "out[{i}] = {v} is not finite");
+    }
+}
+
+#[test]
+fn forward_cpu_rejects_wrong_input_size() {
+    let n_experts = 4;
+    let hidden = 4;
+    let ffn = 6;
+    let cfg = toy_config(n_experts, hidden, ffn, 2);
+    let tmp = build_one_layer_moe_gguf(n_experts, hidden, ffn);
+    let gguf = GgufFile::open(tmp.path()).unwrap();
+    let layer = Qwen3MoeLayer::<CpuBackend>::load_from_gguf(&gguf, 0, &cfg).unwrap();
+
+    let x = vec![0.0_f32; 7]; // wrong size
+    let mut out = Vec::new();
+    let result = layer.forward_cpu(&x, 2, &mut out);
+    assert!(result.is_err());
+}
+
+#[test]
+fn missing_router_tensor_returns_clear_error() {
+    // Synthesize a GGUF that has only the expert tensors but no router.
+    let n_experts = 4;
+    let hidden = 4;
+    let ffn = 6;
+    let gate_exps = ramp_3d(n_experts, ffn, hidden, 0.1);
+    let up_exps = ramp_3d(n_experts, ffn, hidden, 0.2);
+    let down_exps = ramp_3d(n_experts, hidden, ffn, 0.3);
+
+    let arch_v = Value::String("qwen3moe".to_string());
+    let metadata: Vec<(&str, &Value)> = vec![("general.architecture", &arch_v)];
+    let tensors: Vec<(&str, &QTensor)> = vec![
+        ("blk.0.ffn_gate_exps.weight", &gate_exps),
+        ("blk.0.ffn_up_exps.weight", &up_exps),
+        ("blk.0.ffn_down_exps.weight", &down_exps),
+    ];
+
+    let mut buf: Vec<u8> = Vec::new();
+    {
+        let mut cursor = Cursor::new(&mut buf);
+        gguf_file::write(&mut cursor, &metadata, &tensors).unwrap();
+    }
+    let mut tmp = tempfile::NamedTempFile::new().unwrap();
+    tmp.write_all(&buf).unwrap();
+    tmp.flush().unwrap();
+
+    let gguf = GgufFile::open(tmp.path()).unwrap();
+    let cfg = toy_config(n_experts, hidden, ffn, 2);
+    let result = Qwen3MoeLayer::<CpuBackend>::load_from_gguf(&gguf, 0, &cfg);
+    assert!(result.is_err());
+    let err = result.err().unwrap().to_string();
+    assert!(
+        err.contains("router") && err.contains("ffn_gate_inp"),
+        "error mentions router tensor: {err}"
+    );
+}
+
+#[test]
+fn config_dimension_mismatch_is_caught() {
+    // Build a GGUF with hidden=4, but pass a config that thinks hidden=8.
+    let n_experts = 2;
+    let gguf_hidden = 4;
+    let cfg_hidden = 8; // wrong on purpose
+    let ffn = 4;
+
+    let tmp = build_one_layer_moe_gguf(n_experts, gguf_hidden, ffn);
+    let gguf = GgufFile::open(tmp.path()).unwrap();
+
+    // Router in the GGUF has shape [num_experts=2, hidden=4]. Config
+    // says hidden=8. Construction should fail at the in_features check.
+    let cfg = toy_config(n_experts, cfg_hidden, ffn, 1);
+    let result = Qwen3MoeLayer::<CpuBackend>::load_from_gguf(&gguf, 0, &cfg);
+    assert!(result.is_err());
+    let err = result.err().unwrap().to_string();
+    // Could fire from either the ExpertStack size check or the router
+    // in_features check — both are valid evidence of "config doesn't
+    // match GGUF shapes".
+    assert!(
+        err.contains("mismatch") || err.contains("in_features"),
+        "expected dimension mismatch error, got: {err}"
+    );
+}
+
+#[test]
+fn top_k_one_with_strong_router_picks_dominant_expert() {
+    // Make the router strongly favour a particular expert, top_k=1, and
+    // verify forward output equals that expert's standalone MLP output.
+    let n_experts = 2;
+    let hidden = 2;
+    let ffn = 2;
+
+    // Router: [num_experts, hidden]. To force expert 1 to win for input
+    // x=[1, 0], make row 0 produce -10 and row 1 produce +10 logit.
+    // Row 0 = [logit_of_expert_0_for_basis_0, ...]. Skip — easier to
+    // hand-craft after we know how routing computes:
+    //   logits = router_weight @ x  (shape [num_experts])
+    // For x=[1,0]: logits = [router[0,0], router[1,0]]
+    // Want logits = [-10, +10]: router_weight = [[-10, 0], [10, 0]]
+    let router_q = QTensor::quantize(
+        &Tensor::from_vec(
+            vec![-10.0_f32, 0.0, 10.0, 0.0],
+            (n_experts, hidden),
+            &Device::Cpu,
+        )
+        .unwrap(),
+        GgmlDType::F32,
+    )
+    .unwrap();
+
+    // Expert 0: identity * 0 (zero output). Expert 1: identity * 7 (out = 7*silu(x)*x).
+    // Use ramp_2d_const for the gate/up/down stacks but this is a 3-D
+    // stacked tensor — easier path: hand-build flat data and pack as 3-D.
+    let device = Device::Cpu;
+    // gate_exps shape [E=2, ffn=2, hidden=2]
+    // Expert 0 gate: zeros. Expert 1 gate: 7 * I_2.
+    let mut gate_data = vec![0.0_f32; n_experts * ffn * hidden];
+    // Expert 1 gate (offset = 1 * ffn * hidden = 4): identity*7
+    gate_data[4 + 0 * 2 + 0] = 7.0; // [1, 0, 0]
+    gate_data[4 + 1 * 2 + 1] = 7.0; // [1, 1, 1]
+    let gate_t = Tensor::from_vec(gate_data, (n_experts, ffn, hidden), &device).unwrap();
+    let gate_qt = QTensor::quantize(&gate_t, GgmlDType::F32).unwrap();
+
+    // Same for up_exps
+    let mut up_data = vec![0.0_f32; n_experts * ffn * hidden];
+    up_data[4 + 0 * 2 + 0] = 7.0;
+    up_data[4 + 1 * 2 + 1] = 7.0;
+    let up_t = Tensor::from_vec(up_data, (n_experts, ffn, hidden), &device).unwrap();
+    let up_qt = QTensor::quantize(&up_t, GgmlDType::F32).unwrap();
+
+    // down_exps shape [E=2, hidden=2, ffn=2]
+    let mut down_data = vec![0.0_f32; n_experts * hidden * ffn];
+    down_data[4 + 0 * 2 + 0] = 1.0; // expert 1 down identity
+    down_data[4 + 1 * 2 + 1] = 1.0;
+    let down_t = Tensor::from_vec(down_data, (n_experts, hidden, ffn), &device).unwrap();
+    let down_qt = QTensor::quantize(&down_t, GgmlDType::F32).unwrap();
+
+    // Build GGUF
+    let arch_v = Value::String("qwen3moe".to_string());
+    let metadata: Vec<(&str, &Value)> = vec![("general.architecture", &arch_v)];
+    let tensors: Vec<(&str, &QTensor)> = vec![
+        ("blk.0.ffn_gate_inp.weight", &router_q),
+        ("blk.0.ffn_gate_exps.weight", &gate_qt),
+        ("blk.0.ffn_up_exps.weight", &up_qt),
+        ("blk.0.ffn_down_exps.weight", &down_qt),
+    ];
+    let mut buf: Vec<u8> = Vec::new();
+    {
+        let mut cursor = Cursor::new(&mut buf);
+        gguf_file::write(&mut cursor, &metadata, &tensors).unwrap();
+    }
+    let mut tmp = tempfile::NamedTempFile::new().unwrap();
+    tmp.write_all(&buf).unwrap();
+    tmp.flush().unwrap();
+
+    let gguf = GgufFile::open(tmp.path()).unwrap();
+    let cfg = toy_config(n_experts, hidden, ffn, 1); // top_k = 1
+    let layer = Qwen3MoeLayer::<CpuBackend>::load_from_gguf(&gguf, 0, &cfg).unwrap();
+
+    let x = vec![1.0_f32, 0.0];
+    let mut out = Vec::new();
+    layer.forward_cpu(&x, 1, &mut out).unwrap();
+
+    // Router with x=[1,0] → logits = [-10, +10], softmax → ~[0, 1]
+    // top_k=1 → expert 1 picked with weight 1.0
+    // Expert 1: gate=[7*1, 7*0]=[7, 0], up=[7, 0]
+    // silu(7)*7 ≈ 6.9936 * 7 = 48.95 (silu(7) = 7 * sigmoid(7) ≈ 7 * 0.99909)
+    // silu*up = [48.95, 0]
+    // down identity → [48.95, 0]
+    let silu_7 = 7.0_f32 * (1.0 / (1.0 + (-7.0_f32).exp()));
+    let expected_0 = silu_7 * 7.0;
+    assert!(
+        (out[0] - expected_0).abs() < 0.01,
+        "out[0]: expected {expected_0}, got {}",
+        out[0]
+    );
+    assert!(out[1].abs() < 1e-3, "out[1] should be ~0, got {}", out[1]);
+}

--- a/crates/ferrum-models/tests/moe_router_test.rs
+++ b/crates/ferrum-models/tests/moe_router_test.rs
@@ -1,0 +1,131 @@
+//! Router unit tests — softmax + top-K selection + optional re-norm.
+
+use ferrum_models::moe::{route, RouterOutput};
+
+#[test]
+fn top_k_one_picks_argmax() {
+    // 4-expert logits, expert 2 dominates by a wide margin.
+    let logits = vec![0.0_f32, 0.5, 5.0, 0.1];
+    let out = route(&logits, 1, 4, 1, true);
+    assert_eq!(out.expert_ids, vec![2]);
+    // Single-expert top-1 with norm → weight is 1.0 regardless of softmax.
+    assert!((out.expert_weights[0] - 1.0).abs() < 1e-6);
+}
+
+#[test]
+fn top_k_two_orders_by_weight_descending() {
+    let logits = vec![0.0_f32, 5.0, 1.0, 0.0];
+    let out = route(&logits, 1, 4, 2, false);
+    // Selected: index 1 (largest, ~5.0) then index 2 (second largest, 1.0).
+    assert_eq!(out.expert_ids, vec![1, 2]);
+    // Without renorm, weights are softmax probs of those two.
+    let p1 = (5.0_f32).exp() / (0.0_f32.exp() + 5.0_f32.exp() + 1.0_f32.exp() + 0.0_f32.exp());
+    let p2 = (1.0_f32).exp() / (0.0_f32.exp() + 5.0_f32.exp() + 1.0_f32.exp() + 0.0_f32.exp());
+    assert!(
+        (out.expert_weights[0] - p1).abs() < 1e-5,
+        "expected {p1}, got {}",
+        out.expert_weights[0]
+    );
+    assert!(
+        (out.expert_weights[1] - p2).abs() < 1e-5,
+        "expected {p2}, got {}",
+        out.expert_weights[1]
+    );
+}
+
+#[test]
+fn norm_topk_prob_sums_selected_to_one() {
+    let logits = vec![0.0_f32, 5.0, 1.0, 0.0];
+    let out = route(&logits, 1, 4, 2, true);
+    let total: f32 = out.expert_weights.iter().sum();
+    assert!(
+        (total - 1.0).abs() < 1e-5,
+        "norm-topk weights must sum to 1, got {total}"
+    );
+}
+
+#[test]
+fn raw_softmax_sums_lt_one_when_some_mass_dropped() {
+    let logits = vec![0.0_f32, 0.0, 0.0, 0.0]; // uniform — each prob = 0.25
+    let out = route(&logits, 1, 4, 2, false);
+    let total: f32 = out.expert_weights.iter().sum();
+    // Two of four uniform 0.25s = 0.5
+    assert!((total - 0.5).abs() < 1e-5, "got {total}");
+}
+
+#[test]
+fn batch_dim_routes_each_row_independently() {
+    // Two tokens. Token 0 prefers expert 1; token 1 prefers expert 3.
+    let logits = vec![
+        0.0_f32, 5.0, 0.0, 0.0, // token 0
+        0.0, 0.0, 0.0, 5.0, // token 1
+    ];
+    let out = route(&logits, 2, 4, 1, true);
+    assert_eq!(out.expert_ids, vec![1, 3]);
+    for &w in &out.expert_weights {
+        assert!((w - 1.0).abs() < 1e-6);
+    }
+}
+
+#[test]
+fn top_k_equal_to_num_experts_returns_all_with_renorm_to_one() {
+    // top_k = num_experts means router degenerates: every expert is
+    // selected with the full softmax probability, and renorm keeps the
+    // sum at 1 (which it already was).
+    let logits = vec![1.0_f32, 2.0, 3.0, 4.0];
+    let out = route(&logits, 1, 4, 4, true);
+    assert_eq!(out.expert_ids.len(), 4);
+    // After renorm, the four weights still sum to 1.0.
+    let total: f32 = out.expert_weights.iter().sum();
+    assert!((total - 1.0).abs() < 1e-5);
+    // Highest-logit expert (index 3) should have the largest weight.
+    let max_pos = out
+        .expert_weights
+        .iter()
+        .cloned()
+        .enumerate()
+        .max_by(|a, b| a.1.partial_cmp(&b.1).unwrap())
+        .unwrap()
+        .0;
+    assert_eq!(out.expert_ids[max_pos], 3);
+}
+
+#[test]
+fn ties_break_by_smaller_index_first() {
+    // All logits equal → softmax uniform. Top-2 must pick indices 0, 1
+    // (tie-break: smaller index first) regardless of FP order.
+    let logits = vec![1.0_f32; 8];
+    let out = route(&logits, 1, 8, 2, true);
+    assert_eq!(out.expert_ids, vec![0, 1]);
+}
+
+#[test]
+#[should_panic(expected = "top_k must be > 0")]
+fn top_k_zero_panics() {
+    let _ = route(&[1.0_f32; 4], 1, 4, 0, true);
+}
+
+#[test]
+#[should_panic(expected = "exceeds num_experts")]
+fn top_k_greater_than_num_experts_panics() {
+    let _ = route(&[1.0_f32; 4], 1, 4, 5, true);
+}
+
+#[test]
+#[should_panic(expected = "shape mismatch")]
+fn wrong_logits_size_panics() {
+    let _ = route(&[1.0_f32; 7], 1, 4, 2, true);
+}
+
+#[test]
+fn router_output_can_be_partially_consumed() {
+    // Spot-check: indexing matches the documented stride convention.
+    let logits = vec![0.0_f32, 5.0, 0.0, 0.0, 0.0, 0.0, 0.0, 5.0];
+    let out: RouterOutput = route(&logits, 2, 4, 2, true);
+    // batch=2, top_k=2 → 4 entries
+    assert_eq!(out.expert_ids.len(), 4);
+    assert_eq!(out.expert_weights.len(), 4);
+    // Token 0's selections occupy [0..2]; token 1's occupy [2..4].
+    assert_eq!(out.expert_ids[0], 1); // token 0, k=0
+    assert_eq!(out.expert_ids[2], 3); // token 1, k=0
+}

--- a/crates/ferrum-quantization/src/gguf/names.rs
+++ b/crates/ferrum-quantization/src/gguf/names.rs
@@ -6,9 +6,25 @@
 //! truth for that mapping; both `GgufLoader` and any future tooling go
 //! through `ferrum_to_gguf`.
 //!
-//! Scope (Phase 1C): dense Llama-family models — Qwen3, Qwen2.x, Llama-3.x,
-//! Mistral, TinyLlama. MoE-specific names (`ffn_gate_inp`, `ffn_*_exps`)
-//! land in Phase 2 alongside the MoE runtime.
+//! Scope: dense Llama-family models (Qwen3, Qwen2.x, Llama-3.x, Mistral,
+//! TinyLlama) and Qwen-style MoE families (Qwen3-MoE, Mixtral, DeepSeek-V2 —
+//! they all use the same GGUF layout: per-layer router `ffn_gate_inp` plus
+//! three stacked-expert tensors `ffn_{gate,up,down}_exps` with shape
+//! `[num_experts, ...]`).
+//!
+//! ## ferrum-side naming convention for MoE tensors
+//!
+//! ferrum mirrors GGUF's stacked layout rather than HuggingFace's
+//! `experts.{e}.gate_proj` per-expert layout. Reasons:
+//!   1. The stacked form is what candle's `QMatMul::indexed_moe_forward`
+//!      expects — slicing per-expert is a runtime concern, not a
+//!      storage concern.
+//!   2. Loading per-expert from GGUF would require N reads + concat per
+//!      layer (the dense path's qkv-fusion shim works the other direction
+//!      and only does 3, not N=128).
+//!   3. If a future safetensors-MoE loader needs to consume per-expert
+//!      tensors, it can do its own concat just like the dense Qwen2.5
+//!      path concatenates q/k/v.
 
 /// Translate a ferrum tensor name to its GGUF equivalent.
 ///
@@ -67,10 +83,21 @@ fn map_layer_scoped(rest: &str) -> Option<String> {
         // Qwen3 QK-norm — only present on that family
         "self_attn.q_norm" => "attn_q_norm",
         "self_attn.k_norm" => "attn_k_norm",
-        // MLP projections
+        // Dense MLP projections
         "mlp.gate_proj" => "ffn_gate",
         "mlp.up_proj" => "ffn_up",
         "mlp.down_proj" => "ffn_down",
+        // MoE: router (gating) + stacked expert weights. Shape conventions:
+        //   router:    [hidden_size, num_experts]
+        //   gate_exps: [num_experts, expert_intermediate, hidden_size]
+        //   up_exps:   [num_experts, expert_intermediate, hidden_size]
+        //   down_exps: [num_experts, hidden_size, expert_intermediate]
+        // Loaded as flat fp32 buffers; the MoE runtime slices per-expert
+        // at forward time.
+        "mlp.router" => "ffn_gate_inp",
+        "mlp.gate_exps" => "ffn_gate_exps",
+        "mlp.up_exps" => "ffn_up_exps",
+        "mlp.down_exps" => "ffn_down_exps",
         _ => return None,
     };
 
@@ -195,11 +222,44 @@ mod tests {
     }
 
     #[test]
+    fn maps_moe_router_and_stacked_experts() {
+        // Router (2-D, [hidden, num_experts])
+        assert_eq!(
+            ferrum_to_gguf("model.layers.0.mlp.router.weight"),
+            Some("blk.0.ffn_gate_inp.weight".into())
+        );
+        // Stacked expert weights (3-D, [num_experts, ...])
+        assert_eq!(
+            ferrum_to_gguf("model.layers.0.mlp.gate_exps.weight"),
+            Some("blk.0.ffn_gate_exps.weight".into())
+        );
+        assert_eq!(
+            ferrum_to_gguf("model.layers.27.mlp.up_exps.weight"),
+            Some("blk.27.ffn_up_exps.weight".into())
+        );
+        assert_eq!(
+            ferrum_to_gguf("model.layers.0.mlp.down_exps.weight"),
+            Some("blk.0.ffn_down_exps.weight".into())
+        );
+        // Bare stems (load_linear-style for 2-D router)
+        assert_eq!(
+            ferrum_to_gguf("model.layers.0.mlp.router"),
+            Some("blk.0.ffn_gate_inp".into())
+        );
+    }
+
+    #[test]
     fn rejects_unknown_names() {
         assert_eq!(ferrum_to_gguf("totally_made_up"), None);
         assert_eq!(ferrum_to_gguf("model.layers.0.unknown_part.weight"), None);
         assert_eq!(
             ferrum_to_gguf("model.layers.bad_idx.input_layernorm.weight"),
+            None
+        );
+        // HF-style per-expert names are NOT supported (deliberately —
+        // the loader expects stacked names).
+        assert_eq!(
+            ferrum_to_gguf("model.layers.0.mlp.experts.0.gate_proj.weight"),
             None
         );
     }

--- a/crates/ferrum-quantization/tests/gguf_loader_moe_test.rs
+++ b/crates/ferrum-quantization/tests/gguf_loader_moe_test.rs
@@ -1,0 +1,216 @@
+//! Phase 2B integration tests: synthesize a Qwen-MoE-shaped GGUF (one
+//! decoder layer with router + 3 stacked-expert tensors) and verify
+//! `GgufLoader<B>` translates the new ferrum-side names correctly,
+//! reads the tensors at full size, and rejects loading 3-D stacked
+//! expert tensors as `Linear<B>` (which require rank-2).
+//!
+//! The runtime path that actually USES these tensors lands in Phase 2C/2D.
+//! This PR just proves the loader can materialise them.
+
+use std::io::{Cursor, Write};
+use std::sync::Arc;
+
+use candle_core::quantized::gguf_file::{self, Value};
+use candle_core::quantized::{GgmlDType, QTensor};
+use candle_core::{Device, Tensor};
+use ferrum_kernels::backend::cpu::CpuBackend;
+use ferrum_quantization::gguf::{GgufFile, GgufLoader};
+use ferrum_quantization::WeightLoader;
+
+// Toy MoE dimensions: 4 experts, hidden 4, expert FFN 8.
+// Router: [E=4, hidden=4] = 16 elements
+// gate_exps / up_exps: [E=4, ffn=8, hidden=4] = 128 elements
+// down_exps: [E=4, hidden=4, ffn=8] = 128 elements
+const HIDDEN: usize = 4;
+const NUM_EXPERTS: usize = 4;
+const EXPERT_FFN: usize = 8;
+const VOCAB: usize = 8;
+
+fn ramp_2d(rows: usize, cols: usize, base: f32) -> QTensor {
+    let device = Device::Cpu;
+    let n = rows * cols;
+    let raw: Vec<f32> = (0..n).map(|i| base + (i as f32) * 0.001).collect();
+    let t = Tensor::from_vec(raw, (rows, cols), &device).unwrap();
+    QTensor::quantize(&t, GgmlDType::F32).unwrap()
+}
+
+fn ramp_3d(d0: usize, d1: usize, d2: usize, base: f32) -> QTensor {
+    let device = Device::Cpu;
+    let n = d0 * d1 * d2;
+    let raw: Vec<f32> = (0..n).map(|i| base + (i as f32) * 0.001).collect();
+    let t = Tensor::from_vec(raw, (d0, d1, d2), &device).unwrap();
+    QTensor::quantize(&t, GgmlDType::F32).unwrap()
+}
+
+fn ramp_1d(n: usize, base: f32) -> QTensor {
+    let device = Device::Cpu;
+    let raw: Vec<f32> = (0..n).map(|i| base + (i as f32) * 0.01).collect();
+    let t = Tensor::from_vec(raw, n, &device).unwrap();
+    QTensor::quantize(&t, GgmlDType::F32).unwrap()
+}
+
+/// Build a minimal Qwen3-MoE-shaped GGUF: top-level (embed/output),
+/// one layer's attention (dense, same as dense GGUFs), and the four
+/// MoE-specific tensors.
+fn build_moe_gguf() -> tempfile::NamedTempFile {
+    let token_embd = ramp_2d(VOCAB, HIDDEN, 0.0);
+    let output_norm = ramp_1d(HIDDEN, 0.5);
+    let output = ramp_2d(VOCAB, HIDDEN, 1.0);
+
+    let attn_norm = ramp_1d(HIDDEN, 0.6);
+    let attn_q = ramp_2d(HIDDEN, HIDDEN, 2.0);
+    let attn_k = ramp_2d(HIDDEN, HIDDEN, 3.0);
+    let attn_v = ramp_2d(HIDDEN, HIDDEN, 4.0);
+    let attn_output = ramp_2d(HIDDEN, HIDDEN, 5.0);
+    let ffn_norm = ramp_1d(HIDDEN, 0.7);
+
+    // The four MoE-specific tensors
+    let router = ramp_2d(NUM_EXPERTS, HIDDEN, 8.0); // [E, hidden]
+    let gate_exps = ramp_3d(NUM_EXPERTS, EXPERT_FFN, HIDDEN, 9.0); // [E, ffn, hidden]
+    let up_exps = ramp_3d(NUM_EXPERTS, EXPERT_FFN, HIDDEN, 10.0); // [E, ffn, hidden]
+    let down_exps = ramp_3d(NUM_EXPERTS, HIDDEN, EXPERT_FFN, 11.0); // [E, hidden, ffn]
+
+    let arch_v = Value::String("qwen3moe".to_string());
+    let metadata: Vec<(&str, &Value)> = vec![("general.architecture", &arch_v)];
+    let tensors: Vec<(&str, &QTensor)> = vec![
+        ("token_embd.weight", &token_embd),
+        ("output_norm.weight", &output_norm),
+        ("output.weight", &output),
+        ("blk.0.attn_norm.weight", &attn_norm),
+        ("blk.0.attn_q.weight", &attn_q),
+        ("blk.0.attn_k.weight", &attn_k),
+        ("blk.0.attn_v.weight", &attn_v),
+        ("blk.0.attn_output.weight", &attn_output),
+        ("blk.0.ffn_norm.weight", &ffn_norm),
+        ("blk.0.ffn_gate_inp.weight", &router),
+        ("blk.0.ffn_gate_exps.weight", &gate_exps),
+        ("blk.0.ffn_up_exps.weight", &up_exps),
+        ("blk.0.ffn_down_exps.weight", &down_exps),
+    ];
+
+    let mut buf: Vec<u8> = Vec::new();
+    {
+        let mut cursor = Cursor::new(&mut buf);
+        gguf_file::write(&mut cursor, &metadata, &tensors).unwrap();
+    }
+    let mut tmp = tempfile::NamedTempFile::new().unwrap();
+    tmp.write_all(&buf).unwrap();
+    tmp.flush().unwrap();
+    tmp
+}
+
+fn build_loader(tmp: &tempfile::NamedTempFile) -> GgufLoader<CpuBackend> {
+    let gguf = GgufFile::open(tmp.path()).unwrap();
+    GgufLoader::<CpuBackend>::from_file(Arc::new(gguf))
+}
+
+#[test]
+fn moe_tensors_are_discoverable_by_ferrum_names() {
+    let tmp = build_moe_gguf();
+    let loader = build_loader(&tmp);
+
+    assert!(loader.has_tensor("model.layers.0.mlp.router.weight"));
+    assert!(loader.has_tensor("model.layers.0.mlp.gate_exps.weight"));
+    assert!(loader.has_tensor("model.layers.0.mlp.up_exps.weight"));
+    assert!(loader.has_tensor("model.layers.0.mlp.down_exps.weight"));
+
+    // HF-style per-expert names should NOT resolve (we deliberately
+    // didn't map them — see names.rs design notes).
+    assert!(!loader.has_tensor("model.layers.0.mlp.experts.0.gate_proj.weight"));
+}
+
+#[test]
+fn router_load_tensor_returns_full_buffer() {
+    let tmp = build_moe_gguf();
+    let loader = build_loader(&tmp);
+
+    let router = loader
+        .load_tensor("model.layers.0.mlp.router.weight")
+        .unwrap();
+    // [num_experts=4, hidden=4] = 16 elements
+    assert_eq!(router.len(), NUM_EXPERTS * HIDDEN);
+
+    // Spot-check the ramp: base 8.0 step 0.001, first elem = 8.0
+    assert!((router[0] - 8.0).abs() < 1e-6);
+    let last_idx = NUM_EXPERTS * HIDDEN - 1;
+    let expected_last = 8.0 + (last_idx as f32) * 0.001;
+    assert!(
+        (router[last_idx] - expected_last).abs() < 1e-5,
+        "last router element: got {}, expected {expected_last}",
+        router[last_idx]
+    );
+}
+
+#[test]
+fn stacked_expert_tensors_load_at_full_3d_size() {
+    let tmp = build_moe_gguf();
+    let loader = build_loader(&tmp);
+
+    let gate = loader
+        .load_tensor("model.layers.0.mlp.gate_exps.weight")
+        .unwrap();
+    assert_eq!(gate.len(), NUM_EXPERTS * EXPERT_FFN * HIDDEN);
+
+    let up = loader
+        .load_tensor("model.layers.0.mlp.up_exps.weight")
+        .unwrap();
+    assert_eq!(up.len(), NUM_EXPERTS * EXPERT_FFN * HIDDEN);
+
+    let down = loader
+        .load_tensor("model.layers.0.mlp.down_exps.weight")
+        .unwrap();
+    assert_eq!(down.len(), NUM_EXPERTS * HIDDEN * EXPERT_FFN);
+
+    // The runtime in Phase 2C/2D will slice these per-expert; the loader's
+    // job is just to materialise them at full size in row-major order.
+    // Spot-check ramp consistency (gate base=9.0):
+    assert!((gate[0] - 9.0).abs() < 1e-6);
+}
+
+#[test]
+fn router_load_linear_succeeds_as_2d() {
+    // The router is 2-D so it can go through GgufLinear if a caller wants
+    // a `Box<dyn Linear<B>>` (e.g. if the router is reused across layers
+    // some day). This isn't the primary path — most MoE runtimes use
+    // load_tensor for the router and fold its forward into the dispatch
+    // kernel — but supporting it costs nothing and keeps symmetry with
+    // dense projections.
+    let tmp = build_moe_gguf();
+    let loader = build_loader(&tmp);
+
+    let router_linear = loader.load_linear("model.layers.0.mlp.router").unwrap();
+    assert_eq!(router_linear.in_features(), HIDDEN);
+    assert_eq!(router_linear.out_features(), NUM_EXPERTS);
+}
+
+#[test]
+fn stacked_expert_load_linear_rejects_rank_3() {
+    // Stacked expert tensors are 3-D and must NOT be wrapped in
+    // GgufLinear<B> — the rank check catches that and returns Err with
+    // a clear message about the dimensionality.
+    let tmp = build_moe_gguf();
+    let loader = build_loader(&tmp);
+
+    let result = loader.load_linear("model.layers.0.mlp.gate_exps");
+    assert!(result.is_err(), "3-D stacked expert tensor must reject");
+    let err = result.err().unwrap().to_string();
+    assert!(
+        err.contains("2-D"),
+        "error message mentions rank constraint: {err}"
+    );
+}
+
+#[test]
+fn dense_tensors_still_loadable_alongside_moe() {
+    // A regression check: adding MoE mappings shouldn't have broken any
+    // dense names. The fixture has both attention (dense) and MoE
+    // tensors in the same layer; both should resolve.
+    let tmp = build_moe_gguf();
+    let loader = build_loader(&tmp);
+
+    assert!(loader.has_tensor("model.layers.0.self_attn.q_proj.weight"));
+    assert!(loader.has_tensor("model.layers.0.input_layernorm.weight"));
+    assert!(loader.has_tensor("model.layers.0.post_attention_layernorm.weight"));
+    assert!(loader.has_tensor("model.embed_tokens.weight"));
+    assert!(loader.has_tensor("lm_head.weight"));
+}


### PR DESCRIPTION
The full MoE foundation in one PR (combining Phase 2B name mappings + 2C router + 2D dispatch + 2E Qwen3MoeLayer). Larger PR per process feedback — local CPU + Metal validation is sufficient.

## What ships

| Layer | Module | Purpose |
|---|---|---|
| Tensor names | \`gguf::names\` | 4 new ferrum↔GGUF mappings: \`mlp.router\`, \`mlp.{gate,up,down}_exps\` |
| Router | \`moe::router\` | Top-K selection: softmax + sort + optional renorm |
| Expert dispatch | \`moe::dispatch\` | \`ExpertStack<B>\` weight container + \`moe_forward_cpu\` |
| Layer wrapper | \`moe::layer\` | \`Qwen3MoeLayer<B>\` bundles router + experts + config + 1-call \`forward_cpu\` |

A user can now synthesize/open a Qwen3-MoE GGUF, build a \`Qwen3MoeLayer\`, and run a forward pass end-to-end. See \`moe_layer_test.rs::top_k_one_with_strong_router_picks_dominant_expert\` for the full path with hand-computed expected output.

## Tests (27 new, all CPU)

- \`moe_router_test.rs\` (11): top-K correctness, norm/no-norm modes, batch dim independence, deterministic tie-break, panic paths
- \`moe_dispatch_test.rs\` (10): ExpertStack construction, single + multi-expert numerical correctness (\`silu(x)\` hand-computed), batch routing, error paths, end-to-end router+dispatch
- \`moe_layer_test.rs\` (6): Qwen3MoeLayer loads from synthesized GGUF, forward shape, missing router tensor, config mismatch, top-1 strong-router routes correctly

Plus 7 new tests in \`gguf::names\` unit + integration (Phase 2B), all 31 existing GGUF tests still pass.

\`RUSTFLAGS=\"-D warnings\" cargo check --workspace --all-targets [--features metal]\` clean across all targets.

## Files

- \`crates/ferrum-quantization/src/gguf/names.rs\` (4 MoE mappings + tests)
- \`crates/ferrum-quantization/tests/gguf_loader_moe_test.rs\` (Phase 2B integration tests)
- \`crates/ferrum-models/src/moe/{mod,router,dispatch,layer}.rs\` (new module)
- \`crates/ferrum-models/tests/moe_{router,dispatch,layer}_test.rs\` (27 tests)
- \`crates/ferrum-models/src/lib.rs\` (\`pub mod moe\`)

## Trade-offs (not blockers)

- **CPU-only forward**: Backend trait doesn't yet expose scaled-accumulate or cheap buffer slicing. Generic \`moe_forward<B>\` deferred to Phase 2F (probably extends Backend trait + uses candle's \`QMatMul::indexed_moe_forward\` for GPU).
- **Per-expert \`Linear<B>\` storage**: 128 experts × 4-byte fp32 weights doesn't fit Qwen3-30B-A3B on M1 Max (~113 GB). Fine for synthetic tests; real-model loading needs the lazy-quantised path (Phase 2F).
- **Scratch reallocated each forward call**: Reasonable reference, bad for decode hot path. Workspace reuse = Phase 2F.

## What's next (Phase 2F / 3)

- \`Qwen3MoeModel<B>\`: full transformer with attention + MoE layers + KV cache
- Real Qwen3-30B-A3B GGUF smoke test (downloaded, not synthesized)
- Backend extension for generic GPU MoE forward
- Then: M1 Max benchmark vs mistral.rs / llama.cpp on Q4_K_M

🤖 Generated with [Claude Code](https://claude.com/claude-code)