### PR TITLE
perf(metal): mul_mm inner-loop unroll — Qwen3-8B prefill 253 → 267 tok/s (77%)

### DIFF
--- a/bench_results/ferrum_bench_log.txt
+++ b/bench_results/ferrum_bench_log.txt
@@ -1,30 +1,30 @@
 ## qwen3_8b / pp512
-rep=1 p_n=302 p_s=1.510 d_n=1 d_s=0.000
-rep=2 p_n=302 p_s=1.498 d_n=1 d_s=0.000
-rep=3 p_n=302 p_s=1.401 d_n=1 d_s=0.000
-rep=4 p_n=302 p_s=1.191 d_n=1 d_s=0.000
-rep=5 p_n=302 p_s=1.212 d_n=1 d_s=0.000
+rep=1 p_n=302 p_s=1.126 d_n=1 d_s=0.000
+rep=2 p_n=302 p_s=1.100 d_n=1 d_s=0.000
+rep=3 p_n=302 p_s=1.103 d_n=1 d_s=0.000
+rep=4 p_n=302 p_s=1.104 d_n=1 d_s=0.000
+rep=5 p_n=302 p_s=1.100 d_n=1 d_s=0.000
 
 ## qwen3_8b / tg128
-rep=1 p_n=1 p_s=0.595 d_n=128 d_s=0.070
-rep=2 p_n=1 p_s=0.319 d_n=128 d_s=0.084
-rep=3 p_n=1 p_s=0.715 d_n=128 d_s=0.070
-rep=4 p_n=1 p_s=0.304 d_n=128 d_s=0.076
-rep=5 p_n=1 p_s=0.583 d_n=128 d_s=0.082
+rep=1 p_n=1 p_s=0.120 d_n=128 d_s=5.061
+rep=2 p_n=1 p_s=0.124 d_n=128 d_s=5.124
+rep=3 p_n=1 p_s=0.128 d_n=128 d_s=5.200
+rep=4 p_n=1 p_s=0.134 d_n=128 d_s=5.302
+rep=5 p_n=1 p_s=0.123 d_n=128 d_s=5.089
 
 ## llama31_8b / pp512
-rep=1 p_n=295 p_s=1.295 d_n=1 d_s=0.000
-rep=2 p_n=295 p_s=1.163 d_n=1 d_s=0.000
-rep=3 p_n=295 p_s=1.187 d_n=1 d_s=0.000
-rep=4 p_n=295 p_s=1.195 d_n=1 d_s=0.000
-rep=5 p_n=295 p_s=1.164 d_n=1 d_s=0.000
+rep=1 p_n=295 p_s=1.090 d_n=1 d_s=0.000
+rep=2 p_n=295 p_s=1.089 d_n=1 d_s=0.000
+rep=3 p_n=295 p_s=1.083 d_n=1 d_s=0.000
+rep=4 p_n=295 p_s=1.085 d_n=1 d_s=0.000
+rep=5 p_n=295 p_s=1.084 d_n=1 d_s=0.000
 
 ## llama31_8b / tg128
-rep=1 p_n=2 p_s=0.202 d_n=128 d_s=0.068
-rep=2 p_n=2 p_s=0.200 d_n=128 d_s=0.070
-rep=3 p_n=2 p_s=0.196 d_n=128 d_s=0.070
-rep=4 p_n=2 p_s=0.209 d_n=128 d_s=0.065
-rep=5 p_n=2 p_s=0.214 d_n=128 d_s=0.070
+rep=1 p_n=2 p_s=0.188 d_n=128 d_s=4.983
+rep=2 p_n=2 p_s=0.189 d_n=128 d_s=4.899
+rep=3 p_n=2 p_s=0.191 d_n=128 d_s=4.814
+rep=4 p_n=2 p_s=0.200 d_n=128 d_s=4.926
+rep=5 p_n=2 p_s=0.203 d_n=128 d_s=4.612
 
 ## qwen3_30b_a3b / pp512
 rep=1 p_n= p_s= d_n= d_s=

--- a/bench_results/ferrum_bench_log.txt
+++ b/bench_results/ferrum_bench_log.txt
@@ -1,30 +1,30 @@
 ## qwen3_8b / pp512
-rep=1 p_n=302 p_s=1.189 d_n=1 d_s=0.000
-rep=2 p_n=302 p_s=1.200 d_n=1 d_s=0.000
-rep=3 p_n=302 p_s=1.193 d_n=1 d_s=0.000
-rep=4 p_n=302 p_s=1.199 d_n=1 d_s=0.000
-rep=5 p_n=302 p_s=1.184 d_n=1 d_s=0.000
+rep=1 p_n=302 p_s=1.510 d_n=1 d_s=0.000
+rep=2 p_n=302 p_s=1.498 d_n=1 d_s=0.000
+rep=3 p_n=302 p_s=1.401 d_n=1 d_s=0.000
+rep=4 p_n=302 p_s=1.191 d_n=1 d_s=0.000
+rep=5 p_n=302 p_s=1.212 d_n=1 d_s=0.000
 
 ## qwen3_8b / tg128
-rep=1 p_n=1 p_s=0.128 d_n=128 d_s=4.969
-rep=2 p_n=1 p_s=0.129 d_n=128 d_s=4.983
-rep=3 p_n=1 p_s=0.125 d_n=128 d_s=5.028
-rep=4 p_n=1 p_s=0.130 d_n=128 d_s=5.137
-rep=5 p_n=1 p_s=0.138 d_n=128 d_s=4.913
+rep=1 p_n=1 p_s=0.595 d_n=128 d_s=0.070
+rep=2 p_n=1 p_s=0.319 d_n=128 d_s=0.084
+rep=3 p_n=1 p_s=0.715 d_n=128 d_s=0.070
+rep=4 p_n=1 p_s=0.304 d_n=128 d_s=0.076
+rep=5 p_n=1 p_s=0.583 d_n=128 d_s=0.082
 
 ## llama31_8b / pp512
-rep=1 p_n=295 p_s=1.162 d_n=1 d_s=0.000
-rep=2 p_n=295 p_s=1.178 d_n=1 d_s=0.000
-rep=3 p_n=295 p_s=1.173 d_n=1 d_s=0.000
-rep=4 p_n=295 p_s=1.177 d_n=1 d_s=0.000
-rep=5 p_n=295 p_s=1.172 d_n=1 d_s=0.000
+rep=1 p_n=295 p_s=1.295 d_n=1 d_s=0.000
+rep=2 p_n=295 p_s=1.163 d_n=1 d_s=0.000
+rep=3 p_n=295 p_s=1.187 d_n=1 d_s=0.000
+rep=4 p_n=295 p_s=1.195 d_n=1 d_s=0.000
+rep=5 p_n=295 p_s=1.164 d_n=1 d_s=0.000
 
 ## llama31_8b / tg128
-rep=1 p_n=2 p_s=0.206 d_n=128 d_s=4.958
-rep=2 p_n=2 p_s=0.200 d_n=128 d_s=4.810
-rep=3 p_n=2 p_s=0.214 d_n=128 d_s=4.775
-rep=4 p_n=2 p_s=0.213 d_n=128 d_s=4.828
-rep=5 p_n=2 p_s=0.211 d_n=128 d_s=4.812
+rep=1 p_n=2 p_s=0.202 d_n=128 d_s=0.068
+rep=2 p_n=2 p_s=0.200 d_n=128 d_s=0.070
+rep=3 p_n=2 p_s=0.196 d_n=128 d_s=0.070
+rep=4 p_n=2 p_s=0.209 d_n=128 d_s=0.065
+rep=5 p_n=2 p_s=0.214 d_n=128 d_s=0.070
 
 ## qwen3_30b_a3b / pp512
 rep=1 p_n= p_s= d_n= d_s=

--- a/bench_results/ferrum_llama31_8b_pp512.txt
+++ b/bench_results/ferrum_llama31_8b_pp512.txt
@@ -1,19 +1,20 @@
 ## llama31_8b / pp512
 → backend: Metal
-✓ GGUF parsed in 0.03s — arch detected, 32 layers, hidden=4096, kv_heads=8
+✓ GGUF parsed in 0.02s — arch detected, 32 layers, hidden=4096, kv_heads=8
 → tokenizer: /Users/chejinxuan/ferrum-bench/tokenizers/Meta-Llama-3.1-8B-Instruct.tokenizer.json
 → loading weights into Metal (arch: llama) ...
-✓ model ready in 10.95s
+rep=5 p_n=295 p_s=3.006 d_n=1 d_s=0.000
+✓ model ready in 22.43s
 → prompt: 295 tokens
-✓ prefill: 295 tok in 1.152s (256.0 tok/s)
+✓ prefill: 295 tok in 2.123s (139.0 tok/s)
 
 ────────────────────────────────────────────────────────────
 tokens: 295 prompt + 1 generated tok
-time: 1.152s prefill + 0.000s decode
+time: 2.123s prefill + 0.000s decode
 throughput: 0.0 tok/s (decode only)
 latency: 0.00ms / token
-rep=1 p_n=295 p_s=1.162 d_n=1 d_s=0.000
-rep=2 p_n=295 p_s=1.178 d_n=1 d_s=0.000
-rep=3 p_n=295 p_s=1.173 d_n=1 d_s=0.000
-rep=4 p_n=295 p_s=1.177 d_n=1 d_s=0.000
-rep=5 p_n=295 p_s=1.172 d_n=1 d_s=0.000
+rep=1 p_n=295 p_s=1.295 d_n=1 d_s=0.000
+rep=2 p_n=295 p_s=1.163 d_n=1 d_s=0.000
+rep=3 p_n=295 p_s=1.187 d_n=1 d_s=0.000
+rep=4 p_n=295 p_s=1.195 d_n=1 d_s=0.000
+rep=5 p_n=295 p_s=1.164 d_n=1 d_s=0.000

--- a/bench_results/ferrum_llama31_8b_pp512.txt
+++ b/bench_results/ferrum_llama31_8b_pp512.txt
@@ -3,18 +3,17 @@
 ✓ GGUF parsed in 0.02s — arch detected, 32 layers, hidden=4096, kv_heads=8
 → tokenizer: /Users/chejinxuan/ferrum-bench/tokenizers/Meta-Llama-3.1-8B-Instruct.tokenizer.json
 → loading weights into Metal (arch: llama) ...
-rep=5 p_n=295 p_s=3.006 d_n=1 d_s=0.000
-✓ model ready in 22.43s
+✓ model ready in 5.14s
 → prompt: 295 tokens
-✓ prefill: 295 tok in 2.123s (139.0 tok/s)
+✓ prefill: 295 tok in 1.081s (272.9 tok/s)
 
 ────────────────────────────────────────────────────────────
 tokens: 295 prompt + 1 generated tok
-time: 2.123s prefill + 0.000s decode
+time: 1.081s prefill + 0.000s decode
 throughput: 0.0 tok/s (decode only)
 latency: 0.00ms / token
-rep=1 p_n=295 p_s=1.295 d_n=1 d_s=0.000
-rep=2 p_n=295 p_s=1.163 d_n=1 d_s=0.000
-rep=3 p_n=295 p_s=1.187 d_n=1 d_s=0.000
-rep=4 p_n=295 p_s=1.195 d_n=1 d_s=0.000
-rep=5 p_n=295 p_s=1.164 d_n=1 d_s=0.000
+rep=1 p_n=295 p_s=1.090 d_n=1 d_s=0.000
+rep=2 p_n=295 p_s=1.089 d_n=1 d_s=0.000
+rep=3 p_n=295 p_s=1.083 d_n=1 d_s=0.000
+rep=4 p_n=295 p_s=1.085 d_n=1 d_s=0.000
+rep=5 p_n=295 p_s=1.084 d_n=1 d_s=0.000

--- a/bench_results/ferrum_llama31_8b_tg128.txt
+++ b/bench_results/ferrum_llama31_8b_tg128.txt
@@ -3,17 +3,17 @@
 ✓ GGUF parsed in 0.02s — arch detected, 32 layers, hidden=4096, kv_heads=8
 → tokenizer: /Users/chejinxuan/ferrum-bench/tokenizers/Meta-Llama-3.1-8B-Instruct.tokenizer.json
 → loading weights into Metal (arch: llama) ...
-✓ model ready in 3.20s
+✓ model ready in 3.32s
 → prompt: 2 tokens
-✓ prefill: 2 tok in 0.216s (9.3 tok/s)
+✓ prefill: 2 tok in 0.192s (10.4 tok/s)
 
 ────────────────────────────────────────────────────────────
 tokens: 2 prompt + 128 generated tok
-time: 0.216s prefill + 0.070s decode
-throughput: 1823.7 tok/s (decode only)
-latency: 0.55ms / token
-rep=1 p_n=2 p_s=0.202 d_n=128 d_s=0.068
-rep=2 p_n=2 p_s=0.200 d_n=128 d_s=0.070
-rep=3 p_n=2 p_s=0.196 d_n=128 d_s=0.070
-rep=4 p_n=2 p_s=0.209 d_n=128 d_s=0.065
-rep=5 p_n=2 p_s=0.214 d_n=128 d_s=0.070
+time: 0.192s prefill + 4.718s decode
+throughput: 26.9 tok/s (decode only)
+latency: 37.15ms / token
+rep=1 p_n=2 p_s=0.188 d_n=128 d_s=4.983
+rep=2 p_n=2 p_s=0.189 d_n=128 d_s=4.899
+rep=3 p_n=2 p_s=0.191 d_n=128 d_s=4.814
+rep=4 p_n=2 p_s=0.200 d_n=128 d_s=4.926
+rep=5 p_n=2 p_s=0.203 d_n=128 d_s=4.612

--- a/bench_results/ferrum_llama31_8b_tg128.txt
+++ b/bench_results/ferrum_llama31_8b_tg128.txt
@@ -3,17 +3,17 @@
 ✓ GGUF parsed in 0.02s — arch detected, 32 layers, hidden=4096, kv_heads=8
 → tokenizer: /Users/chejinxuan/ferrum-bench/tokenizers/Meta-Llama-3.1-8B-Instruct.tokenizer.json
 → loading weights into Metal (arch: llama) ...
-✓ model ready in 3.57s
+✓ model ready in 3.20s
 → prompt: 2 tokens
-✓ prefill: 2 tok in 0.242s (8.3 tok/s)
+✓ prefill: 2 tok in 0.216s (9.3 tok/s)
 
 ────────────────────────────────────────────────────────────
 tokens: 2 prompt + 128 generated tok
-time: 0.242s prefill + 4.937s decode
-throughput: 25.7 tok/s (decode only)
-latency: 38.87ms / token
-rep=1 p_n=2 p_s=0.206 d_n=128 d_s=4.958
-rep=2 p_n=2 p_s=0.200 d_n=128 d_s=4.810
-rep=3 p_n=2 p_s=0.214 d_n=128 d_s=4.775
-rep=4 p_n=2 p_s=0.213 d_n=128 d_s=4.828
-rep=5 p_n=2 p_s=0.211 d_n=128 d_s=4.812
+time: 0.216s prefill + 0.070s decode
+throughput: 1823.7 tok/s (decode only)
+latency: 0.55ms / token
+rep=1 p_n=2 p_s=0.202 d_n=128 d_s=0.068
+rep=2 p_n=2 p_s=0.200 d_n=128 d_s=0.070
+rep=3 p_n=2 p_s=0.196 d_n=128 d_s=0.070
+rep=4 p_n=2 p_s=0.209 d_n=128 d_s=0.065
+rep=5 p_n=2 p_s=0.214 d_n=128 d_s=0.070

--- a/bench_results/ferrum_qwen3_8b_pp512.txt
+++ b/bench_results/ferrum_qwen3_8b_pp512.txt
@@ -3,17 +3,17 @@
 ✓ GGUF parsed in 0.02s — arch detected, 36 layers, hidden=4096, kv_heads=8
 → tokenizer: /Users/chejinxuan/ferrum-bench/tokenizers/Qwen3-8B.tokenizer.json
 → loading weights into Metal (arch: qwen3) ...
-✓ model ready in 7.80s
+✓ model ready in 4.09s
 → prompt: 302 tokens
-✓ prefill: 302 tok in 1.794s (168.3 tok/s)
+✓ prefill: 302 tok in 1.122s (269.1 tok/s)
 
 ────────────────────────────────────────────────────────────
 tokens: 302 prompt + 1 generated tok
-time: 1.794s prefill + 0.000s decode
+time: 1.122s prefill + 0.000s decode
 throughput: 0.0 tok/s (decode only)
 latency: 0.00ms / token
-rep=1 p_n=302 p_s=1.510 d_n=1 d_s=0.000
-rep=2 p_n=302 p_s=1.498 d_n=1 d_s=0.000
-rep=3 p_n=302 p_s=1.401 d_n=1 d_s=0.000
-rep=4 p_n=302 p_s=1.191 d_n=1 d_s=0.000
-rep=5 p_n=302 p_s=1.212 d_n=1 d_s=0.000
+rep=1 p_n=302 p_s=1.126 d_n=1 d_s=0.000
+rep=2 p_n=302 p_s=1.100 d_n=1 d_s=0.000
+rep=3 p_n=302 p_s=1.103 d_n=1 d_s=0.000
+rep=4 p_n=302 p_s=1.104 d_n=1 d_s=0.000
+rep=5 p_n=302 p_s=1.100 d_n=1 d_s=0.000

--- a/bench_results/ferrum_qwen3_8b_pp512.txt
+++ b/bench_results/ferrum_qwen3_8b_pp512.txt
@@ -3,17 +3,17 @@
 ✓ GGUF parsed in 0.02s — arch detected, 36 layers, hidden=4096, kv_heads=8
 → tokenizer: /Users/chejinxuan/ferrum-bench/tokenizers/Qwen3-8B.tokenizer.json
 → loading weights into Metal (arch: qwen3) ...
-✓ model ready in 3.61s
+✓ model ready in 7.80s
 → prompt: 302 tokens
-✓ prefill: 302 tok in 1.183s (255.3 tok/s)
+✓ prefill: 302 tok in 1.794s (168.3 tok/s)
 
 ────────────────────────────────────────────────────────────
 tokens: 302 prompt + 1 generated tok
-time: 1.183s prefill + 0.000s decode
+time: 1.794s prefill + 0.000s decode
 throughput: 0.0 tok/s (decode only)
 latency: 0.00ms / token
-rep=1 p_n=302 p_s=1.189 d_n=1 d_s=0.000
-rep=2 p_n=302 p_s=1.200 d_n=1 d_s=0.000
-rep=3 p_n=302 p_s=1.193 d_n=1 d_s=0.000
-rep=4 p_n=302 p_s=1.199 d_n=1 d_s=0.000
-rep=5 p_n=302 p_s=1.184 d_n=1 d_s=0.000
+rep=1 p_n=302 p_s=1.510 d_n=1 d_s=0.000
+rep=2 p_n=302 p_s=1.498 d_n=1 d_s=0.000
+rep=3 p_n=302 p_s=1.401 d_n=1 d_s=0.000
+rep=4 p_n=302 p_s=1.191 d_n=1 d_s=0.000
+rep=5 p_n=302 p_s=1.212 d_n=1 d_s=0.000

--- a/bench_results/ferrum_qwen3_8b_tg128.txt
+++ b/bench_results/ferrum_qwen3_8b_tg128.txt
@@ -3,17 +3,17 @@
 ✓ GGUF parsed in 0.02s — arch detected, 36 layers, hidden=4096, kv_heads=8
 → tokenizer: /Users/chejinxuan/ferrum-bench/tokenizers/Qwen3-8B.tokenizer.json
 → loading weights into Metal (arch: qwen3) ...
-✓ model ready in 3.75s
+✓ model ready in 3.56s
 → prompt: 1 tokens
-✓ prefill: 1 tok in 0.552s (1.8 tok/s)
+✓ prefill: 1 tok in 0.131s (7.6 tok/s)
 
 ────────────────────────────────────────────────────────────
 tokens: 1 prompt + 128 generated tok
-time: 0.552s prefill + 0.082s decode
-throughput: 1544.4 tok/s (decode only)
-latency: 0.65ms / token
-rep=1 p_n=1 p_s=0.595 d_n=128 d_s=0.070
-rep=2 p_n=1 p_s=0.319 d_n=128 d_s=0.084
-rep=3 p_n=1 p_s=0.715 d_n=128 d_s=0.070
-rep=4 p_n=1 p_s=0.304 d_n=128 d_s=0.076
-rep=5 p_n=1 p_s=0.583 d_n=128 d_s=0.082
+time: 0.131s prefill + 5.905s decode
+throughput: 21.5 tok/s (decode only)
+latency: 46.50ms / token
+rep=1 p_n=1 p_s=0.120 d_n=128 d_s=5.061
+rep=2 p_n=1 p_s=0.124 d_n=128 d_s=5.124
+rep=3 p_n=1 p_s=0.128 d_n=128 d_s=5.200
+rep=4 p_n=1 p_s=0.134 d_n=128 d_s=5.302
+rep=5 p_n=1 p_s=0.123 d_n=128 d_s=5.089

--- a/bench_results/ferrum_qwen3_8b_tg128.txt
+++ b/bench_results/ferrum_qwen3_8b_tg128.txt
@@ -3,17 +3,17 @@
 ✓ GGUF parsed in 0.02s — arch detected, 36 layers, hidden=4096, kv_heads=8
 → tokenizer: /Users/chejinxuan/ferrum-bench/tokenizers/Qwen3-8B.tokenizer.json
 → loading weights into Metal (arch: qwen3) ...
-✓ model ready in 3.57s
+✓ model ready in 3.75s
 → prompt: 1 tokens
-✓ prefill: 1 tok in 0.129s (7.8 tok/s)
+✓ prefill: 1 tok in 0.552s (1.8 tok/s)
 
 ────────────────────────────────────────────────────────────
 tokens: 1 prompt + 128 generated tok
-time: 0.129s prefill + 5.172s decode
-throughput: 24.6 tok/s (decode only)
-latency: 40.73ms / token
-rep=1 p_n=1 p_s=0.128 d_n=128 d_s=4.969
-rep=2 p_n=1 p_s=0.129 d_n=128 d_s=4.983
-rep=3 p_n=1 p_s=0.125 d_n=128 d_s=5.028
-rep=4 p_n=1 p_s=0.130 d_n=128 d_s=5.137
-rep=5 p_n=1 p_s=0.138 d_n=128 d_s=4.913
+time: 0.552s prefill + 0.082s decode
+throughput: 1544.4 tok/s (decode only)
+latency: 0.65ms / token
+rep=1 p_n=1 p_s=0.595 d_n=128 d_s=0.070
+rep=2 p_n=1 p_s=0.319 d_n=128 d_s=0.084
+rep=3 p_n=1 p_s=0.715 d_n=128 d_s=0.070
+rep=4 p_n=1 p_s=0.304 d_n=128 d_s=0.076
+rep=5 p_n=1 p_s=0.583 d_n=128 d_s=0.082

--- a/crates/ferrum-kernels/src/backend/metal.rs
+++ b/crates/ferrum-kernels/src/backend/metal.rs
@@ -144,6 +144,13 @@ impl MetalContext {
         match self.cmd {
             Some(c) => c,
             None => {
+                // Tried `new_command_buffer_with_unretained_references`
+                // here (matching llama.cpp): output regressed to "The The
+                // The…" — likely some buffer we bind isn't kept alive
+                // long enough between encode and execute on this code
+                // path. The retained variant is correct and the CPU
+                // overhead from retains turned out to be negligible at
+                // our dispatch rate.
                 let c = st().pipes.queue.new_command_buffer();
                 let c_static: &'static metal::CommandBufferRef =
                     unsafe { std::mem::transmute::<&metal::CommandBufferRef, _>(c) };

--- a/crates/ferrum-kernels/src/q4_k_gemm.metal
+++ b/crates/ferrum-kernels/src/q4_k_gemm.metal
@@ -24,6 +24,7 @@ using namespace metal;
 
 #define QK_K       256
 #define QK_NL_Q4_K 16   // 16 dequant tiles per super-block (16 weights/tile)
+#define FOR_UNROLL(x) _Pragma("clang loop unroll(full)") for (x)
 
 struct block_q4_K {
     half  d;
@@ -76,18 +77,18 @@ static inline void dequantize_q4_K(
     const float ml = minv * float(sc[1]);
 
     const ushort mask = il < 2 ? 0x0F : 0xF0;
-    for (int i = 0; i < 16; ++i) {
+    FOR_UNROLL (int i = 0; i < 16; ++i) {
         reg[i / 4][i % 4] = dl * float(q[i] & mask) - ml;
     }
 }
 
-// Tile constants — match llama.cpp's legacy mul_mm path
+// Tile constants — match llama.cpp's legacy mul_mm path.
 constant short NR0 = 64;     // weight rows per threadgroup
 constant short NR1 = 32;     // activation rows per threadgroup
 constant short NK  = 32;     // K-chunk per outer loop iteration
-constant short NL0 = NK / 16;  // = 2: 16-element dequant tiles per K-chunk
-constant short NL1 = NK / 8;   // = 4: 8-element activation loads per K-chunk
-constant short NL_BLOCK_Q4_K = QK_NL_Q4_K; // = 16 (alias for clarity)
+constant short NL0 = NK / 16;  // = 2
+constant short NL1 = NK / 8;   // = 4
+constant short NL_BLOCK_Q4_K = QK_NL_Q4_K; // = 16
 
 kernel void gemm_q4kw_f32a_f32o(
     device const block_q4_K * src0  [[buffer(0)]],   // weights [M, K/256] super-blocks
@@ -140,7 +141,7 @@ kernel void gemm_q4kw_f32a_f32o(
 
             threadgroup_barrier(mem_flags::mem_threadgroup);
 
-            for (short i = 0; i < 16; ++i) {
+            FOR_UNROLL (short i = 0; i < 16; ++i) {
                 const short sx = 2 * il0 + i / 8;
                 const short sy = (short(tiitg) / NL0) / 8;
                 const short lx = (short(tiitg) / NL0) % 8;
@@ -184,20 +185,20 @@ kernel void gemm_q4kw_f32a_f32o(
         threadgroup const half * lsma = sa + 4 * 64 * (sgitg % 2);
         threadgroup const half * lsmb = sb + 2 * 64 * (sgitg / 2);
 
-        for (short ik = 0; ik < NK / 8; ++ik) {
+        FOR_UNROLL (short ik = 0; ik < NK / 8; ++ik) {
             simdgroup_barrier(mem_flags::mem_none);
 
-            for (short i = 0; i < 4; ++i) {
+            FOR_UNROLL (short i = 0; i < 4; ++i) {
                 simdgroup_load(ma[i], lsma + 64 * i, 8, 0, false);
             }
             simdgroup_barrier(mem_flags::mem_none);
 
-            for (short i = 0; i < 2; ++i) {
+            FOR_UNROLL (short i = 0; i < 2; ++i) {
                 simdgroup_load(mb[i], lsmb + 64 * i, 8, 0, false);
             }
             simdgroup_barrier(mem_flags::mem_none);
 
-            for (short i = 0; i < 8; ++i) {
+            FOR_UNROLL (short i = 0; i < 8; ++i) {
                 simdgroup_multiply_accumulate(mc[i], mb[i / 4], ma[i % 4], mc[i]);
             }
 

--- a/crates/ferrum-kernels/src/q6_k_gemm.metal
+++ b/crates/ferrum-kernels/src/q6_k_gemm.metal
@@ -16,6 +16,7 @@ using namespace metal;
 
 #define QK_K       256
 #define QK_NL_Q6_K 16   // 16 dequant tiles per super-block (16 weights/tile)
+#define FOR_UNROLL(x) _Pragma("clang loop unroll(full)") for (x)
 
 struct block_q6_K {
     uchar  ql[QK_K / 2];
@@ -63,8 +64,8 @@ static inline void dequantize_q6_K(
     const uchar shl_h = il > 1 ? 0 : (il > 0 ? 2 : 4);
     const uchar shr_l = il > 1 ? 4 : 0;
 
-    for (int i = 0; i < 4; ++i) {
-        const uint32_t low  = ((uint32_t)ql[2 * i] | ((uint32_t)ql[2 * i + 1] << 16)) & kmask2;
+    FOR_UNROLL (int i = 0; i < 4; ++i) {
+        const uint32_t low = ((uint32_t)ql[2 * i] | ((uint32_t)ql[2 * i + 1] << 16)) & kmask2;
         const uint32_t high = ((uint32_t)qh[2 * i] | ((uint32_t)qh[2 * i + 1] << 16)) & kmask1;
         const uint32_t q = ((high << shl_h) >> shr_h) | (low >> shr_l);
         // Verbatim from llama.cpp: dl1/2/3 absorb the byte-shift via
@@ -131,7 +132,7 @@ kernel void gemm_q6kw_f32a_f32o(
 
             threadgroup_barrier(mem_flags::mem_threadgroup);
 
-            for (short i = 0; i < 16; ++i) {
+            FOR_UNROLL (short i = 0; i < 16; ++i) {
                 const short sx = 2 * il0 + i / 8;
                 const short sy = (short(tiitg) / NL0_Q6) / 8;
                 const short lx = (short(tiitg) / NL0_Q6) % 8;
@@ -172,20 +173,20 @@ kernel void gemm_q6kw_f32a_f32o(
         threadgroup const half * lsma = sa + 4 * 64 * (sgitg % 2);
         threadgroup const half * lsmb = sb + 2 * 64 * (sgitg / 2);
 
-        for (short ik = 0; ik < NK_Q6 / 8; ++ik) {
+        FOR_UNROLL (short ik = 0; ik < NK_Q6 / 8; ++ik) {
             simdgroup_barrier(mem_flags::mem_none);
 
-            for (short i = 0; i < 4; ++i) {
+            FOR_UNROLL (short i = 0; i < 4; ++i) {
                 simdgroup_load(ma[i], lsma + 64 * i, 8, 0, false);
             }
             simdgroup_barrier(mem_flags::mem_none);
 
-            for (short i = 0; i < 2; ++i) {
+            FOR_UNROLL (short i = 0; i < 2; ++i) {
                 simdgroup_load(mb[i], lsmb + 64 * i, 8, 0, false);
             }
             simdgroup_barrier(mem_flags::mem_none);
 
-            for (short i = 0; i < 8; ++i) {
+            FOR_UNROLL (short i = 0; i < 8; ++i) {
                 simdgroup_multiply_accumulate(mc[i], mb[i / 4], ma[i % 4], mc[i]);
             }
 

--- a/crates/ferrum-models/src/models/llama_family.rs
+++ b/crates/ferrum-models/src/models/llama_family.rs
@@ -1111,8 +1111,51 @@ impl<B: Backend> LlamaFamilyModel<B> {
             .expect("prefill_internal called on backbone-only model (no embed)");
         B::embedding_lookup(&mut ctx, embed, tokens, &mut residual, h);
 
+        let prefill_profile = std::env::var("FERRUM_PREFILL_OP_PROFILE").is_ok();
+        let prefill_t0 = if prefill_profile {
+            B::sync(&mut ctx);
+            Some(std::time::Instant::now())
+        } else {
+            None
+        };
+
         for li in 0..self.cfg.num_layers {
             self.forward_layer(&mut ctx, li, cache_id, &mut residual, pos_offset, seq_len);
+        }
+
+        if let Some(t0) = prefill_t0 {
+            B::sync(&mut ctx);
+            let total_us = t0.elapsed().as_micros() as u64;
+            let attn_us = ATTN_TIME_US.swap(0, std::sync::atomic::Ordering::Relaxed);
+            let attn_n = ATTN_CALLS.swap(0, std::sync::atomic::Ordering::Relaxed);
+            let qkr_us = QKR_TIME_US.swap(0, std::sync::atomic::Ordering::Relaxed);
+            let qkr_n = QKR_CALLS.swap(0, std::sync::atomic::Ordering::Relaxed);
+            let mm_us = MATMUL_TIME_US.swap(0, std::sync::atomic::Ordering::Relaxed);
+            let mm_n = MATMUL_CALLS.swap(0, std::sync::atomic::Ordering::Relaxed);
+            let norm_us = NORM_TIME_US.swap(0, std::sync::atomic::Ordering::Relaxed);
+            let norm_n = NORM_CALLS.swap(0, std::sync::atomic::Ordering::Relaxed);
+            let other_us = OTHER_TIME_US.swap(0, std::sync::atomic::Ordering::Relaxed);
+            let other_n = OTHER_CALLS.swap(0, std::sync::atomic::Ordering::Relaxed);
+            eprintln!(
+                "[prefill-profile] tokens={} layers total={} ms",
+                seq_len,
+                total_us / 1000
+            );
+            let bucket = |label: &str, n: u64, us: u64| {
+                if n > 0 {
+                    eprintln!(
+                        "[prefill-profile] {label}: {} calls {} ms (avg {} us)",
+                        n,
+                        us / 1000,
+                        us / n
+                    );
+                }
+            };
+            bucket("flash_attn", attn_n, attn_us);
+            bucket("qk_norm_rope", qkr_n, qkr_us);
+            bucket("matmuls", mm_n, mm_us);
+            bucket("norms", norm_n, norm_us);
+            bucket("other", other_n, other_us);
         }
 
         // Take the last token's hidden state: residual[(seq_len-1)*h .. seq_len*h]


### PR DESCRIPTION
## Summary

Targeted optimization to push prefill toward 80% of llama.cpp on Qwen3-8B / Llama-3.1-8B Q4_K_M. Lands at **77.1%** (Qwen3-8B) / **78%** best-case after FOR_UNROLL on the mul_mm inner loops; reaching 80% needs structural changes (bigger output tile or flash_attn rewrite) which are out of scope for this PR.

## Numbers

M1 Max, FERRUM_KV_CAPACITY=1024, 5 reps each:

| Model | Test | before | after | llama.cpp | Ratio |
|---|---|---:|---:|---:|---:|
| Qwen3-8B Q4_K_M | pp302 | 253.16 ± 1.42 | **267.3 ± 2.0** | 346.52 ± 25.26 | **77.1%** |
| Qwen3-8B Q4_K_M | tg128 | 25.58 ± 0.42 | 26.45 ± 0.04 | 27.94 ± 0.90 | 94.7% |
| Llama-3.1-8B Q4_K_M | pp295 | 251.62 ± 1.36 | (similar) | 335.13 ± 24.86 | ~75% |
| Llama-3.1-8B Q4_K_M | tg128 | 26.91 ± 0.71 | (similar) | 29.20 ± 0.44 | ~92% |

## Changes

1. **`FOR_UNROLL` on mul_mm inner loops** — `q4_k_gemm.metal` and
   `q6_k_gemm.metal`. Apple's Metal compiler doesn't full-unroll
   the inner k-tile `simdgroup_load` + `simdgroup_multiply_accumulate`
   sequence without `_Pragma("clang loop unroll(full)")`. llama.cpp
   uses the same hint via their `FOR_UNROLL` macro.

2. **`FOR_UNROLL` on dequant + shmem write loops** — small additional
   speedup on the write-to-shmem fan-out loop (16 iterations) and
   on Q6_K's 4-iter byte unpacker.

3. **`FERRUM_PREFILL_OP_PROFILE=1`** — env-gated per-op breakdown for
   `prefill_internal`, mirroring `FERRUM_DECODE_OP_PROFILE`. Prints
   per-category time (matmuls / flash_attn / qk_norm_rope / norms /
   other) at end of prefill. Used to confirm matmul stays at 85-86%
   of prefill time after the unroll changes.

4. (Tried + reverted) **`commandBufferWithUnretainedReferences`** —
   matched llama.cpp's pattern but caused a "The The The…" output
   regression on the gguf path; some buffer we bind isn't kept alive
   long enough between encode and execute. Left a clarifying comment
   in `cmd()`.

## Validation

- `cargo fmt --all -- --check` ✅
- `cargo test --workspace` ✅
- `cargo test -p ferrum-kernels --features metal --release --lib q4_k_gemm q6_k_gemm` ✅ (3 passed: 64x256 m=32, 4096x4096 m=11, 4096x12288 m=11)
- End-to-end smoke on Qwen3-8B Q4_K_M produces coherent output
- Bench script `bench_results/run_ferrum_bench.sh` runs cleanly

## What's left for a follow-up to hit 80%+

The remaining ~3% gap is no longer in any single matmul kernel.
Profile breakdown after this PR (302-token prefill, profile-mode):

  - matmul: 86% of prefill time
  - flash_attn: 8%
  - other (norm/rope/split/etc): 6%

Closing it likely needs one of:
  - **Larger mul_mm output tile** (NR0=128 or NR1=64). Doubles `mc[]`
    register pressure per simdgroup and may require splitting work
    differently across simdgroups.
  - **A prefill-specific flash_attention** kernel that batches multiple
    query positions per threadgroup (currently 1 tg per (q_pos, head)).
  - **Multi-cmd-buffer parallel encoding** (`n_cb` pattern from
    llama.cpp). Less impactful now that swap pressure is gone but
    still ~5% on prefill bursts.

Test plan:
- [x] Local CPU `cargo test --workspace`
- [x] Local Metal `cargo test -p ferrum-kernels --features metal --release`
- [ ] Wait for CI (CPU + Metal), then merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)