### PR TITLE
feat(models): Qwen3MoeModel<B> + quantised expert storage + CLI dispatch

### DIFF
--- a/crates/ferrum-attention/src/metal/pipelines.rs
+++ b/crates/ferrum-attention/src/metal/pipelines.rs
@@ -51,6 +51,7 @@ impl MetalPipelines {
                     "rms_norm_f32",
                     "silu_mul_f32",
                     "add_f32",
+                    "scaled_add_inplace_f32",
                     "mul_scale_f32",
                     "fused_scale_add_f32",
                     "fused_residual_norm_f32",
@@ -256,6 +257,34 @@ impl MetalPipelines {
         enc.set_buffer(1, Some(b), 0);
         enc.set_buffer(2, Some(output), 0);
         enc.set_bytes(3, 4, &params as *const _ as *const c_void as *const _);
+        let grid = MTLSize::new(n.div_ceil(256) as u64, 1, 1);
+        let tg = MTLSize::new(256, 1, 1);
+        enc.dispatch_thread_groups(grid, tg);
+    }
+
+    /// Scalar-scaled in-place add: `dst[i] += scale * src[i]`. Used by the
+    /// MoE per-(token, expert) combine where each expert's down-projection
+    /// is weighted by a router-derived scalar before summing into the
+    /// per-token output. Inlining the multiply avoids materialising
+    /// `scale * src` into a transient buffer.
+    pub fn scaled_add_inplace_enc(
+        &self,
+        enc: &ComputeCommandEncoderRef,
+        dst: &Buffer,
+        src: &Buffer,
+        scale: f32,
+        n: usize,
+    ) {
+        #[repr(C)]
+        struct P {
+            n: i32,
+            scale: f32,
+        }
+        let params = P { n: n as i32, scale };
+        enc.set_compute_pipeline_state(self.pipeline("scaled_add_inplace_f32"));
+        enc.set_buffer(0, Some(dst), 0);
+        enc.set_buffer(1, Some(src), 0);
+        enc.set_bytes(2, 8, &params as *const _ as *const c_void as *const _);
         let grid = MTLSize::new(n.div_ceil(256) as u64, 1, 1);
         let tg = MTLSize::new(256, 1, 1);
         enc.dispatch_thread_groups(grid, tg);

--- a/crates/ferrum-attention/src/metal/shaders/transformer_ops.metal
+++ b/crates/ferrum-attention/src/metal/shaders/transformer_ops.metal
@@ -91,6 +91,25 @@ kernel void add_f32(
     output[tid] = a[tid] + b[tid];
 }
 
+// ── Scalar-scaled add: dst[i] += scale * src[i] ─────────────────────────
+// MoE expert combine — used in the per-(token, expert) accumulate loop
+// where each contribution is weighted by a router-derived scalar.
+
+struct ScaledAddParams {
+    int   n;
+    float scale;
+};
+
+kernel void scaled_add_inplace_f32(
+    device       float* dst       [[buffer(0)]],
+    device const float* src       [[buffer(1)]],
+    constant ScaledAddParams& p   [[buffer(2)]],
+    uint tid [[thread_position_in_grid]])
+{
+    if (tid >= uint(p.n)) return;
+    dst[tid] += p.scale * src[tid];
+}
+
 // ── Element-wise Multiply (broadcast scale) ─────────────────────────────
 // out[i] = a[i] * scale[i % scale_len]
 

--- a/crates/ferrum-cli/src/commands/run_gguf.rs
+++ b/crates/ferrum-cli/src/commands/run_gguf.rs
@@ -30,6 +30,8 @@ use rand::rngs::StdRng;
 use ferrum_kernels::backend::cpu::CpuBackend;
 use ferrum_models::common::llm::DecoderOnlyLLM;
 use ferrum_models::models::llama_family::{LlamaFamilyConfig, LlamaFamilyModel};
+use ferrum_models::models::qwen3_moe::Qwen3MoeModel;
+use ferrum_models::moe_config::Qwen3MoeConfig;
 use ferrum_quantization::gguf::{GgufFile, GgufLoader};
 use ferrum_types::{FerrumError, Result};
 use tokenizers::Tokenizer;
@@ -54,15 +56,58 @@ pub async fn run_gguf_one_shot(cmd: RunCommand, _config: CliConfig) -> Result<()
     let load_start = Instant::now();
     let gguf = GgufFile::open(&gguf_path)
         .map_err(|e| FerrumError::model(format!("GgufFile::open: {e}")))?;
-    let cfg = LlamaFamilyConfig::from_gguf(&gguf)?;
-    eprintln!(
-        "{} GGUF parsed in {:.2}s — arch detected, {} layers, hidden={}, kv_heads={}",
-        "✓".green(),
-        load_start.elapsed().as_secs_f64(),
-        cfg.num_layers,
-        cfg.hidden_size,
-        cfg.num_kv_heads
-    );
+
+    // Architecture-aware config parse: dense Qwen3 / Llama goes through
+    // `LlamaFamilyConfig::from_gguf`; MoE variants (qwen3moe) need
+    // `Qwen3MoeConfig::from_gguf` since the MoE-specific keys (expert
+    // count, top-K, expert FFN width) live alongside the dense fields.
+    let arch_str = gguf
+        .architecture()
+        .map_err(|e| FerrumError::model(format!("read arch: {e}")))?
+        .to_string();
+    let is_moe = arch_str == "qwen3moe";
+
+    // Parse the right config flavour. Both end up exposing num_layers /
+    // hidden_size / kv_heads for the load-time banner.
+    let (dense_cfg, moe_cfg) = if is_moe {
+        let mc = Qwen3MoeConfig::from_gguf(&gguf)?;
+        (None, Some(mc))
+    } else {
+        let dc = LlamaFamilyConfig::from_gguf(&gguf)?;
+        (Some(dc), None)
+    };
+    let (n_layers, hidden, kv_heads) = if let Some(c) = dense_cfg.as_ref() {
+        (c.num_layers, c.hidden_size, c.num_kv_heads)
+    } else {
+        let c = moe_cfg.as_ref().unwrap();
+        (c.base.num_layers, c.base.hidden_size, c.base.num_kv_heads)
+    };
+    let cfg = dense_cfg
+        .clone()
+        .unwrap_or_else(|| moe_cfg.as_ref().unwrap().base.clone());
+
+    if let Some(c) = moe_cfg.as_ref() {
+        eprintln!(
+            "{} GGUF parsed in {:.2}s — MoE arch detected, {} layers, hidden={}, kv_heads={}, experts={}, top_k={}, expert_inter={}",
+            "✓".green(),
+            load_start.elapsed().as_secs_f64(),
+            n_layers,
+            hidden,
+            kv_heads,
+            c.num_experts,
+            c.num_experts_per_tok,
+            c.expert_intermediate_size,
+        );
+    } else {
+        eprintln!(
+            "{} GGUF parsed in {:.2}s — arch detected, {} layers, hidden={}, kv_heads={}",
+            "✓".green(),
+            load_start.elapsed().as_secs_f64(),
+            n_layers,
+            hidden,
+            kv_heads
+        );
+    }
 
     // Tokenizer (auto-discover if not provided)
     let tokenizer_path = cmd
@@ -97,37 +142,65 @@ pub async fn run_gguf_one_shot(cmd: RunCommand, _config: CliConfig) -> Result<()
 
     match backend_kind {
         BackendKind::Cpu => {
-            let loader = GgufLoader::<CpuBackend>::from_file(gguf_arc);
-            let mut model = LlamaFamilyModel::<CpuBackend>::new(cfg, &loader)?;
-            let model_load_secs = model_load_start.elapsed().as_secs_f64();
-            eprintln!("{} model ready in {:.2}s", "✓".green(), model_load_secs);
-
-            run_inference(
-                &mut model,
-                &tokenizer,
-                &cmd,
-                &arch_label,
-                tokenizer_path,
-                &gguf_path,
-                BackendKind::Cpu,
-            )?;
+            let loader = GgufLoader::<CpuBackend>::from_file(gguf_arc.clone());
+            if let Some(mc) = moe_cfg.clone() {
+                let mut model = Qwen3MoeModel::<CpuBackend>::new(mc, &loader, &gguf_arc)?;
+                let model_load_secs = model_load_start.elapsed().as_secs_f64();
+                eprintln!("{} model ready in {:.2}s", "✓".green(), model_load_secs);
+                run_inference(
+                    &mut model,
+                    &tokenizer,
+                    &cmd,
+                    &arch_label,
+                    tokenizer_path,
+                    &gguf_path,
+                    BackendKind::Cpu,
+                )?;
+            } else {
+                let mut model = LlamaFamilyModel::<CpuBackend>::new(cfg, &loader)?;
+                let model_load_secs = model_load_start.elapsed().as_secs_f64();
+                eprintln!("{} model ready in {:.2}s", "✓".green(), model_load_secs);
+                run_inference(
+                    &mut model,
+                    &tokenizer,
+                    &cmd,
+                    &arch_label,
+                    tokenizer_path,
+                    &gguf_path,
+                    BackendKind::Cpu,
+                )?;
+            }
         }
         #[cfg(all(target_os = "macos", feature = "metal"))]
         BackendKind::Metal => {
-            let loader = GgufLoader::<MetalBackend>::from_file(gguf_arc);
-            let mut model = LlamaFamilyModel::<MetalBackend>::new(cfg, &loader)?;
-            let model_load_secs = model_load_start.elapsed().as_secs_f64();
-            eprintln!("{} model ready in {:.2}s", "✓".green(), model_load_secs);
-
-            run_inference(
-                &mut model,
-                &tokenizer,
-                &cmd,
-                &arch_label,
-                tokenizer_path,
-                &gguf_path,
-                BackendKind::Metal,
-            )?;
+            let loader = GgufLoader::<MetalBackend>::from_file(gguf_arc.clone());
+            if let Some(mc) = moe_cfg.clone() {
+                let mut model = Qwen3MoeModel::<MetalBackend>::new(mc, &loader, &gguf_arc)?;
+                let model_load_secs = model_load_start.elapsed().as_secs_f64();
+                eprintln!("{} model ready in {:.2}s", "✓".green(), model_load_secs);
+                run_inference(
+                    &mut model,
+                    &tokenizer,
+                    &cmd,
+                    &arch_label,
+                    tokenizer_path,
+                    &gguf_path,
+                    BackendKind::Metal,
+                )?;
+            } else {
+                let mut model = LlamaFamilyModel::<MetalBackend>::new(cfg, &loader)?;
+                let model_load_secs = model_load_start.elapsed().as_secs_f64();
+                eprintln!("{} model ready in {:.2}s", "✓".green(), model_load_secs);
+                run_inference(
+                    &mut model,
+                    &tokenizer,
+                    &cmd,
+                    &arch_label,
+                    tokenizer_path,
+                    &gguf_path,
+                    BackendKind::Metal,
+                )?;
+            }
         }
     }
 

--- a/crates/ferrum-kernels/src/backend/cpu.rs
+++ b/crates/ferrum-kernels/src/backend/cpu.rs
@@ -496,8 +496,12 @@ impl Backend for CpuBackend {
         debug_assert!(cache_len + new_tokens <= cache_capacity);
         debug_assert_eq!(cache_k.len(), nkv * cache_capacity * hd);
         debug_assert_eq!(cache_v.len(), nkv * cache_capacity * hd);
-        debug_assert_eq!(new_k_head_major.len(), nkv * new_tokens * hd);
-        debug_assert_eq!(new_v_head_major.len(), nkv * new_tokens * hd);
+        // The source buffers may be sized for `max_tokens` (the prefill-
+        // sized scratch) while only the first `nkv * new_tokens * hd`
+        // entries are valid for this call. Allow >= so reusing scratch
+        // across prefill and decode doesn't trip the assert.
+        debug_assert!(new_k_head_major.len() >= nkv * new_tokens * hd);
+        debug_assert!(new_v_head_major.len() >= nkv * new_tokens * hd);
 
         for h in 0..nkv {
             let dst_base = h * cache_capacity * hd + cache_len * hd;
@@ -534,6 +538,18 @@ impl Backend for CpuBackend {
     ) {
         for i in 0..len {
             residual[i] += x[i];
+        }
+    }
+
+    fn scaled_add_inplace(
+        _ctx: &mut Self::Context,
+        dst: &mut Self::Buffer,
+        src: &Self::Buffer,
+        scale: f32,
+        len: usize,
+    ) {
+        for i in 0..len {
+            dst[i] += scale * src[i];
         }
     }
 

--- a/crates/ferrum-kernels/src/backend/metal.rs
+++ b/crates/ferrum-kernels/src/backend/metal.rs
@@ -1084,6 +1084,20 @@ impl Backend for MetalBackend {
         st().pipes.add_enc(enc, r, x, r, len);
     }
 
+    fn scaled_add_inplace(
+        ctx: &mut Self::Context,
+        dst: &mut Self::Buffer,
+        src: &Self::Buffer,
+        scale: f32,
+        len: usize,
+    ) {
+        let dst_buf = dst.expect_f32_mut("scaled_add_inplace dst");
+        let src_buf = src.expect_f32("scaled_add_inplace src");
+        let enc = ctx.compute_encoder();
+        st().pipes
+            .scaled_add_inplace_enc(enc, dst_buf, src_buf, scale, len);
+    }
+
     // ── Buffer management ────────────────────────────────────────────
 
     fn alloc(len: usize) -> Self::Buffer {

--- a/crates/ferrum-kernels/src/backend/traits.rs
+++ b/crates/ferrum-kernels/src/backend/traits.rs
@@ -567,6 +567,32 @@ pub trait Backend: Send + Sync + Sized + 'static {
         len: usize,
     );
 
+    /// `dst[i] += scale * src[i]` — scalar-broadcast scaled add, in place.
+    ///
+    /// MoE per-token combine writes `out[b] += weight_k * expert_k(x[b])`
+    /// for each top-K expert; this primitive is the per-call accumulate.
+    /// Backends without a dedicated kernel can fall back to the default
+    /// implementation, which round-trips through host memory — correct,
+    /// but slow on a hot path. Override on any backend you actually
+    /// dispatch MoE on.
+    fn scaled_add_inplace(
+        _ctx: &mut Self::Context,
+        dst: &mut Self::Buffer,
+        src: &Self::Buffer,
+        scale: f32,
+        len: usize,
+    ) {
+        let mut dst_v = Self::to_vec(dst, len);
+        let src_v = Self::to_vec(src, len);
+        for i in 0..len {
+            dst_v[i] += scale * src_v[i];
+        }
+        // Move the new buffer into the slot pointed to by `dst`. Safe
+        // because `Self::Buffer: Send + Sync` and the old buffer is
+        // dropped here when overwritten.
+        *dst = Self::from_slice(&dst_v);
+    }
+
     /// Broadcast bias add: `data[r, c] += bias[c]` for every row.
     /// Required by Bert / Clip / Whisper whose linear projections carry a bias.
     fn add_bias(

--- a/crates/ferrum-models/src/models/mod.rs
+++ b/crates/ferrum-models/src/models/mod.rs
@@ -16,5 +16,7 @@
 //!   - `qwen_vl`     — ViT backbone + LLM (multimodal).
 
 pub mod llama_family;
+pub mod qwen3_moe;
 
 pub use llama_family::{LlamaFamilyConfig, LlamaFamilyModel};
+pub use qwen3_moe::Qwen3MoeModel;

--- a/crates/ferrum-models/src/models/qwen3_moe.rs
+++ b/crates/ferrum-models/src/models/qwen3_moe.rs
@@ -1,0 +1,757 @@
+//! `Qwen3MoeModel<B>` — Qwen3-MoE family decoder (Qwen3-30B-A3B and friends).
+//!
+//! Architectural delta vs [`LlamaFamilyModel`]:
+//!   * Each transformer layer's FFN is a top-K MoE block instead of a
+//!     fused `gate_up_proj → silu → down_proj` MLP.
+//!     - One small router linear (`[hidden] → [num_experts]`) picks
+//!       top-K experts per token.
+//!     - Each expert is itself a fused `gate_up + down` MLP with the
+//!       same SwiGLU + RMSNorm structure as the dense path, just with
+//!       `expert_intermediate_size` (typically much smaller than the
+//!       dense `intermediate_size`).
+//!     - Output is the weight-summed combination of the K selected
+//!       expert outputs.
+//!   * Attention path is unchanged from dense Qwen3 (GQA + QK-norm + RoPE).
+//!
+//! Implementation re-uses the dense layer's attention machinery
+//! verbatim — RMSNorm, fused QKV, QK-norm + RoPE, KV cache append,
+//! flash attention, O-projection, residual + post-norm. The only new
+//! code is the MoE FFN block at the tail of each layer's forward.
+//!
+//! Memory model: experts are loaded as `QuantLinear<B>` per expert,
+//! slicing the on-disk 3-D `ffn_{gate,up,down}_exps.weight` tensors
+//! byte-wise so weights stay compressed (Q4_K / Q6_K). For a 32 GB
+//! Mac to run Qwen3-30B-A3B at all, this is non-negotiable: an
+//! eager-fp32 expert stack would weigh ~110 GB.
+
+use std::collections::HashMap;
+use std::sync::atomic::AtomicU64;
+
+use ferrum_kernels::backend::{Backend, KvCache};
+use ferrum_quantization::WeightLoader;
+use ferrum_types::{FerrumError, Result};
+
+use crate::common::{DecoderOnlyLLM, LlmRuntimeConfig};
+use crate::models::llama_family::{LlamaFamilyConfig, LlamaFamilyLayer, RopeCache};
+use crate::moe::{moe_forward, ExpertStack};
+use crate::moe_config::Qwen3MoeConfig;
+
+// Decode-side per-op profile counters — same names as the dense path
+// so existing tooling (`FERRUM_DECODE_OP_PROFILE=1` log scrapers) keeps
+// working without a separate switch for MoE.
+static ATTN_TIME_US: AtomicU64 = AtomicU64::new(0);
+static ATTN_CALLS: AtomicU64 = AtomicU64::new(0);
+static MOE_TIME_US: AtomicU64 = AtomicU64::new(0);
+static MOE_CALLS: AtomicU64 = AtomicU64::new(0);
+
+/// Per-layer MoE state: router linear (small) + per-expert MLP stack.
+pub struct Qwen3MoeLayerState<B: Backend> {
+    /// Router projection `[hidden] → [num_experts]` — tiny, never sparse,
+    /// always runs the full GEMV.
+    pub router: Box<dyn ferrum_quantization::Linear<B>>,
+    /// Per-expert weight stack. Each entry's `gate_up` is the fused
+    /// `[gate; up]` projection; `down` is the post-SwiGLU output proj.
+    pub experts: ExpertStack<B>,
+}
+
+/// Reusable scratch buffers for the MoE forward path. All sized at
+/// allocation time and reused across layers / forward calls.
+pub struct Qwen3MoeScratch<B: Backend> {
+    /// See [`crate::models::llama_family::LlamaFamilyScratch`] for the
+    /// attention scratch — we re-use those names verbatim.
+    pub residual: Option<B::Buffer>,
+    pub norm_out: B::Buffer,
+    pub qkv_out: B::Buffer,
+    pub q_buf: B::Buffer,
+    pub k_buf: B::Buffer,
+    pub v_buf: B::Buffer,
+    pub q_head_major: B::Buffer,
+    pub k_head_major: B::Buffer,
+    pub v_head_major: B::Buffer,
+    pub attn_head_major_out: B::Buffer,
+    pub attn_flat: B::Buffer,
+    pub o_proj_out: B::Buffer,
+
+    // ── MoE-specific scratch ─────────────────────────────────────────
+    /// Router logits for the whole batch: `[max_tokens, num_experts]`.
+    pub router_logits: B::Buffer,
+    /// Per-(token, expert) gate||up projection output — `[2 * expert_inter]`.
+    pub gate_up_buf: B::Buffer,
+    /// SiLU(gate) * up scratch — `[expert_inter]`.
+    pub silu_buf: B::Buffer,
+    /// Per-(token, expert) down-projection output — `[hidden]`.
+    pub down_buf: B::Buffer,
+    /// Per-token row scratch — `[hidden]`. Reused both as a copy of the
+    /// input row for the gate_up_proj and as a row-accumulator for the
+    /// scaled-add-and-store path inside `moe_forward`.
+    pub x_single: B::Buffer,
+    /// MoE output `[max_tokens, hidden]`. Zeroed each forward.
+    pub moe_out: B::Buffer,
+
+    // ── Final-token / lm_head outputs ────────────────────────────────
+    pub last_hidden: B::Buffer,
+    pub last_normed: B::Buffer,
+    pub logits: B::Buffer,
+    pub batch_logits: B::Buffer,
+
+    pub max_tokens: usize,
+}
+
+impl<B: Backend> Qwen3MoeScratch<B> {
+    fn alloc(cfg: &Qwen3MoeConfig, max_tokens: usize) -> Self {
+        let h = cfg.base.hidden_size;
+        let q_dim = cfg.base.num_heads * cfg.base.head_dim;
+        let kv_dim = cfg.base.num_kv_heads * cfg.base.head_dim;
+        let qkv_dim = q_dim + 2 * kv_dim;
+        let t = max_tokens;
+        let inter = cfg.expert_intermediate_size;
+        let n_exp = cfg.num_experts;
+        let vocab = cfg.base.vocab_size;
+        Self {
+            residual: Some(B::alloc(t * h)),
+            norm_out: B::alloc(t * h),
+            qkv_out: B::alloc(t * qkv_dim),
+            q_buf: B::alloc(t * q_dim),
+            k_buf: B::alloc(t * kv_dim),
+            v_buf: B::alloc(t * kv_dim),
+            q_head_major: B::alloc(cfg.base.num_heads * t * cfg.base.head_dim),
+            k_head_major: B::alloc(cfg.base.num_kv_heads * t * cfg.base.head_dim),
+            v_head_major: B::alloc(cfg.base.num_kv_heads * t * cfg.base.head_dim),
+            attn_head_major_out: B::alloc(cfg.base.num_heads * t * cfg.base.head_dim),
+            attn_flat: B::alloc(t * q_dim),
+            o_proj_out: B::alloc(t * h),
+            router_logits: B::alloc(t * n_exp),
+            gate_up_buf: B::alloc(2 * inter),
+            silu_buf: B::alloc(inter),
+            down_buf: B::alloc(h),
+            x_single: B::alloc(h),
+            moe_out: B::alloc(t * h),
+            last_hidden: B::alloc(h),
+            last_normed: B::alloc(h),
+            logits: B::alloc(vocab),
+            batch_logits: B::alloc(t * vocab),
+            max_tokens: t,
+        }
+    }
+}
+
+/// Qwen3-MoE decoder model.
+///
+/// Holds the same per-layer attention weights as [`LlamaFamilyModel`]
+/// plus a [`Qwen3MoeLayerState`] per layer for the MoE FFN. Routing,
+/// expert dispatch, and weighted combine all happen inside
+/// [`moe_forward`]; this struct only owns the storage and orchestrates
+/// the per-layer call sequence.
+pub struct Qwen3MoeModel<B: Backend> {
+    pub cfg: Qwen3MoeConfig,
+    pub runtime_cfg: LlmRuntimeConfig,
+
+    pub embed: B::Buffer,
+    /// Per-layer attention weights (re-uses dense `LlamaFamilyLayer`).
+    pub attn_layers: Vec<LlamaFamilyLayer<B>>,
+    /// Per-layer MoE state (router + expert stack).
+    pub moe_layers: Vec<Qwen3MoeLayerState<B>>,
+    pub final_norm_w: B::Buffer,
+    pub lm_head: Box<dyn ferrum_quantization::Linear<B>>,
+
+    pub rope: RopeCache<B>,
+    pub scratch: Qwen3MoeScratch<B>,
+
+    pub kv_caches: HashMap<String, Vec<KvCache<B>>>,
+    kv_free_pool: Vec<Vec<KvCache<B>>>,
+}
+
+impl<B: Backend> Qwen3MoeModel<B> {
+    /// Build a Qwen3-MoE model from a generic `WeightLoader<B>` plus a
+    /// GGUF reader for the experts (which `WeightLoader` doesn't model
+    /// directly — its API is rank-2 only).
+    ///
+    /// `loader` provides: token embedding, attention projections, layer
+    /// norms, lm_head — all the rank-2 weights.
+    /// `gguf` provides: the rank-3 expert tensors, sliced per-expert
+    /// inside [`ExpertStack::load_from_gguf`].
+    pub fn new(
+        cfg: Qwen3MoeConfig,
+        loader: &dyn WeightLoader<B>,
+        gguf: &ferrum_quantization::gguf::GgufFile,
+    ) -> Result<Self> {
+        {
+            let mut ctx = B::new_context();
+            B::reset_graph(&mut ctx);
+        }
+        let rope = build_rope_cache::<B>(&cfg.base);
+        let scratch = Qwen3MoeScratch::alloc(&cfg, 1);
+
+        let embed = loader.load_tensor("model.embed_tokens.weight")?;
+
+        let mut attn_layers = Vec::with_capacity(cfg.base.num_layers);
+        let mut moe_layers = Vec::with_capacity(cfg.base.num_layers);
+        for li in 0..cfg.base.num_layers {
+            let prefix = format!("model.layers.{li}");
+            let input_ln_w = loader.load_tensor(&format!("{prefix}.input_layernorm.weight"))?;
+            let qkv_proj = loader.load_linear(&format!("{prefix}.self_attn.qkv_proj"))?;
+            let o_proj = loader.load_linear(&format!("{prefix}.self_attn.o_proj"))?;
+            let post_ln_w =
+                loader.load_tensor(&format!("{prefix}.post_attention_layernorm.weight"))?;
+
+            // Dense gate_up_proj / down_proj are absent in MoE GGUFs —
+            // we synthesise stub Linears so the LlamaFamilyLayer struct
+            // type-checks. They're never invoked because forward_layer
+            // calls the MoE path. Cheap: tiny zero-sized DenseLinears.
+            let gate_up_proj: Box<dyn ferrum_quantization::Linear<B>> =
+                stub_linear::<B>(2 * cfg.expert_intermediate_size, cfg.base.hidden_size);
+            let down_proj: Box<dyn ferrum_quantization::Linear<B>> =
+                stub_linear::<B>(cfg.base.hidden_size, cfg.expert_intermediate_size);
+
+            let (q_norm_w, k_norm_w) = if cfg.base.has_qk_norm {
+                let q = loader
+                    .load_tensor(&format!("{prefix}.self_attn.q_norm.weight"))
+                    .ok();
+                let k = loader
+                    .load_tensor(&format!("{prefix}.self_attn.k_norm.weight"))
+                    .ok();
+                (q, k)
+            } else {
+                (None, None)
+            };
+
+            attn_layers.push(LlamaFamilyLayer {
+                input_ln_w,
+                qkv_proj,
+                q_norm_w,
+                k_norm_w,
+                o_proj,
+                post_ln_w,
+                gate_up_proj,
+                down_proj,
+            });
+
+            // Router lives at `model.layers.{li}.mlp.router.weight` in
+            // ferrum-name space (see ferrum_to_gguf mapping). It's a
+            // plain rank-2 linear so the standard loader path covers
+            // it without going through the MoE-specific GGUF helper.
+            let router = loader.load_linear(&format!("{prefix}.mlp.router"))?;
+            if router.in_features() != cfg.base.hidden_size {
+                return Err(FerrumError::model(format!(
+                    "router layer {li}: in_features {} != hidden {}",
+                    router.in_features(),
+                    cfg.base.hidden_size
+                )));
+            }
+            if router.out_features() != cfg.num_experts {
+                return Err(FerrumError::model(format!(
+                    "router layer {li}: out_features {} != num_experts {}",
+                    router.out_features(),
+                    cfg.num_experts
+                )));
+            }
+
+            let experts = ExpertStack::<B>::load_from_gguf(
+                gguf,
+                li,
+                cfg.num_experts,
+                cfg.base.hidden_size,
+                cfg.expert_intermediate_size,
+            )?;
+
+            moe_layers.push(Qwen3MoeLayerState { router, experts });
+        }
+
+        let final_norm_w = loader.load_tensor("model.norm.weight")?;
+        let lm_head = if loader.has_tensor("lm_head.weight") {
+            loader.load_linear("lm_head")?
+        } else {
+            // Tied embeddings — same as dense path.
+            tracing::info!(
+                "Qwen3MoeModel: tied embeddings — loading model.embed_tokens.weight as lm_head"
+            );
+            loader.load_linear("model.embed_tokens")?
+        };
+
+        let runtime_cfg = cfg.base.to_runtime();
+        Ok(Self {
+            cfg,
+            runtime_cfg,
+            embed,
+            attn_layers,
+            moe_layers,
+            final_norm_w,
+            lm_head,
+            rope,
+            scratch,
+            kv_caches: HashMap::new(),
+            kv_free_pool: Vec::new(),
+        })
+    }
+
+    pub(crate) fn ensure_scratch(&mut self, tokens: usize) {
+        if self.scratch.max_tokens < tokens {
+            {
+                let mut ctx = B::new_context();
+                B::reset_graph(&mut ctx);
+            }
+            self.scratch = Qwen3MoeScratch::alloc(&self.cfg, tokens);
+        }
+    }
+
+    pub(crate) fn ensure_kv(&mut self, cache_id: &str) {
+        if self.kv_caches.contains_key(cache_id) {
+            return;
+        }
+        let nkv = self.cfg.base.num_kv_heads;
+        let hd = self.cfg.base.head_dim;
+        let model_max = self.cfg.base.max_seq_len;
+        let max = std::env::var("FERRUM_KV_CAPACITY")
+            .ok()
+            .and_then(|s| s.parse::<usize>().ok())
+            .map(|cap| cap.min(model_max))
+            .unwrap_or(model_max);
+
+        let mut caches = self.kv_free_pool.pop().unwrap_or_else(|| {
+            (0..self.cfg.base.num_layers)
+                .map(|_| KvCache {
+                    k: B::alloc(nkv * max * hd),
+                    v: B::alloc(nkv * max * hd),
+                    len: 0,
+                    capacity: max,
+                    num_kv_heads: nkv,
+                    head_dim: hd,
+                })
+                .collect()
+        });
+        for c in caches.iter_mut() {
+            c.len = 0;
+        }
+        self.kv_caches.insert(cache_id.to_string(), caches);
+    }
+
+    /// Run one full transformer layer (attention + MoE FFN).
+    pub(crate) fn forward_layer(
+        &mut self,
+        ctx: &mut B::Context,
+        li: usize,
+        cache_id: &str,
+        residual: &mut B::Buffer,
+        pos_offset: usize,
+        tokens: usize,
+    ) -> Result<()> {
+        let cfg_base = &self.cfg.base;
+        let h = cfg_base.hidden_size;
+        let nh = cfg_base.num_heads;
+        let nkv = cfg_base.num_kv_heads;
+        let hd = cfg_base.head_dim;
+        let eps = cfg_base.rms_norm_eps;
+        let q_dim = nh * hd;
+        let kv_dim = nkv * hd;
+        let attn_layer = &self.attn_layers[li];
+        let moe_layer = &self.moe_layers[li];
+
+        let attn_t0 = if std::env::var("FERRUM_DECODE_OP_PROFILE").is_ok() {
+            B::sync(ctx);
+            Some(std::time::Instant::now())
+        } else {
+            None
+        };
+
+        // 1. Input RMSNorm
+        B::rms_norm(
+            ctx,
+            residual,
+            &attn_layer.input_ln_w,
+            eps,
+            &mut self.scratch.norm_out,
+            tokens,
+            h,
+        );
+
+        // 2. Fused QKV
+        attn_layer.qkv_proj.forward(
+            ctx,
+            &self.scratch.norm_out,
+            &mut self.scratch.qkv_out,
+            tokens,
+        );
+
+        // 3. split QKV
+        B::split_qkv(
+            ctx,
+            &self.scratch.qkv_out,
+            &mut self.scratch.q_buf,
+            &mut self.scratch.k_buf,
+            &mut self.scratch.v_buf,
+            tokens,
+            q_dim,
+            kv_dim,
+        );
+
+        // 4. QK-norm + RoPE → head-major Q/K, transpose-only V
+        let qk_mode: i32 = if cfg_base.has_qk_norm { 1 } else { 2 };
+        let dummy = &attn_layer.input_ln_w;
+        let q_norm_w = attn_layer.q_norm_w.as_ref().unwrap_or(dummy);
+        let k_norm_w = attn_layer.k_norm_w.as_ref().unwrap_or(dummy);
+        B::qk_norm_rope(
+            ctx,
+            &self.scratch.q_buf,
+            q_norm_w,
+            &self.rope.cos,
+            &self.rope.sin,
+            &mut self.scratch.q_head_major,
+            tokens,
+            nh,
+            hd,
+            pos_offset,
+            eps,
+            qk_mode,
+        );
+        B::qk_norm_rope(
+            ctx,
+            &self.scratch.k_buf,
+            k_norm_w,
+            &self.rope.cos,
+            &self.rope.sin,
+            &mut self.scratch.k_head_major,
+            tokens,
+            nkv,
+            hd,
+            pos_offset,
+            eps,
+            qk_mode,
+        );
+        B::qk_norm_rope(
+            ctx,
+            &self.scratch.v_buf,
+            dummy,
+            &self.rope.cos,
+            &self.rope.sin,
+            &mut self.scratch.v_head_major,
+            tokens,
+            nkv,
+            hd,
+            pos_offset,
+            eps,
+            0,
+        );
+
+        // 5. KV append + 6. flash attention.
+        let caches = self
+            .kv_caches
+            .get_mut(cache_id)
+            .expect("ensure_kv must be called before forward_layer");
+        let cache = &mut caches[li];
+        B::kv_cache_append_head_major(
+            ctx,
+            &mut cache.k,
+            &mut cache.v,
+            cache.len,
+            cache.capacity,
+            &self.scratch.k_head_major,
+            &self.scratch.v_head_major,
+            tokens,
+            nkv,
+            hd,
+        );
+        cache.len += tokens;
+        let kv_len = cache.len;
+        let kv_stride = cache.capacity;
+
+        let attn_cfg = ferrum_kernels::backend::AttnConfig {
+            num_heads: nh,
+            num_kv_heads: nkv,
+            head_dim: hd,
+            causal: true,
+            scale: 1.0 / (hd as f32).sqrt(),
+            kv_seq_stride: kv_stride,
+            sliding_window: cfg_base.sliding_window,
+        };
+        B::flash_attention(
+            ctx,
+            &self.scratch.q_head_major,
+            &cache.k,
+            &cache.v,
+            &mut self.scratch.attn_head_major_out,
+            1,
+            tokens,
+            kv_len,
+            pos_offset,
+            &attn_cfg,
+        );
+
+        if let Some(t0) = attn_t0 {
+            B::sync(ctx);
+            ATTN_TIME_US.fetch_add(
+                t0.elapsed().as_micros() as u64,
+                std::sync::atomic::Ordering::Relaxed,
+            );
+            ATTN_CALLS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        }
+
+        // 7. transpose head-major → token-major.
+        B::transpose_head_to_token(
+            ctx,
+            &self.scratch.attn_head_major_out,
+            &mut self.scratch.attn_flat,
+            tokens,
+            nh,
+            hd,
+        );
+
+        // 8. O-proj.
+        attn_layer.o_proj.forward(
+            ctx,
+            &self.scratch.attn_flat,
+            &mut self.scratch.o_proj_out,
+            tokens,
+        );
+
+        // 9. fused residual-add + post-attention RMSNorm.
+        B::fused_add_rms_norm(
+            ctx,
+            residual,
+            &self.scratch.o_proj_out,
+            &attn_layer.post_ln_w,
+            eps,
+            &mut self.scratch.norm_out,
+            tokens,
+            h,
+        );
+
+        // ── MoE FFN block ────────────────────────────────────────────
+        let moe_t0 = if std::env::var("FERRUM_DECODE_OP_PROFILE").is_ok() {
+            B::sync(ctx);
+            Some(std::time::Instant::now())
+        } else {
+            None
+        };
+
+        // 10. Router gemv: norm_out [tokens, hidden] → router_logits [tokens, num_experts]
+        moe_layer.router.forward(
+            ctx,
+            &self.scratch.norm_out,
+            &mut self.scratch.router_logits,
+            tokens,
+        );
+
+        // 11. Zero moe_out before scaled-add accumulate. The simplest
+        //     write-zero in our Backend trait is `from_slice(zeros)` →
+        //     copy_slice into moe_out, but that allocates a host vec
+        //     each call. Use scaled_add_inplace with scale=-1 on itself
+        //     to zero — works for any backend. Cheaper than a host
+        //     round-trip.
+        //
+        //     Edge case: if moe_out has NaN from previous run, -1*NaN
+        //     stays NaN; still fine because next iteration overwrites
+        //     row-wise via scaled-add-into-x_single → copy back.
+        //     Use copy_slice with a zero buffer for correctness.
+        let zeros = vec![0.0f32; tokens * h];
+        let zero_buf = B::from_slice(&zeros);
+        B::copy_slice(ctx, &zero_buf, 0, &mut self.scratch.moe_out, 0, tokens * h);
+
+        // 12. Per-(token, expert) MLP dispatch + weighted combine.
+        moe_forward::<B>(
+            ctx,
+            &self.scratch.norm_out,
+            &self.scratch.router_logits,
+            &mut self.scratch.moe_out,
+            tokens,
+            h,
+            self.cfg.expert_intermediate_size,
+            self.cfg.num_experts,
+            self.cfg.num_experts_per_tok,
+            self.cfg.norm_topk_prob,
+            &moe_layer.experts,
+            &mut self.scratch.x_single,
+            &mut self.scratch.gate_up_buf,
+            &mut self.scratch.silu_buf,
+            &mut self.scratch.down_buf,
+        )?;
+
+        // 13. residual += moe_out
+        B::add_inplace(ctx, residual, &self.scratch.moe_out, tokens * h);
+
+        if let Some(t0) = moe_t0 {
+            B::sync(ctx);
+            MOE_TIME_US.fetch_add(
+                t0.elapsed().as_micros() as u64,
+                std::sync::atomic::Ordering::Relaxed,
+            );
+            MOE_CALLS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        }
+
+        Ok(())
+    }
+
+    /// Prefill: process `tokens` prompt tokens, return last-token logits.
+    pub fn prefill_internal(&mut self, cache_id: &str, tokens: &[u32]) -> Vec<f32> {
+        let seq_len = tokens.len();
+        assert!(seq_len > 0);
+        self.ensure_scratch(seq_len);
+        self.ensure_kv(cache_id);
+
+        let pos_offset = self
+            .kv_caches
+            .get(cache_id)
+            .and_then(|layers| layers.first())
+            .map(|c| c.len)
+            .unwrap_or(0);
+
+        let h = self.cfg.base.hidden_size;
+        let vocab = self.cfg.base.vocab_size;
+        let mut ctx = B::new_context();
+
+        let mut residual = self
+            .scratch
+            .residual
+            .take()
+            .expect("scratch residual missing (previous call didn't restore)");
+        B::embedding_lookup(&mut ctx, &self.embed, tokens, &mut residual, h);
+
+        for li in 0..self.cfg.base.num_layers {
+            self.forward_layer(&mut ctx, li, cache_id, &mut residual, pos_offset, seq_len)
+                .expect("forward_layer");
+        }
+
+        // Last-token slice → final RMSNorm → lm_head.
+        B::copy_slice(
+            &mut ctx,
+            &residual,
+            (seq_len - 1) * h,
+            &mut self.scratch.last_hidden,
+            0,
+            h,
+        );
+        B::rms_norm(
+            &mut ctx,
+            &self.scratch.last_hidden,
+            &self.final_norm_w,
+            self.cfg.base.rms_norm_eps,
+            &mut self.scratch.last_normed,
+            1,
+            h,
+        );
+        self.lm_head.forward(
+            &mut ctx,
+            &self.scratch.last_normed,
+            &mut self.scratch.logits,
+            1,
+        );
+
+        B::sync(&mut ctx);
+        self.scratch.residual = Some(residual);
+        B::to_vec(&self.scratch.logits, vocab)
+    }
+
+    /// Decode: 1 token at position `pos`, return next-step logits.
+    pub fn decode_internal(&mut self, cache_id: &str, token: u32, pos: u32) -> Vec<f32> {
+        self.ensure_scratch(1);
+        self.ensure_kv(cache_id);
+
+        let h = self.cfg.base.hidden_size;
+        let vocab = self.cfg.base.vocab_size;
+        let mut ctx = B::new_context();
+
+        let mut residual = self
+            .scratch
+            .residual
+            .take()
+            .expect("scratch residual missing (previous call didn't restore)");
+        B::embedding_lookup(&mut ctx, &self.embed, &[token], &mut residual, h);
+
+        for li in 0..self.cfg.base.num_layers {
+            self.forward_layer(&mut ctx, li, cache_id, &mut residual, pos as usize, 1)
+                .expect("forward_layer");
+        }
+
+        B::rms_norm(
+            &mut ctx,
+            &residual,
+            &self.final_norm_w,
+            self.cfg.base.rms_norm_eps,
+            &mut self.scratch.last_normed,
+            1,
+            h,
+        );
+        self.lm_head.forward(
+            &mut ctx,
+            &self.scratch.last_normed,
+            &mut self.scratch.logits,
+            1,
+        );
+
+        B::sync(&mut ctx);
+        self.scratch.residual = Some(residual);
+        B::to_vec(&self.scratch.logits, vocab)
+    }
+}
+
+impl<B: Backend> DecoderOnlyLLM for Qwen3MoeModel<B> {
+    fn config(&self) -> &LlmRuntimeConfig {
+        &self.runtime_cfg
+    }
+
+    fn prefill(&mut self, cache_id: &str, tokens: &[u32]) -> Vec<f32> {
+        self.prefill_internal(cache_id, tokens)
+    }
+
+    fn decode(&mut self, cache_id: &str, token: u32, pos: u32) -> Vec<f32> {
+        self.decode_internal(cache_id, token, pos)
+    }
+
+    fn release(&mut self, cache_id: &str) {
+        let mut ctx = B::new_context();
+        B::sync(&mut ctx);
+        B::reset_graph(&mut ctx);
+        B::sync(&mut ctx);
+        if let Some(caches) = self.kv_caches.remove(cache_id) {
+            self.kv_free_pool.push(caches);
+        }
+    }
+
+    fn reset(&mut self) {
+        let mut ctx = B::new_context();
+        B::sync(&mut ctx);
+        B::reset_graph(&mut ctx);
+        B::sync(&mut ctx);
+        self.kv_caches.clear();
+        self.kv_free_pool.clear();
+    }
+}
+
+/// Build a stub Linear<B> with the given shape but zero weights. Used to
+/// fill the dense `gate_up_proj` / `down_proj` slots in `LlamaFamilyLayer`
+/// for MoE models — those slots are never invoked because the MoE FFN
+/// path runs through `moe_layer.experts` instead. The stub's only purpose
+/// is to satisfy the struct's type signature with minimal memory cost.
+fn stub_linear<B: Backend>(
+    out_features: usize,
+    in_features: usize,
+) -> Box<dyn ferrum_quantization::Linear<B>> {
+    // Zero-init: out_features * in_features f32. For a 30B-A3B layer
+    // this is 2*768*2048 = 3.1M f32 = 12 MB → fine; per-layer overhead
+    // ≈ 12 MB × 48 = 576 MB. Marginal vs the experts (~16 GB).
+    let zeros = vec![0.0f32; out_features * in_features];
+    Box::new(ferrum_quantization::DenseLinear::<B>::from_rows(
+        &zeros,
+        out_features,
+        in_features,
+    ))
+}
+
+fn build_rope_cache<B: Backend>(cfg: &LlamaFamilyConfig) -> RopeCache<B> {
+    let hd = cfg.head_dim;
+    let half = hd / 2;
+    let max = cfg.max_seq_len;
+    let mut cos = vec![0.0f32; max * half];
+    let mut sin = vec![0.0f32; max * half];
+    for pos in 0..max {
+        for i in 0..half {
+            let freq = 1.0f64 / cfg.rope_theta.powf((2 * i) as f64 / hd as f64);
+            let angle = pos as f64 * freq;
+            cos[pos * half + i] = angle.cos() as f32;
+            sin[pos * half + i] = angle.sin() as f32;
+        }
+    }
+    RopeCache {
+        cos: B::from_slice(&cos),
+        sin: B::from_slice(&sin),
+    }
+}

--- a/crates/ferrum-models/src/moe/dispatch.rs
+++ b/crates/ferrum-models/src/moe/dispatch.rs
@@ -21,12 +21,13 @@
 
 use std::path::Path;
 
+use candle_core::quantized::GgmlDType;
 use candle_core::{Device, Result as CandleResult};
 use ferrum_kernels::backend::cpu::CpuBackend;
-use ferrum_kernels::backend::Backend;
+use ferrum_kernels::backend::{Backend, GgufQuantType};
 use ferrum_kernels::Linear;
 use ferrum_quantization::gguf::GgufFile;
-use ferrum_quantization::DenseLinear;
+use ferrum_quantization::{DenseLinear, QuantLinear};
 use ferrum_types::{FerrumError, Result};
 
 use crate::moe::router::RouterOutput;
@@ -110,7 +111,23 @@ impl<B: Backend> ExpertStack<B> {
 
     /// Load all experts for one MoE layer from a GGUF file. Names follow
     /// the GGUF convention: `blk.{layer_idx}.ffn_{gate,up,down}_exps.weight`.
-    /// Tensors are dequantised on CPU (Phase 2 dispatch is CPU-only).
+    ///
+    /// The loader picks between two strategies based on the on-disk dtype
+    /// of the expert tensors:
+    ///
+    ///   - **Quantised path** (Q4_K / Q6_K only): each expert's
+    ///     `gate || up` becomes a single `QuantLinear<B>` (Fused
+    ///     QuantStore — gate + up share `n_cols = hidden`), and `down` is
+    ///     a plain `QuantLinear<B>`. Block bytes stay compressed in
+    ///     backend memory; per-call dequant happens inside `gemm_quant`.
+    ///   - **Dense fallback** (everything else, e.g. F32 / F16 / Q5_K
+    ///     until a kernel ships): eager-dequant to fp32 and wrap
+    ///     `DenseLinear<B>`. Memory inflates ~7× vs Q4_K_M but the
+    ///     algorithm is correctness-equivalent and this is the path the
+    ///     synthetic-MoE test fixtures need.
+    ///
+    /// The runtime dispatcher (`moe_forward<B>`) doesn't see which path
+    /// was taken — it just calls `Linear::forward` per (token, expert).
     pub fn load_from_gguf(
         gguf: &GgufFile,
         layer_idx: usize,
@@ -118,6 +135,23 @@ impl<B: Backend> ExpertStack<B> {
         hidden_size: usize,
         expert_intermediate: usize,
     ) -> Result<Self> {
+        if let Some(quant) = Self::try_load_quantised(
+            gguf,
+            layer_idx,
+            num_experts,
+            hidden_size,
+            expert_intermediate,
+        )? {
+            if std::env::var("FERRUM_MOE_LOAD_TRACE").is_ok() {
+                eprintln!("[moe-load] layer {layer_idx} → quantised expert path");
+            }
+            return Ok(quant);
+        }
+
+        if std::env::var("FERRUM_MOE_LOAD_TRACE").is_ok() {
+            eprintln!("[moe-load] layer {layer_idx} → eager fp32 dense fallback ⚠");
+        }
+
         let device = Device::Cpu;
         let gate = read_dequant_flat(
             gguf,
@@ -142,6 +176,122 @@ impl<B: Backend> ExpertStack<B> {
             hidden_size,
             expert_intermediate,
         )
+    }
+
+    /// Attempt the quantised path. Returns `Ok(None)` if any of the three
+    /// tensors isn't a supported k-quant flavour (Q4_K / Q6_K) or if the
+    /// shape doesn't match the expected per-expert tile size — caller
+    /// then takes the eager-dequant fallback. Returns `Err` only on a
+    /// genuine load failure (missing tensor, byte-count mismatch).
+    fn try_load_quantised(
+        gguf: &GgufFile,
+        layer_idx: usize,
+        num_experts: usize,
+        hidden_size: usize,
+        expert_intermediate: usize,
+    ) -> Result<Option<Self>> {
+        let device = Device::Cpu;
+
+        let gate_name = format!("blk.{layer_idx}.ffn_gate_exps.weight");
+        let up_name = format!("blk.{layer_idx}.ffn_up_exps.weight");
+        let down_name = format!("blk.{layer_idx}.ffn_down_exps.weight");
+
+        // Inspect tensor info up front — if any tensor isn't a k-quant
+        // flavour the backend can dispatch on, bail to the dense path
+        // before paying the byte-read cost.
+        let gate_kind = match quant_kind(gguf, &gate_name)? {
+            Some(k) => k,
+            None => return Ok(None),
+        };
+        let up_kind = match quant_kind(gguf, &up_name)? {
+            Some(k) => k,
+            None => return Ok(None),
+        };
+        let down_kind = match quant_kind(gguf, &down_name)? {
+            Some(k) => k,
+            None => return Ok(None),
+        };
+
+        // Read the three 3-D quantised tensors. `qt.data()` exposes the
+        // raw block-byte payload — the same bytes that live on disk.
+        let gate_qt = gguf
+            .read_tensor(&gate_name, &device)
+            .map_err(candle_to_ferrum)?;
+        let up_qt = gguf
+            .read_tensor(&up_name, &device)
+            .map_err(candle_to_ferrum)?;
+        let down_qt = gguf
+            .read_tensor(&down_name, &device)
+            .map_err(candle_to_ferrum)?;
+        let gate_bytes = gate_qt.data().map_err(candle_to_ferrum)?;
+        let up_bytes = up_qt.data().map_err(candle_to_ferrum)?;
+        let down_bytes = down_qt.data().map_err(candle_to_ferrum)?;
+        let gate_bytes = gate_bytes.as_ref();
+        let up_bytes = up_bytes.as_ref();
+        let down_bytes = down_bytes.as_ref();
+
+        // Per-expert byte stride for each tensor. The 3-D layout is
+        // contiguous, [num_experts, rows, cols] row-major, so each
+        // expert's slab is exactly `total_bytes / num_experts`.
+        let gate_per = block_bytes_for(
+            gate_kind,
+            expert_intermediate * hidden_size,
+            "ffn_gate_exps",
+        )?;
+        let up_per = block_bytes_for(up_kind, expert_intermediate * hidden_size, "ffn_up_exps")?;
+        let down_per = block_bytes_for(
+            down_kind,
+            hidden_size * expert_intermediate,
+            "ffn_down_exps",
+        )?;
+
+        check_size(
+            gate_bytes.len(),
+            num_experts * gate_per,
+            "ffn_gate_exps bytes",
+        )?;
+        check_size(up_bytes.len(), num_experts * up_per, "ffn_up_exps bytes")?;
+        check_size(
+            down_bytes.len(),
+            num_experts * down_per,
+            "ffn_down_exps bytes",
+        )?;
+
+        let mut gate_up: Vec<Box<dyn Linear<B>>> = Vec::with_capacity(num_experts);
+        let mut down: Vec<Box<dyn Linear<B>>> = Vec::with_capacity(num_experts);
+
+        for e in 0..num_experts {
+            let g_slice = &gate_bytes[e * gate_per..(e + 1) * gate_per];
+            let u_slice = &up_bytes[e * up_per..(e + 1) * up_per];
+            let d_slice = &down_bytes[e * down_per..(e + 1) * down_per];
+
+            // gate || up — fused QuantStore (rows = 2*expert_inter, cols = hidden).
+            // `from_gguf_fused` requires the parts share `in_features` (cols).
+            let parts: [(GgufQuantType, &[u8], usize); 2] = [
+                (gate_kind, g_slice, expert_intermediate),
+                (up_kind, u_slice, expert_intermediate),
+            ];
+            let gate_up_e = match QuantLinear::<B>::from_gguf_fused(&parts, hidden_size) {
+                Ok(q) => q,
+                // Backend doesn't support the Fused variant — fall back
+                // entirely. The caller will retry through the dense path.
+                Err(_) => return Ok(None),
+            };
+            gate_up.push(Box::new(gate_up_e) as Box<dyn Linear<B>>);
+
+            let down_e = match QuantLinear::<B>::from_gguf_bytes(
+                down_kind,
+                d_slice,
+                hidden_size,
+                expert_intermediate,
+            ) {
+                Ok(q) => q,
+                Err(_) => return Ok(None),
+            };
+            down.push(Box::new(down_e) as Box<dyn Linear<B>>);
+        }
+
+        Ok(Some(Self { gate_up, down }))
     }
 
     /// Convenience: open a GGUF and load layer `layer_idx`. The GGUF
@@ -173,6 +323,125 @@ impl<B: Backend> ExpertStack<B> {
         );
         self.gate_up.len()
     }
+}
+
+/// Backend-generic MoE forward.
+///
+/// Equivalent of [`moe_forward_cpu`] but parameterised on `B: Backend`
+/// so Metal / CUDA paths can dispatch the same per-(token, expert) loop
+/// using their own kernels for the gemv + silu + scaled-add primitives.
+///
+/// The caller pre-supplies all scratch buffers — this function does no
+/// allocation, which matters because it's invoked from inside the
+/// transformer's `forward_layer` where allocation during graph capture
+/// (CUDA) would corrupt the captured graph.
+///
+/// Buffer contract (lengths, sized at scratch alloc time):
+///   - `x`            : `[batch * hidden]` post-RMSNorm activations
+///   - `router_logits`: `[batch * num_experts]` raw router output
+///   - `out`          : `[batch * hidden]` — caller is responsible for
+///                      zeroing this before the call (we use scaled-add
+///                      to accumulate, not assign)
+///   - `x_single`     : `[hidden]` per-token slice scratch
+///   - `gate_up_buf`  : `[2 * expert_inter]` per-(token, expert) gemv out
+///   - `silu_buf`     : `[expert_inter]`
+///   - `down_buf`     : `[hidden]` per-(token, expert) accumulate src
+///
+/// Routing (softmax + top-K + optional renorm) runs host-side using
+/// `B::to_vec(router_logits, …)` — the routing computation is small
+/// (`batch * num_experts` floats) and the top-K is a sort, both of
+/// which dwarf in cost any plausible host↔device transfer.
+#[allow(clippy::too_many_arguments)]
+pub fn moe_forward<B: Backend>(
+    ctx: &mut B::Context,
+    x: &B::Buffer,
+    router_logits: &B::Buffer,
+    out: &mut B::Buffer,
+    batch: usize,
+    hidden_size: usize,
+    expert_intermediate: usize,
+    num_experts: usize,
+    top_k: usize,
+    norm_topk_prob: bool,
+    experts: &ExpertStack<B>,
+    x_single: &mut B::Buffer,
+    gate_up_buf: &mut B::Buffer,
+    silu_buf: &mut B::Buffer,
+    down_buf: &mut B::Buffer,
+) -> Result<()> {
+    let n_experts = experts.num_experts();
+    if n_experts != num_experts {
+        return Err(FerrumError::model(format!(
+            "moe_forward: experts.num_experts() = {n_experts} != cfg.num_experts = {num_experts}"
+        )));
+    }
+
+    // Routing on host. Sized batch*num_experts (e.g. 512*128 = 64k floats
+    // per layer for Qwen3-30B-A3B prefill); cheap relative to the per-
+    // expert gemvs that follow.
+    B::sync(ctx);
+    let logits_host = B::to_vec(router_logits, batch * num_experts);
+    let route_out =
+        crate::moe::router::route(&logits_host, batch, num_experts, top_k, norm_topk_prob);
+
+    for b in 0..batch {
+        // x[b] → x_single
+        B::copy_slice(ctx, x, b * hidden_size, x_single, 0, hidden_size);
+
+        for k in 0..top_k {
+            let pair = b * top_k + k;
+            let expert_id = route_out.expert_ids[pair] as usize;
+            let weight = route_out.expert_weights[pair];
+            if expert_id >= num_experts {
+                return Err(FerrumError::model(format!(
+                    "moe_forward: routed expert {expert_id} >= num_experts {num_experts}"
+                )));
+            }
+
+            // Fused gate||up gemv → [2 * expert_inter]
+            experts.gate_up[expert_id].forward(ctx, x_single, gate_up_buf, 1);
+
+            // SiLU(gate) * up → [expert_inter]
+            B::fused_silu_mul_split(ctx, gate_up_buf, silu_buf, 1, expert_intermediate);
+
+            // down gemv → [hidden]
+            experts.down[expert_id].forward(ctx, silu_buf, down_buf, 1);
+
+            // out[b] += weight * down_buf. Slice-targeted scaled add
+            // requires writing into a sub-range of `out`; we go through
+            // a per-token scratch and copy back.
+            //
+            // For Metal: `scaled_add_inplace` writes into the front of
+            // `out` only. To target row `b`, we copy down_buf into a
+            // properly-offset temp, but doing N copies per layer is
+            // wasteful. Instead, we exploit `copy_slice` to first pull
+            // out the existing row, scaled-add into it, then push back.
+            //
+            // Simpler: just use a per-row B::Buffer view via copy_slice
+            // semantics. Because top_k==1 is the common case for the
+            // synthetic tests and decode is m=1 anyway, we use
+            // copy_slice to extract row b → x_single (reusing it as
+            // a row accumulator), scaled_add into x_single, then
+            // copy_slice back. (`x_single` has sufficient capacity
+            // — it's sized [hidden].)
+            //
+            // Note: x_single is being aliased here as the accumulator
+            // for the duration of this pair — which is fine because we
+            // just consumed it (gate_up_buf is fully derived from
+            // x_single's earlier value).
+            B::copy_slice(ctx, out, b * hidden_size, x_single, 0, hidden_size);
+            B::scaled_add_inplace(ctx, x_single, down_buf, weight, hidden_size);
+            B::copy_slice(ctx, x_single, 0, out, b * hidden_size, hidden_size);
+
+            // Restore x_single to the original token's hidden state for
+            // the next k iteration's gate_up gemv. (Could be optimised
+            // away when top_k == 1 by skipping the second pull, but
+            // measure first.)
+            B::copy_slice(ctx, x, b * hidden_size, x_single, 0, hidden_size);
+        }
+    }
+
+    Ok(())
 }
 
 /// Run MoE forward on CPU.
@@ -278,6 +547,45 @@ fn check_size(actual: usize, expected: usize, label: &str) -> Result<()> {
         )));
     }
     Ok(())
+}
+
+/// Map candle's `GgmlDType` to the kernel-side `GgufQuantType` for the
+/// dtypes a backend can dispatch on. Returns `None` for any other dtype
+/// (callers fall back to eager dequant).
+fn quant_kind(gguf: &GgufFile, name: &str) -> Result<Option<GgufQuantType>> {
+    let info = gguf.tensor_info(name).ok_or_else(|| {
+        FerrumError::model(format!("ExpertStack: tensor info missing for '{name}'"))
+    })?;
+    Ok(match info.ggml_dtype {
+        GgmlDType::Q4K => Some(GgufQuantType::Q4K),
+        GgmlDType::Q6K => Some(GgufQuantType::Q6K),
+        _ => None,
+    })
+}
+
+/// Per-expert block-byte count for a given k-quant flavour and element
+/// count. Q4_K = 144 B / 256 elems, Q6_K = 210 B / 256 elems. Errors if
+/// `n_elems` is not a multiple of the super-block size (256) — a Q-quant
+/// invariant.
+fn block_bytes_for(kind: GgufQuantType, n_elems: usize, label: &str) -> Result<usize> {
+    const QK_K: usize = 256;
+    if n_elems % QK_K != 0 {
+        return Err(FerrumError::model(format!(
+            "ExpertStack {label}: per-expert element count {n_elems} not a multiple of {QK_K}"
+        )));
+    }
+    let block_bytes = match kind {
+        GgufQuantType::Q4K => 144,
+        GgufQuantType::Q6K => 210,
+        // Other k-quants are filtered out earlier via `quant_kind`; reaching here
+        // with one would be a programming error.
+        other => {
+            return Err(FerrumError::model(format!(
+                "ExpertStack {label}: unsupported k-quant flavour {other:?}"
+            )))
+        }
+    };
+    Ok((n_elems / QK_K) * block_bytes)
 }
 
 fn read_dequant_flat(gguf: &GgufFile, name: &str, device: &Device) -> Result<Vec<f32>> {

--- a/crates/ferrum-models/src/moe/mod.rs
+++ b/crates/ferrum-models/src/moe/mod.rs
@@ -17,6 +17,6 @@ pub mod dispatch;
 pub mod layer;
 pub mod router;
 
-pub use dispatch::{moe_forward_cpu, ExpertStack};
+pub use dispatch::{moe_forward, moe_forward_cpu, ExpertStack};
 pub use layer::Qwen3MoeLayer;
 pub use router::{route, RouterOutput};

--- a/crates/ferrum-models/tests/moe_layer_test.rs
+++ b/crates/ferrum-models/tests/moe_layer_test.rs
@@ -241,21 +241,23 @@ fn top_k_one_with_strong_router_picks_dominant_expert() {
     // Expert 0 gate: zeros. Expert 1 gate: 7 * I_2.
     let mut gate_data = vec![0.0_f32; n_experts * ffn * hidden];
     // Expert 1 gate (offset = 1 * ffn * hidden = 4): identity*7
-    gate_data[4 + 0 * 2 + 0] = 7.0; // [1, 0, 0]
-    gate_data[4 + 1 * 2 + 1] = 7.0; // [1, 1, 1]
+    // Index layout intentional: `[expert_offset + ffn_idx * hidden + hidden_idx]`.
+    // The first row uses ffn_idx=0, hidden_idx=0 → offset 0; second uses (1,1) → 3.
+    gate_data[4] = 7.0; // [expert=1, ffn=0, hidden=0]
+    gate_data[4 + 1 * 2 + 1] = 7.0; // [expert=1, ffn=1, hidden=1]
     let gate_t = Tensor::from_vec(gate_data, (n_experts, ffn, hidden), &device).unwrap();
     let gate_qt = QTensor::quantize(&gate_t, GgmlDType::F32).unwrap();
 
     // Same for up_exps
     let mut up_data = vec![0.0_f32; n_experts * ffn * hidden];
-    up_data[4 + 0 * 2 + 0] = 7.0;
+    up_data[4] = 7.0;
     up_data[4 + 1 * 2 + 1] = 7.0;
     let up_t = Tensor::from_vec(up_data, (n_experts, ffn, hidden), &device).unwrap();
     let up_qt = QTensor::quantize(&up_t, GgmlDType::F32).unwrap();
 
     // down_exps shape [E=2, hidden=2, ffn=2]
     let mut down_data = vec![0.0_f32; n_experts * hidden * ffn];
-    down_data[4 + 0 * 2 + 0] = 1.0; // expert 1 down identity
+    down_data[4] = 1.0; // expert 1 down identity, [expert=1, hidden=0, ffn=0]
     down_data[4 + 1 * 2 + 1] = 1.0;
     let down_t = Tensor::from_vec(down_data, (n_experts, hidden, ffn), &device).unwrap();
     let down_qt = QTensor::quantize(&down_t, GgmlDType::F32).unwrap();

--- a/crates/ferrum-models/tests/qwen3_moe_model_test.rs
+++ b/crates/ferrum-models/tests/qwen3_moe_model_test.rs
@@ -1,0 +1,234 @@
+//! `Qwen3MoeModel<B>` integration smoke test: load from a synthesized
+//! Qwen3-MoE-shaped GGUF, run a small prefill + decode sequence on CPU,
+//! verify the model state machine is coherent (no NaN logits, no panics
+//! across multi-layer dispatch, KV cache grows by one each decode step).
+//!
+//! This is intentionally architectural — not a numerical-parity test
+//! against a reference implementation. Numerical correctness of the MoE
+//! primitive is covered by `moe_dispatch_test.rs`. What's new here is
+//! the wiring between attention + router + expert dispatch + LM head.
+
+use std::io::{Cursor, Write};
+use std::sync::Arc;
+
+use candle_core::quantized::gguf_file::{self, Value};
+use candle_core::quantized::{GgmlDType, QTensor};
+use candle_core::{Device, Tensor};
+use ferrum_kernels::backend::cpu::CpuBackend;
+use ferrum_models::common::DecoderOnlyLLM;
+use ferrum_models::models::Qwen3MoeModel;
+use ferrum_models::moe_config::Qwen3MoeConfig;
+use ferrum_quantization::gguf::{GgufFile, GgufLoader};
+
+// Tiny MoE shape — enough exercise for the full forward path.
+const VOCAB: usize = 16;
+const HIDDEN: usize = 8;
+const NUM_HEADS: usize = 2;
+const HEAD_DIM: usize = 4; // hidden / heads
+const NUM_KV_HEADS: usize = 2;
+const NUM_LAYERS: usize = 2;
+const NUM_EXPERTS: usize = 4;
+const TOP_K: usize = 2;
+const EXPERT_FFN: usize = 8;
+
+fn ramp_2d(rows: usize, cols: usize, base: f32) -> QTensor {
+    let device = Device::Cpu;
+    let n = rows * cols;
+    let raw: Vec<f32> = (0..n).map(|i| base + (i as f32) * 0.001).collect();
+    let t = Tensor::from_vec(raw, (rows, cols), &device).unwrap();
+    QTensor::quantize(&t, GgmlDType::F32).unwrap()
+}
+
+fn ramp_3d(d0: usize, d1: usize, d2: usize, base: f32) -> QTensor {
+    let device = Device::Cpu;
+    let n = d0 * d1 * d2;
+    let raw: Vec<f32> = (0..n).map(|i| base + (i as f32) * 0.001).collect();
+    let t = Tensor::from_vec(raw, (d0, d1, d2), &device).unwrap();
+    QTensor::quantize(&t, GgmlDType::F32).unwrap()
+}
+
+fn ramp_1d(n: usize, base: f32) -> QTensor {
+    let device = Device::Cpu;
+    let raw: Vec<f32> = (0..n).map(|i| base + (i as f32) * 0.01).collect();
+    let t = Tensor::from_vec(raw, n, &device).unwrap();
+    QTensor::quantize(&t, GgmlDType::F32).unwrap()
+}
+
+/// Build a Qwen3-MoE-shaped GGUF with all the metadata `Qwen3MoeConfig::from_gguf`
+/// reads, plus per-layer attention + MoE tensors.
+fn build_synth_moe_gguf() -> tempfile::NamedTempFile {
+    // Top-level
+    let token_embd = ramp_2d(VOCAB, HIDDEN, 0.0);
+    let output_norm = ramp_1d(HIDDEN, 0.5);
+    let output = ramp_2d(VOCAB, HIDDEN, 1.0);
+
+    // Per-layer tensors: attention dense + MoE-specific.
+    // We construct two layers worth of (attn_norm, attn_q/k/v, attn_output,
+    // ffn_norm, router, gate_exps, up_exps, down_exps).
+    let mut tensors: Vec<(String, QTensor)> = Vec::new();
+    tensors.push(("token_embd.weight".into(), token_embd));
+    tensors.push(("output_norm.weight".into(), output_norm));
+    tensors.push(("output.weight".into(), output));
+
+    for li in 0..NUM_LAYERS {
+        let base = (li + 1) as f32;
+        let attn_norm = ramp_1d(HIDDEN, 0.6 * base);
+        let attn_q = ramp_2d(NUM_HEADS * HEAD_DIM, HIDDEN, 2.0 * base);
+        let attn_k = ramp_2d(NUM_KV_HEADS * HEAD_DIM, HIDDEN, 3.0 * base);
+        let attn_v = ramp_2d(NUM_KV_HEADS * HEAD_DIM, HIDDEN, 4.0 * base);
+        let attn_output = ramp_2d(HIDDEN, NUM_HEADS * HEAD_DIM, 5.0 * base);
+        let ffn_norm = ramp_1d(HIDDEN, 0.7 * base);
+
+        let router = ramp_2d(NUM_EXPERTS, HIDDEN, 8.0 * base);
+        let gate_exps = ramp_3d(NUM_EXPERTS, EXPERT_FFN, HIDDEN, 9.0 * base);
+        let up_exps = ramp_3d(NUM_EXPERTS, EXPERT_FFN, HIDDEN, 10.0 * base);
+        let down_exps = ramp_3d(NUM_EXPERTS, HIDDEN, EXPERT_FFN, 11.0 * base);
+
+        tensors.push((format!("blk.{li}.attn_norm.weight"), attn_norm));
+        tensors.push((format!("blk.{li}.attn_q.weight"), attn_q));
+        tensors.push((format!("blk.{li}.attn_k.weight"), attn_k));
+        tensors.push((format!("blk.{li}.attn_v.weight"), attn_v));
+        tensors.push((format!("blk.{li}.attn_output.weight"), attn_output));
+        tensors.push((format!("blk.{li}.ffn_norm.weight"), ffn_norm));
+        tensors.push((format!("blk.{li}.ffn_gate_inp.weight"), router));
+        tensors.push((format!("blk.{li}.ffn_gate_exps.weight"), gate_exps));
+        tensors.push((format!("blk.{li}.ffn_up_exps.weight"), up_exps));
+        tensors.push((format!("blk.{li}.ffn_down_exps.weight"), down_exps));
+    }
+
+    // Metadata — `Qwen3MoeConfig::from_gguf` keys.
+    let arch = Value::String("qwen3moe".to_string());
+    let block_count = Value::U32(NUM_LAYERS as u32);
+    let embed_len = Value::U32(HIDDEN as u32);
+    let head_cnt = Value::U32(NUM_HEADS as u32);
+    let head_cnt_kv = Value::U32(NUM_KV_HEADS as u32);
+    let rms_eps = Value::F32(1e-5);
+    let ctx_len = Value::U32(64);
+    let rope_theta = Value::F32(10_000.0);
+    let vocab_sz = Value::U32(VOCAB as u32);
+    let expert_count = Value::U32(NUM_EXPERTS as u32);
+    let expert_used = Value::U32(TOP_K as u32);
+    let expert_ffn = Value::U32(EXPERT_FFN as u32);
+    let norm_topk = Value::Bool(true);
+
+    let metadata: Vec<(&str, &Value)> = vec![
+        ("general.architecture", &arch),
+        ("qwen3moe.block_count", &block_count),
+        ("qwen3moe.embedding_length", &embed_len),
+        ("qwen3moe.attention.head_count", &head_cnt),
+        ("qwen3moe.attention.head_count_kv", &head_cnt_kv),
+        ("qwen3moe.attention.layer_norm_rms_epsilon", &rms_eps),
+        ("qwen3moe.context_length", &ctx_len),
+        ("qwen3moe.rope.freq_base", &rope_theta),
+        ("qwen3moe.vocab_size", &vocab_sz),
+        ("qwen3moe.expert_count", &expert_count),
+        ("qwen3moe.expert_used_count", &expert_used),
+        ("qwen3moe.expert_feed_forward_length", &expert_ffn),
+        ("qwen3moe.expert_norm_topk_prob", &norm_topk),
+    ];
+    let tensors_view: Vec<(&str, &QTensor)> =
+        tensors.iter().map(|(n, t)| (n.as_str(), t)).collect();
+
+    let mut buf: Vec<u8> = Vec::new();
+    {
+        let mut cursor = Cursor::new(&mut buf);
+        gguf_file::write(&mut cursor, &metadata, &tensors_view).unwrap();
+    }
+    let mut tmp = tempfile::NamedTempFile::new().unwrap();
+    tmp.write_all(&buf).unwrap();
+    tmp.flush().unwrap();
+    tmp
+}
+
+/// Building blocks of `Qwen3MoeModel::new` plumb through to construction.
+/// Loads + asserts dimensions are coherent before any forward call.
+fn build_model_for_test() -> Qwen3MoeModel<CpuBackend> {
+    let tmp = build_synth_moe_gguf();
+    let gguf = GgufFile::open(tmp.path()).unwrap();
+    let cfg = Qwen3MoeConfig::from_gguf(&gguf).unwrap();
+    let gguf_arc = Arc::new(gguf);
+    let loader = GgufLoader::<CpuBackend>::from_file(gguf_arc.clone());
+    Qwen3MoeModel::<CpuBackend>::new(cfg, &loader, &gguf_arc).unwrap()
+}
+
+#[test]
+fn model_loads_from_synth_gguf() {
+    let model = build_model_for_test();
+    assert_eq!(model.cfg.base.num_layers, NUM_LAYERS);
+    assert_eq!(model.cfg.base.hidden_size, HIDDEN);
+    assert_eq!(model.cfg.num_experts, NUM_EXPERTS);
+    assert_eq!(model.cfg.num_experts_per_tok, TOP_K);
+    assert_eq!(model.cfg.expert_intermediate_size, EXPERT_FFN);
+    // One MoE state per layer + matching attention layers.
+    assert_eq!(model.attn_layers.len(), NUM_LAYERS);
+    assert_eq!(model.moe_layers.len(), NUM_LAYERS);
+    // Each MoE layer has num_experts experts.
+    for l in &model.moe_layers {
+        assert_eq!(l.experts.num_experts(), NUM_EXPERTS);
+    }
+    // Router shape sanity.
+    let r0 = &model.moe_layers[0].router;
+    assert_eq!(r0.in_features(), HIDDEN);
+    assert_eq!(r0.out_features(), NUM_EXPERTS);
+}
+
+#[test]
+fn prefill_returns_finite_logits() {
+    let mut model = build_model_for_test();
+    // 3-token prompt, all valid token ids.
+    let tokens: Vec<u32> = vec![1, 2, 3];
+    let logits = model.prefill("test", &tokens);
+    assert_eq!(logits.len(), VOCAB);
+    for (i, v) in logits.iter().enumerate() {
+        assert!(v.is_finite(), "non-finite logit at vocab index {i}: {v}");
+    }
+}
+
+#[test]
+fn decode_advances_kv_cache_one_per_step() {
+    let mut model = build_model_for_test();
+    let tokens: Vec<u32> = vec![1, 2];
+    let _ = model.prefill("seq1", &tokens);
+    // After 2-token prefill, kv cache len should be 2.
+    let kv_len_after_prefill = model
+        .kv_caches
+        .get("seq1")
+        .and_then(|layers| layers.first())
+        .map(|c| c.len)
+        .unwrap();
+    assert_eq!(kv_len_after_prefill, tokens.len());
+
+    // Decode 3 tokens. Each step should grow the cache by one.
+    for step in 0..3 {
+        let pos = (kv_len_after_prefill + step) as u32;
+        let logits = model.decode("seq1", 5 + step as u32, pos);
+        assert_eq!(logits.len(), VOCAB);
+        let new_len = model
+            .kv_caches
+            .get("seq1")
+            .and_then(|layers| layers.first())
+            .map(|c| c.len)
+            .unwrap();
+        assert_eq!(
+            new_len,
+            kv_len_after_prefill + step + 1,
+            "kv cache length wrong at decode step {step}"
+        );
+    }
+}
+
+#[test]
+fn release_and_reset_clear_kv_caches() {
+    let mut model = build_model_for_test();
+    let _ = model.prefill("a", &[1, 2]);
+    let _ = model.prefill("b", &[3, 4]);
+    assert!(model.kv_caches.contains_key("a"));
+    assert!(model.kv_caches.contains_key("b"));
+
+    model.release("a");
+    assert!(!model.kv_caches.contains_key("a"));
+    assert!(model.kv_caches.contains_key("b"));
+
+    model.reset();
+    assert!(model.kv_caches.is_empty());
+}


### PR DESCRIPTION
## Summary

Build a Qwen3-MoE family decoder. Targets Qwen3-30B-A3B Q4_K_M end-to-end on a 32 GB Mac. Mirrors `LlamaFamilyModel<B>` for attention, swaps the dense FFN for a router + per-(token, expert) MLP dispatch.

- **`Qwen3MoeModel<B>`** new in `crates/ferrum-models/src/models/qwen3_moe.rs`. Same attention path as dense (RMSNorm → fused QKV → QK-norm + RoPE → KV-append → flash attn → O-proj → fused-add-rms-norm). FFN path is router gemv → host top-K + softmax → per-(token, expert) gate_up + silu_mul + down + scaled-add into output row.
- **Quantised expert storage**: `ExpertStack::load_from_gguf` now slices the on-disk 3-D `ffn_{gate,up,down}_exps.weight` tensors byte-wise into `QuantLinear<B>` per expert (Fused gate||up + plain down). Falls back to eager fp32 dense for unsupported dtypes (e.g. F32 in test fixtures). Without this, an eager-fp32 expert stack for Qwen3-30B-A3B would be ~110 GB.
- **`Backend::scaled_add_inplace(dst, src, scale, len)`** new primitive for the MoE weighted combine. CPU + Metal kernels (new `scaled_add_inplace_f32` shader). Default impl uses host round-trip for unimplemented backends.
- **CLI dispatch**: `cargo run -p ferrum-cli ... run <gguf>` now detects `qwen3moe` arch and routes through `Qwen3MoeModel` instead of erroring with "use Qwen3MoeConfig::from_gguf".
- **CPU `kv_cache_append_head_major` debug_assert relaxed to `>=`** so scratch-buffer reuse across prefill (N tokens) and decode (1 token) doesn't trip an exact-size match.

## Tests

`qwen3_moe_model_test.rs` (4 tests, CPU): load from synthesized qwen3moe GGUF, prefill returns finite logits, decode advances KV cache by one per step, release/reset clear caches. Existing `moe_dispatch_test.rs` and `moe_layer_test.rs` still pass.

Pre-existing `erasing_op` clippy errors in `moe_layer_test.rs` (`0 * 2 + 0` zero-mult indexing) fixed incidentally so workspace clippy passes.

## Local validation

- ` cargo fmt --all -- --check` clean
- `cargo check --workspace --all-targets` clean
- `cargo clippy --workspace --all-targets -- -A warnings` clean
- `cargo test --workspace` 88/88 suites pass
- `cargo test --workspace --features metal` 88/88 suites pass

## What's not yet here (followup)

- Bench Qwen3-30B-A3B Q4_K_M end-to-end vs llama.cpp (596 pp512 / 44.52 tg128). The CLI path is wired and the model loads; the actual 17 GB GGUF download + run is the next step.
- Per-expert prefill batching (currently per-token loop — fine for decode, will be slow for long prompts).

## Test plan

- [x] CPU unit tests pass
- [x] Metal feature compiles + unit tests pass
- [x] fmt + clippy clean
- [ ] Bench Qwen3-30B-A3B Q4_K_M load + decode on M1 Max — followup PR (out of scope here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)