### PR TITLE
perf(moe): mul_mat_id Q4_K/Q6_K + stacked memory + post-op fusion

### DIFF
--- a/crates/ferrum-kernels/src/backend/metal.rs
+++ b/crates/ferrum-kernels/src/backend/metal.rs
@@ -294,6 +294,24 @@ pub enum MetalQuantStore {
         total_rows: usize,
         n_cols: usize,
     },
+    /// 3-D expert stack for MoE indirect dispatch. Holds **all experts'
+    /// weights for one matmul role** (e.g. all `ffn_gate_exps` rows for
+    /// every expert) in one contiguous Metal buffer with byte stride
+    /// `nb02` between expert slabs. Consumed by the
+    /// `gemv_q4kw_moe_id_f32` / `gemv_q6kw_moe_id_f32` Metal kernels in
+    /// a single dispatch covering all selected (token, expert) pairs.
+    Q4KExperts {
+        blocks: metal::Buffer,
+        num_experts: usize,
+        n_rows: usize, // per-expert out_features
+        n_cols: usize, // in_features
+    },
+    Q6KExperts {
+        blocks: metal::Buffer,
+        num_experts: usize,
+        n_rows: usize,
+        n_cols: usize,
+    },
 }
 
 impl MetalQuantStore {
@@ -301,7 +319,142 @@ impl MetalQuantStore {
         match self {
             MetalQuantStore::Q4K { n_rows, .. } | MetalQuantStore::Q6K { n_rows, .. } => *n_rows,
             MetalQuantStore::Fused { total_rows, .. } => *total_rows,
+            MetalQuantStore::Q4KExperts { n_rows, .. }
+            | MetalQuantStore::Q6KExperts { n_rows, .. } => *n_rows,
         }
+    }
+}
+
+/// Build a `Q4KExperts` MoE stack from a contiguous block-bytes payload.
+///
+/// `bytes` must be exactly `num_experts * n_rows * (n_cols/256) * 144`
+/// bytes — typically the raw `ffn_gate_exps` / `ffn_up_exps` data slab
+/// straight off the GGUF.
+pub fn load_q4k_experts(
+    bytes: &[u8],
+    num_experts: usize,
+    n_rows: usize,
+    n_cols: usize,
+) -> Result<MetalQuantStore> {
+    const QK_K: usize = 256;
+    const BLOCK_BYTES: usize = 144;
+    if n_cols % QK_K != 0 {
+        return Err(FerrumError::model(format!(
+            "load_q4k_experts: n_cols {n_cols} not a multiple of {QK_K}"
+        )));
+    }
+    let expected = num_experts * n_rows * (n_cols / QK_K) * BLOCK_BYTES;
+    if bytes.len() != expected {
+        return Err(FerrumError::model(format!(
+            "load_q4k_experts: bytes {} != expected {expected} ({num_experts}E × {n_rows}R × {n_cols}C)",
+            bytes.len()
+        )));
+    }
+    let blocks = st().pipes.device.new_buffer_with_data(
+        bytes.as_ptr() as *const c_void,
+        bytes.len() as u64,
+        MTLResourceOptions::StorageModeShared,
+    );
+    Ok(MetalQuantStore::Q4KExperts {
+        blocks,
+        num_experts,
+        n_rows,
+        n_cols,
+    })
+}
+
+/// Build a `Q6KExperts` MoE stack from a contiguous block-bytes payload.
+pub fn load_q6k_experts(
+    bytes: &[u8],
+    num_experts: usize,
+    n_rows: usize,
+    n_cols: usize,
+) -> Result<MetalQuantStore> {
+    const QK_K: usize = 256;
+    const BLOCK_BYTES: usize = crate::q6_k_gemv::Q6_K_BLOCK_BYTES;
+    if n_cols % QK_K != 0 {
+        return Err(FerrumError::model(format!(
+            "load_q6k_experts: n_cols {n_cols} not a multiple of {QK_K}"
+        )));
+    }
+    let expected = num_experts * n_rows * (n_cols / QK_K) * BLOCK_BYTES;
+    if bytes.len() != expected {
+        return Err(FerrumError::model(format!(
+            "load_q6k_experts: bytes {} != expected {expected}",
+            bytes.len()
+        )));
+    }
+    let blocks = st().pipes.device.new_buffer_with_data(
+        bytes.as_ptr() as *const c_void,
+        bytes.len() as u64,
+        MTLResourceOptions::StorageModeShared,
+    );
+    Ok(MetalQuantStore::Q6KExperts {
+        blocks,
+        num_experts,
+        n_rows,
+        n_cols,
+    })
+}
+
+/// Dispatch the MoE indirect-gemv on an existing compute encoder.
+/// `ids` is a Metal buffer of `n_selected` i32 expert IDs (one per
+/// selected slot). The kernel writes `[n_selected, n_rows]` outputs.
+/// `src1_stride` is the per-slot activation stride in elements: 0 for
+/// broadcast (gate/up), `n_cols` for per-slot (down).
+pub fn dispatch_gemv_moe_id(
+    enc: &metal::ComputeCommandEncoderRef,
+    a: &metal::Buffer,
+    weights: &MetalQuantStore,
+    ids: &metal::Buffer,
+    out: &metal::Buffer,
+    n_selected: usize,
+    src1_stride: usize,
+) -> Result<()> {
+    match weights {
+        MetalQuantStore::Q4KExperts {
+            blocks,
+            n_rows,
+            n_cols,
+            ..
+        } => {
+            crate::q4_k_moe_id_gemv::dispatch_gemv_q4k_moe_id_on_encoder(
+                &st().pipes.device,
+                enc,
+                a,
+                blocks,
+                ids,
+                out,
+                *n_rows,
+                *n_cols,
+                n_selected,
+                src1_stride,
+            );
+            Ok(())
+        }
+        MetalQuantStore::Q6KExperts {
+            blocks,
+            n_rows,
+            n_cols,
+            ..
+        } => {
+            crate::q6_k_moe_id_gemv::dispatch_gemv_q6k_moe_id_on_encoder(
+                &st().pipes.device,
+                enc,
+                a,
+                blocks,
+                ids,
+                out,
+                *n_rows,
+                *n_cols,
+                n_selected,
+                src1_stride,
+            );
+            Ok(())
+        }
+        _ => Err(FerrumError::model(
+            "dispatch_gemv_moe_id: weights must be Q4KExperts or Q6KExperts variant".to_string(),
+        )),
     }
 }
 
@@ -357,9 +510,11 @@ fn dispatch_part_gemm(
                 n_cols,
             );
         }
-        MetalQuantStore::Fused { .. } => {
+        MetalQuantStore::Fused { .. }
+        | MetalQuantStore::Q4KExperts { .. }
+        | MetalQuantStore::Q6KExperts { .. } => {
             return Err(FerrumError::model(
-                "gemm_quant Fused: nested Fused parts not supported".to_string(),
+                "gemm_quant Fused: only Q4K/Q6K leaf parts supported here".to_string(),
             ));
         }
     }
@@ -426,9 +581,11 @@ fn dispatch_part_gemv_offset(
                 n_cols,
             );
         }
-        MetalQuantStore::Fused { .. } => {
+        MetalQuantStore::Fused { .. }
+        | MetalQuantStore::Q4KExperts { .. }
+        | MetalQuantStore::Q6KExperts { .. } => {
             return Err(FerrumError::model(
-                "gemm_quant Fused: nested Fused parts not supported".to_string(),
+                "gemm_quant Fused: only Q4K/Q6K leaf parts supported here".to_string(),
             ));
         }
     }
@@ -523,6 +680,132 @@ impl Backend for MetalBackend {
             other => Err(FerrumError::unsupported(format!(
                 "Metal load_quant: {other:?} not yet implemented"
             ))),
+        }
+    }
+
+    fn load_quant_experts(
+        kind: super::GgufQuantType,
+        bytes: &[u8],
+        num_experts: usize,
+        n_rows: usize,
+        n_cols: usize,
+    ) -> Result<Self::QuantStore> {
+        use super::GgufQuantType;
+        match kind {
+            GgufQuantType::Q4K => load_q4k_experts(bytes, num_experts, n_rows, n_cols),
+            GgufQuantType::Q6K => load_q6k_experts(bytes, num_experts, n_rows, n_cols),
+            other => Err(FerrumError::unsupported(format!(
+                "Metal load_quant_experts: {other:?} not implemented (only Q4K / Q6K)"
+            ))),
+        }
+    }
+
+    fn gemv_quant_moe_id(
+        ctx: &mut Self::Context,
+        a: &Self::Buffer,
+        weight: &Self::QuantStore,
+        ids: &Self::Buffer,
+        out: &mut Self::Buffer,
+        n_selected: usize,
+        src1_stride: usize,
+    ) -> Result<()> {
+        let a_buf = a.expect_f32("gemv_quant_moe_id a");
+        let ids_buf = &ids.raw;
+        let out_buf = out.expect_f32_mut("gemv_quant_moe_id out");
+        let enc = ctx.compute_encoder();
+        dispatch_gemv_moe_id(
+            enc,
+            a_buf,
+            weight,
+            ids_buf,
+            out_buf,
+            n_selected,
+            src1_stride,
+        )
+    }
+
+    fn from_slice_i32(data: &[i32]) -> Self::Buffer {
+        // Encode i32s as a Metal buffer. We tag dtype as F32 since the
+        // raw bytes are 4-byte aligned and the kernel reinterprets them
+        // as int32_t internally. `n` records the element count.
+        let bytes = data.len() * std::mem::size_of::<i32>();
+        let raw = st().pipes.device.new_buffer_with_data(
+            data.as_ptr() as *const c_void,
+            bytes as u64,
+            MTLResourceOptions::StorageModeShared,
+        );
+        MetalBuf {
+            raw,
+            dtype: Dtype::F32,
+            n: data.len(),
+        }
+    }
+
+    fn silu_mul_stacked(
+        ctx: &mut Self::Context,
+        gate: &Self::Buffer,
+        up: &Self::Buffer,
+        out: &mut Self::Buffer,
+        n_slots: usize,
+        ffn: usize,
+    ) -> Result<()> {
+        let gate_buf = gate.expect_f32("silu_mul_stacked gate");
+        let up_buf = up.expect_f32("silu_mul_stacked up");
+        let out_buf = out.expect_f32_mut("silu_mul_stacked out");
+        let enc = ctx.compute_encoder();
+        crate::moe_post_ops::dispatch_silu_mul_stacked(
+            &st().pipes.device,
+            enc,
+            gate_buf,
+            up_buf,
+            out_buf,
+            n_slots,
+            ffn,
+        );
+        Ok(())
+    }
+
+    fn weighted_sum_stacked(
+        ctx: &mut Self::Context,
+        slots: &Self::Buffer,
+        weights: &Self::Buffer,
+        out: &mut Self::Buffer,
+        n_slots: usize,
+        hidden: usize,
+    ) -> Result<()> {
+        let slots_buf = slots.expect_f32("weighted_sum_stacked slots");
+        let weights_buf = weights.expect_f32("weighted_sum_stacked weights");
+        let out_buf = out.expect_f32_mut("weighted_sum_stacked out");
+        let enc = ctx.compute_encoder();
+        crate::moe_post_ops::dispatch_weighted_sum_stacked(
+            &st().pipes.device,
+            enc,
+            slots_buf,
+            weights_buf,
+            out_buf,
+            n_slots,
+            hidden,
+        );
+        Ok(())
+    }
+
+    fn write_i32_into(buf: &mut Self::Buffer, data: &[i32]) {
+        // StorageModeShared = unified memory on Apple Silicon, so the
+        // CPU can write directly into the buffer's contents pointer
+        // without involving a blit encoder. Avoids allocating a fresh
+        // MTLBuffer on every per-layer expert-id update.
+        let dst = buf.raw.contents() as *mut i32;
+        let n = data.len().min(buf.n);
+        unsafe {
+            std::ptr::copy_nonoverlapping(data.as_ptr(), dst, n);
+        }
+    }
+
+    fn write_f32_into(buf: &mut Self::Buffer, data: &[f32]) {
+        let dst = buf.raw.contents() as *mut f32;
+        let n = data.len().min(buf.n);
+        unsafe {
+            std::ptr::copy_nonoverlapping(data.as_ptr(), dst, n);
         }
     }
 
@@ -630,6 +913,11 @@ impl Backend for MetalBackend {
                 n_blocks,
             } => (blocks, *n_rows, *n_cols, *n_blocks, true),
             MetalQuantStore::Fused { .. } => unreachable!("handled above"),
+            MetalQuantStore::Q4KExperts { .. } | MetalQuantStore::Q6KExperts { .. } => {
+                return Err(FerrumError::model(
+                    "gemm_quant: ExpertsStacked must be dispatched via gemv_moe_id".to_string(),
+                ));
+            }
         };
 
         let _t0 = if debug_per_call_flush() {

--- a/crates/ferrum-kernels/src/backend/traits.rs
+++ b/crates/ferrum-kernels/src/backend/traits.rs
@@ -356,6 +356,123 @@ pub trait Backend: Send + Sync + Sized + 'static {
         ))
     }
 
+    /// Build a stacked-experts `QuantStore` from a contiguous 3-D weight
+    /// payload `[num_experts, n_rows, n_cols/256]` super-blocks.
+    /// Used for the MoE indirect-dispatch fast path; backends without
+    /// such a kernel return `Err(unsupported)` and the model code falls
+    /// back to the per-expert loop.
+    ///
+    /// Default: not supported. Override on backends with batched MoE
+    /// kernels (e.g. Metal `gemv_q*kw_moe_id_f32`).
+    fn load_quant_experts(
+        _kind: GgufQuantType,
+        _bytes: &[u8],
+        _num_experts: usize,
+        _n_rows: usize,
+        _n_cols: usize,
+    ) -> Result<Self::QuantStore> {
+        Err(FerrumError::unsupported(
+            "load_quant_experts not implemented for this backend",
+        ))
+    }
+
+    /// MoE indirect-dispatch GEMV: `out[i, :] = a[i, :] @ dequant(weight[ids[i], :])^T`
+    /// for each `i ∈ [0, n_selected)`. Single backend dispatch covers
+    /// all selected (token, expert) pairs.
+    ///
+    /// `weight` must be a stacked-experts variant produced by
+    /// [`Self::load_quant_experts`]. `ids` is a backend-side buffer of
+    /// `n_selected` i32 expert IDs. `out` is sized `[n_selected, n_rows]`.
+    /// `src1_stride` is the per-slot activation stride in **elements**:
+    /// `0` ⇒ every slot reads the same activation row (broadcast — for
+    /// `gate` / `up` projections); `n_cols` ⇒ each slot reads its own
+    /// activation row (for `down` projections, where each expert
+    /// consumes its own silu(gate)·up output).
+    fn gemv_quant_moe_id(
+        _ctx: &mut Self::Context,
+        _a: &Self::Buffer,
+        _weight: &Self::QuantStore,
+        _ids: &Self::Buffer,
+        _out: &mut Self::Buffer,
+        _n_selected: usize,
+        _src1_stride: usize,
+    ) -> Result<()> {
+        Err(FerrumError::unsupported(
+            "gemv_quant_moe_id not implemented for this backend",
+        ))
+    }
+
+    /// Allocate a backend buffer of i32-typed values for kernels that
+    /// need integer indices (MoE expert IDs, scatter indices, etc.).
+    ///
+    /// Default impl bit-casts the i32s to f32s and uploads via
+    /// `from_slice` — useful on backends where the buffer type is type-
+    /// erased (CPU's `Vec<f32>`, Metal's untyped MTLBuffer). Backends
+    /// that use a strongly-typed buffer override.
+    fn from_slice_i32(data: &[i32]) -> Self::Buffer {
+        let f: Vec<f32> = data.iter().map(|&i| f32::from_bits(i as u32)).collect();
+        Self::from_slice(&f)
+    }
+
+    /// Overwrite an existing i32 buffer's contents in place. Used on
+    /// the MoE decode hot path: per-layer expert-id updates do an
+    /// in-place memcpy instead of allocating a fresh device buffer
+    /// (48 layers × 128 tokens = 6144 fresh allocations per decode
+    /// run otherwise — allocator pressure dominates the secondary cost).
+    ///
+    /// Default impl falls back to `from_slice_i32` + drop. Backends
+    /// with shared CPU↔GPU memory (Metal `StorageModeShared`, CPU's
+    /// `Vec<f32>`) override with a direct write.
+    fn write_i32_into(buf: &mut Self::Buffer, data: &[i32]) {
+        *buf = Self::from_slice_i32(data);
+    }
+
+    /// Overwrite an existing f32 buffer's contents in place. Counterpart
+    /// to `write_i32_into` for f32 data — used to update the per-token
+    /// MoE combine weights into a pre-allocated scratch buffer instead
+    /// of allocating a fresh `from_slice` buffer 6144 times per decode
+    /// run.
+    fn write_f32_into(buf: &mut Self::Buffer, data: &[f32]) {
+        *buf = Self::from_slice(data);
+    }
+
+    /// Stacked SiLU·gate over `[n_slots, ffn]` rows.
+    ///
+    /// Computes `out[s, i] = silu(gate[s, i]) * up[s, i]` for each slot
+    /// `s`, element `i`. Single dispatch covers all slots — cuts the
+    /// MoE decode silu staging from `top_k * (3 copy_slice + 1 silu)`
+    /// = 32 dispatches per layer to 1.
+    fn silu_mul_stacked(
+        _ctx: &mut Self::Context,
+        _gate: &Self::Buffer,
+        _up: &Self::Buffer,
+        _out: &mut Self::Buffer,
+        _n_slots: usize,
+        _ffn: usize,
+    ) -> Result<()> {
+        Err(FerrumError::unsupported(
+            "silu_mul_stacked not implemented for this backend",
+        ))
+    }
+
+    /// Weighted sum across `n_slots` rows of `[hidden]`.
+    ///
+    /// Computes `out[i] = Σ_s weights[s] * slots[s, i]`. Single
+    /// dispatch replaces the per-slot `(copy_slice + scaled_add)`
+    /// loop in the MoE decode path (16 dispatches per layer → 1).
+    fn weighted_sum_stacked(
+        _ctx: &mut Self::Context,
+        _slots: &Self::Buffer,
+        _weights: &Self::Buffer,
+        _out: &mut Self::Buffer,
+        _n_slots: usize,
+        _hidden: usize,
+    ) -> Result<()> {
+        Err(FerrumError::unsupported(
+            "weighted_sum_stacked not implemented for this backend",
+        ))
+    }
+
     // ── GEMM ────────────────────────────────────────────────────────────
 
     fn gemm(

--- a/crates/ferrum-kernels/src/lib.rs
+++ b/crates/ferrum-kernels/src/lib.rs
@@ -10,6 +10,8 @@ pub mod linear;
 pub use linear::Linear;
 
 #[cfg(all(target_os = "macos", feature = "metal"))]
+pub mod moe_post_ops;
+#[cfg(all(target_os = "macos", feature = "metal"))]
 pub mod q4_k;
 #[cfg(all(target_os = "macos", feature = "metal"))]
 pub mod q4_k_gemm;
@@ -18,9 +20,13 @@ pub mod q4_k_gemv;
 #[cfg(all(target_os = "macos", feature = "metal"))]
 pub mod q4_k_gemv_v2;
 #[cfg(all(target_os = "macos", feature = "metal"))]
+pub mod q4_k_moe_id_gemv;
+#[cfg(all(target_os = "macos", feature = "metal"))]
 pub mod q6_k_gemm;
 #[cfg(all(target_os = "macos", feature = "metal"))]
 pub mod q6_k_gemv;
+#[cfg(all(target_os = "macos", feature = "metal"))]
+pub mod q6_k_moe_id_gemv;
 
 #[cfg(feature = "cuda")]
 pub(crate) mod ptx {

--- a/crates/ferrum-kernels/src/moe_post_ops.metal
+++ b/crates/ferrum-kernels/src/moe_post_ops.metal
@@ -1,0 +1,89 @@
+// MoE post-ops — fused kernels that collapse the per-(token, expert)
+// loop's silu staging and weighted-sum into single dispatches.
+//
+// Without these kernels, a Qwen3-30B-A3B layer's stacked MoE FFN does:
+//   * 8 × (3 copy_slice + 1 silu_mul_split) = 32 dispatches just to
+//     stage gate / up into silu output
+//   * 8 × (1 copy_slice + 1 scaled_add) = 16 dispatches for the
+//     weighted sum
+//
+// 48 dispatches per layer × 48 layers = 2304 launches per token of
+// pure plumbing — enough to dominate decode latency on M1 Max even
+// though each individual op is tiny. The kernels below cover the
+// same work in 2 dispatches per layer total (one silu, one weighted
+// sum), unlocking the win that batching the gemvs alone couldn't.
+
+#include <metal_stdlib>
+using namespace metal;
+
+// ── Stacked SiLU·gate for top_k experts ──────────────────────────────
+// Inputs:
+//   gate : [n_slots, ffn] — gate gemv outputs, one row per selected expert
+//   up   : [n_slots, ffn] — up gemv outputs, same layout
+//   out  : [n_slots, ffn] — silu(gate[s, i]) * up[s, i] for each slot s, i
+// Grid: (ceil(ffn/256), n_slots). Threadgroup: 256 threads.
+//
+// Single dispatch handles all `n_slots * ffn` elements without any
+// per-row staging — replaces the 32 dispatches the per-slot loop
+// emitted before.
+
+struct SiluMulStackedParams {
+    int ffn;
+    int n_slots;
+};
+
+kernel void silu_mul_stacked_f32(
+    device const float* gate     [[buffer(0)]],
+    device const float* up       [[buffer(1)]],
+    device       float* out      [[buffer(2)]],
+    constant SiluMulStackedParams& p [[buffer(3)]],
+    uint3 tgpig [[threadgroup_position_in_grid]],
+    uint3 tpig  [[thread_position_in_threadgroup]])
+{
+    const uint slot = tgpig.y;
+    if (slot >= uint(p.n_slots)) return;
+
+    const uint i = tgpig.x * 256 + tpig.x;
+    if (i >= uint(p.ffn)) return;
+
+    const uint off = slot * uint(p.ffn) + i;
+    const float g = gate[off];
+    const float u = up[off];
+    // SiLU(x) = x * sigmoid(x) = x / (1 + exp(-x))
+    const float s = g / (1.0f + exp(-g));
+    out[off] = s * u;
+}
+
+// ── Weighted sum across top_k slots ──────────────────────────────────
+// Inputs:
+//   slots   : [n_slots, hidden] — per-slot down outputs
+//   weights : [n_slots]         — router-derived combine weights
+//   out     : [hidden]          — out[i] = Σ_s weights[s] * slots[s, i]
+// Grid: (ceil(hidden/256), 1). Threadgroup: 256 threads.
+//
+// One dispatch replaces the 16 (copy + scaled_add) dispatches the
+// per-slot loop emitted before.
+
+struct WeightedSumStackedParams {
+    int hidden;
+    int n_slots;
+};
+
+kernel void weighted_sum_stacked_f32(
+    device const float* slots    [[buffer(0)]],
+    device const float* weights  [[buffer(1)]],
+    device       float* out      [[buffer(2)]],
+    constant WeightedSumStackedParams& p [[buffer(3)]],
+    uint3 tgpig [[threadgroup_position_in_grid]],
+    uint3 tpig  [[thread_position_in_threadgroup]])
+{
+    const uint i = tgpig.x * 256 + tpig.x;
+    if (i >= uint(p.hidden)) return;
+
+    float sum = 0.0f;
+    // top_k is small (typically 2-8); unroll-friendly without branching.
+    for (int s = 0; s < p.n_slots; s++) {
+        sum += weights[s] * slots[s * uint(p.hidden) + i];
+    }
+    out[i] = sum;
+}

--- a/crates/ferrum-kernels/src/moe_post_ops.rs
+++ b/crates/ferrum-kernels/src/moe_post_ops.rs
@@ -1,0 +1,122 @@
+//! Stacked SiLU·gate + weighted-sum kernels for the MoE decode fast
+//! path. See `moe_post_ops.metal` for the algorithmic notes.
+
+#![cfg(all(target_os = "macos", feature = "metal"))]
+
+use std::ffi::c_void;
+use std::sync::OnceLock;
+
+use metal::{
+    Buffer, CompileOptions, ComputeCommandEncoderRef, ComputePipelineState, Device, MTLSize,
+};
+
+const SHADER_SRC: &str = include_str!("moe_post_ops.metal");
+
+static SILU_PIPELINE: OnceLock<ComputePipelineState> = OnceLock::new();
+static WSUM_PIPELINE: OnceLock<ComputePipelineState> = OnceLock::new();
+
+fn silu_pipeline(device: &Device) -> &'static ComputePipelineState {
+    SILU_PIPELINE.get_or_init(|| {
+        let lib = device
+            .new_library_with_source(SHADER_SRC, &CompileOptions::new())
+            .expect("compile moe_post_ops.metal");
+        let function = lib
+            .get_function("silu_mul_stacked_f32", None)
+            .expect("find silu_mul_stacked_f32");
+        device
+            .new_compute_pipeline_state_with_function(&function)
+            .expect("build silu_mul_stacked_f32 pipeline")
+    })
+}
+
+fn wsum_pipeline(device: &Device) -> &'static ComputePipelineState {
+    WSUM_PIPELINE.get_or_init(|| {
+        let lib = device
+            .new_library_with_source(SHADER_SRC, &CompileOptions::new())
+            .expect("compile moe_post_ops.metal");
+        let function = lib
+            .get_function("weighted_sum_stacked_f32", None)
+            .expect("find weighted_sum_stacked_f32");
+        device
+            .new_compute_pipeline_state_with_function(&function)
+            .expect("build weighted_sum_stacked_f32 pipeline")
+    })
+}
+
+/// Stacked SiLU·gate dispatch.
+///
+/// `gate`, `up`: `[n_slots, ffn]`. `out`: `[n_slots, ffn]`.
+pub fn dispatch_silu_mul_stacked(
+    device: &Device,
+    enc: &ComputeCommandEncoderRef,
+    gate: &Buffer,
+    up: &Buffer,
+    out: &Buffer,
+    n_slots: usize,
+    ffn: usize,
+) {
+    #[repr(C)]
+    struct P {
+        ffn: i32,
+        n_slots: i32,
+    }
+    let params = P {
+        ffn: ffn as i32,
+        n_slots: n_slots as i32,
+    };
+
+    let pipe = silu_pipeline(device);
+    enc.set_compute_pipeline_state(pipe);
+    enc.set_buffer(0, Some(gate), 0);
+    enc.set_buffer(1, Some(up), 0);
+    enc.set_buffer(2, Some(out), 0);
+    enc.set_bytes(
+        3,
+        std::mem::size_of::<P>() as u64,
+        &params as *const _ as *const c_void,
+    );
+
+    let grid_x = (ffn as u64).div_ceil(256);
+    let grid = MTLSize::new(grid_x, n_slots as u64, 1);
+    let tg = MTLSize::new(256, 1, 1);
+    enc.dispatch_thread_groups(grid, tg);
+}
+
+/// Weighted-sum across slots dispatch.
+///
+/// `slots`: `[n_slots, hidden]`. `weights`: `[n_slots]`. `out`: `[hidden]`.
+pub fn dispatch_weighted_sum_stacked(
+    device: &Device,
+    enc: &ComputeCommandEncoderRef,
+    slots: &Buffer,
+    weights: &Buffer,
+    out: &Buffer,
+    n_slots: usize,
+    hidden: usize,
+) {
+    #[repr(C)]
+    struct P {
+        hidden: i32,
+        n_slots: i32,
+    }
+    let params = P {
+        hidden: hidden as i32,
+        n_slots: n_slots as i32,
+    };
+
+    let pipe = wsum_pipeline(device);
+    enc.set_compute_pipeline_state(pipe);
+    enc.set_buffer(0, Some(slots), 0);
+    enc.set_buffer(1, Some(weights), 0);
+    enc.set_buffer(2, Some(out), 0);
+    enc.set_bytes(
+        3,
+        std::mem::size_of::<P>() as u64,
+        &params as *const _ as *const c_void,
+    );
+
+    let grid_x = (hidden as u64).div_ceil(256);
+    let grid = MTLSize::new(grid_x, 1, 1);
+    let tg = MTLSize::new(256, 1, 1);
+    enc.dispatch_thread_groups(grid, tg);
+}

--- a/crates/ferrum-kernels/src/q4_k_moe_id_gemv.metal
+++ b/crates/ferrum-kernels/src/q4_k_moe_id_gemv.metal
@@ -1,0 +1,169 @@
+// Q4_K_M MoE indirect-dispatch GEMV — adapted from q4_k_gemv_v2.metal
+// (which is itself a port of llama.cpp's `kernel_mul_mv_q4_K_f32_impl`).
+//
+// One Metal dispatch handles ALL `n_selected` (token, expert) pairs for
+// decode m=1, replacing the per-expert gemv loop in `moe_forward`. For
+// Qwen3-30B-A3B with top_k=8 and 48 layers, this drops the gate-or-up
+// dispatch count from 8 per layer to 1 per layer (-87%) — matching
+// llama.cpp's `kernel_mul_mm_id` decode path.
+//
+// Inputs:
+//   src0 : [num_experts, N, K/256] Q4_K block bytes, contiguous, with
+//          stride `nb02` (= N * K/256 * 144 bytes) between experts.
+//   src1 : [K] activations (single token).
+//   ids  : [n_selected] selected expert IDs (i32).
+//   dst  : [n_selected, N] output rows (one per selected expert).
+//
+// Grid: (ceil(N/4), 1, n_selected) threadgroups.
+// Threadgroup: (32, 2, 1) threads = 2 simdgroups × 32 threads.
+//
+// The inner reduction is byte-for-byte identical to gemv_f32a_q4kw_v2 —
+// the only changes are:
+//   1. `tgpig.z` selects which expert slot to compute.
+//   2. The src0 base pointer is offset by `ids[tgpig.z] * nb02`.
+//   3. The dst base pointer is offset by `tgpig.z * N`.
+// The arithmetic per thread is unchanged, so M1 Max occupancy /
+// register pressure / instruction mix all carry over from v2 verbatim.
+
+#include <metal_stdlib>
+using namespace metal;
+
+#define QK_K 256
+#define N_R0 2
+#define N_SG 2
+#define FOR_UNROLL(x) _Pragma("clang loop unroll(full)") for (x)
+
+struct block_q4_K {
+    half  d;
+    half  dmin;
+    uchar scales[12];
+    uchar qs[QK_K / 2];
+};
+
+struct GemvQ4KMoeParams {
+    int N;            // out_features per expert
+    int K;            // in_features (multiple of 256)
+    int nb01;         // src0 row stride per expert in BYTES = (K/256) * 144
+    int nb02;         // src0 expert stride in BYTES = N * (K/256) * 144
+    int n_selected;   // number of selected experts (= top_k for decode m=1)
+    int src1_stride;  // src1 element stride per slot. 0 for broadcast
+                      // (every slot reads the same activation row, e.g.
+                      // gate / up), `K` for non-broadcast (each slot
+                      // reads its own row, e.g. down where each expert
+                      // sees its own silu(gate)·up output).
+};
+
+kernel void gemv_q4kw_moe_id_f32(
+    device const block_q4_K * src0  [[buffer(0)]],
+    device const float      * src1  [[buffer(1)]],
+    device const int        * ids   [[buffer(2)]],   // [n_selected]
+    device       float      * dst   [[buffer(3)]],   // [n_selected, N]
+    constant GemvQ4KMoeParams & p   [[buffer(4)]],
+    uint3  tgpig [[threadgroup_position_in_grid]],
+    ushort tiisg [[thread_index_in_simdgroup]],
+    ushort sgitg [[simdgroup_index_in_threadgroup]])
+{
+    const int slot = tgpig.z;
+    if (slot >= p.n_selected) return;
+
+    const int expert_id = ids[slot];
+
+    constexpr uint16_t kmask1 = 0x3f3f;
+    constexpr uint16_t kmask2 = 0x0f0f;
+    constexpr uint16_t kmask3 = 0xc0c0;
+
+    const short ix = tiisg / 8;
+    const short it = tiisg % 8;
+    const short iq = it / 4;
+    const short ir = it % 4;
+
+    const int nb = p.K / QK_K;
+    const int r0 = tgpig.x;
+
+    const int first_row = (r0 * N_SG + sgitg) * N_R0;
+    if (first_row >= p.N) return;
+
+    // src0 base for this expert + this simdgroup's first row.
+    // Byte offsets: expert_id * nb02 picks the expert slab,
+    //               first_row * nb01 advances inside that slab.
+    device const block_q4_K * x = (device const block_q4_K *)(
+        (device const char *)src0 + expert_id * p.nb02 + first_row * p.nb01
+    );
+    // Per-slot activation base. `src1_stride == 0` ⇒ all slots read the
+    // same row (used for gate / up broadcasts). `src1_stride == K` ⇒
+    // each slot reads its own row (used for down — each expert sees a
+    // different silu(gate)·up).
+    device const float * y = src1 + slot * p.src1_stride;
+
+    float yl[16];
+    float yh[16];
+    float sumf[N_R0] = {0.f};
+
+    device const float * y4 = y + ix * QK_K + 64 * iq + 8 * ir;
+
+    uint16_t sc16[4];
+    thread const uint8_t * sc8 = (thread const uint8_t *)sc16;
+
+    for (int ib = ix; ib < nb; ib += 4) {
+        float4 sumy = {0.f, 0.f, 0.f, 0.f};
+        for (short i = 0; i < 8; ++i) {
+            yl[i + 0] = y4[i +   0]; sumy[0] += yl[i + 0];
+            yl[i + 8] = y4[i +  32]; sumy[1] += yl[i + 8];
+            yh[i + 0] = y4[i + 128]; sumy[2] += yh[i + 0];
+            yh[i + 8] = y4[i + 160]; sumy[3] += yh[i + 8];
+        }
+
+        device const uint16_t * sc = (device const uint16_t *)x[ib].scales + iq;
+        device const uint16_t * q1 = (device const uint16_t *)x[ib].qs + 16 * iq + 4 * ir;
+        device const half     * dh = &x[ib].d;
+
+        for (short row = 0; row < N_R0; row++) {
+            sc16[0] = sc[0] & kmask1;
+            sc16[1] = sc[2] & kmask1;
+            sc16[2] = ((sc[4] >> 0) & kmask2) | ((sc[0] & kmask3) >> 2);
+            sc16[3] = ((sc[4] >> 4) & kmask2) | ((sc[2] & kmask3) >> 2);
+
+            device const uint16_t * q2 = q1 + 32;
+
+            float4 acc1 = {0.f, 0.f, 0.f, 0.f};
+            float4 acc2 = {0.f, 0.f, 0.f, 0.f};
+
+            FOR_UNROLL (short i = 0; i < 4; ++i) {
+                acc1[0] += yl[2*i + 0] * (q1[i] & 0x000F);
+                acc1[1] += yl[2*i + 1] * (q1[i] & 0x0F00);
+                acc1[2] += yl[2*i + 8] * (q1[i] & 0x00F0);
+                acc1[3] += yl[2*i + 9] * (q1[i] & 0xF000);
+                acc2[0] += yh[2*i + 0] * (q2[i] & 0x000F);
+                acc2[1] += yh[2*i + 1] * (q2[i] & 0x0F00);
+                acc2[2] += yh[2*i + 8] * (q2[i] & 0x00F0);
+                acc2[3] += yh[2*i + 9] * (q2[i] & 0xF000);
+            }
+
+            sumf[row] += dh[0] * (
+                              (acc1[0] + 1.f/256.f * acc1[1]) * sc8[0] +
+                              (acc1[2] + 1.f/256.f * acc1[3]) * sc8[1] * 1.f/16.f +
+                              (acc2[0] + 1.f/256.f * acc2[1]) * sc8[4] +
+                              (acc2[2] + 1.f/256.f * acc2[3]) * sc8[5] * 1.f/16.f
+                          )
+                        - dh[1] * (
+                              sumy[0] * sc8[2] + sumy[1] * sc8[3] +
+                              sumy[2] * sc8[6] + sumy[3] * sc8[7]
+                          );
+
+            q1 += p.nb01 / 2;
+            sc += p.nb01 / 2;
+            dh += p.nb01 / 2;
+        }
+
+        y4 += 4 * QK_K;
+    }
+
+    // Write nr0 outputs into this slot's row band.
+    device float * dst_slot = dst + slot * p.N;
+    for (short row = 0; row < N_R0 && (first_row + row) < p.N; ++row) {
+        float sum_all = simd_sum(sumf[row]);
+        if (tiisg == 0) {
+            dst_slot[first_row + row] = sum_all;
+        }
+    }
+}

--- a/crates/ferrum-kernels/src/q4_k_moe_id_gemv.rs
+++ b/crates/ferrum-kernels/src/q4_k_moe_id_gemv.rs
@@ -1,0 +1,101 @@
+//! Q4_K_M MoE indirect-dispatch GEMV — Rust glue for `q4_k_moe_id_gemv.metal`.
+//!
+//! Single Metal dispatch covers all `n_selected` (token, expert) pairs at
+//! decode m=1, replacing the per-expert gemv loop in `moe_forward`. See
+//! `q4_k_moe_id_gemv.metal` for the algorithmic notes.
+
+#![cfg(all(target_os = "macos", feature = "metal"))]
+
+use std::ffi::c_void;
+use std::sync::OnceLock;
+
+use metal::{
+    Buffer, CompileOptions, ComputeCommandEncoderRef, ComputePipelineState, Device, MTLSize,
+};
+
+const SHADER_SRC: &str = include_str!("q4_k_moe_id_gemv.metal");
+const KERNEL_NAME: &str = "gemv_q4kw_moe_id_f32";
+
+static PIPELINE: OnceLock<ComputePipelineState> = OnceLock::new();
+
+fn pipeline(device: &Device) -> &'static ComputePipelineState {
+    PIPELINE.get_or_init(|| {
+        let lib = device
+            .new_library_with_source(SHADER_SRC, &CompileOptions::new())
+            .expect("compile q4_k_moe_id_gemv.metal");
+        let function = lib
+            .get_function(KERNEL_NAME, None)
+            .expect("find gemv_q4kw_moe_id_f32 function");
+        device
+            .new_compute_pipeline_state_with_function(&function)
+            .expect("build gemv_q4kw_moe_id_f32 pipeline")
+    })
+}
+
+/// Dispatch a Q4_K MoE GEMV on an existing compute encoder.
+///
+/// `weights_stacked` : `[num_experts, n, k/256]` super-blocks contiguous,
+///                     stride `nb02_bytes = n * (k/256) * 144` per expert.
+/// `a`               : `[k]` activations (single token).
+/// `ids`             : `[n_selected]` selected expert IDs (i32).
+/// `out`             : `[n_selected, n]` output rows.
+/// `n`               : per-expert out_features (must be divisible by 4).
+/// `k`               : in_features (multiple of 256).
+/// `n_selected`      : number of selected experts (= top_k for decode m=1).
+/// `src1_stride` is the per-slot activation stride in **floats**:
+/// `0` means every slot reads the same input row (broadcast — used for
+/// MoE `gate` and `up`); `k` means each slot reads its own input row
+/// (used for `down`, where each expert consumes its own silu·up output).
+pub fn dispatch_gemv_q4k_moe_id_on_encoder(
+    device: &Device,
+    enc: &ComputeCommandEncoderRef,
+    a: &Buffer,
+    weights_stacked: &Buffer,
+    ids: &Buffer,
+    out: &Buffer,
+    n: usize,
+    k: usize,
+    n_selected: usize,
+    src1_stride: usize,
+) {
+    debug_assert!(k % 256 == 0, "K must be a multiple of 256 (got {k})");
+    debug_assert!(n % 4 == 0, "N must be a multiple of 4 (got {n})");
+
+    let nb01_bytes = (k / 256) * 144;
+    let nb02_bytes = n * nb01_bytes;
+
+    #[repr(C)]
+    struct P {
+        n: i32,
+        k: i32,
+        nb01: i32,
+        nb02: i32,
+        n_selected: i32,
+        src1_stride: i32,
+    }
+    let params = P {
+        n: n as i32,
+        k: k as i32,
+        nb01: nb01_bytes as i32,
+        nb02: nb02_bytes as i32,
+        n_selected: n_selected as i32,
+        src1_stride: src1_stride as i32,
+    };
+
+    let pipe = pipeline(device);
+    enc.set_compute_pipeline_state(pipe);
+    enc.set_buffer(0, Some(weights_stacked), 0);
+    enc.set_buffer(1, Some(a), 0);
+    enc.set_buffer(2, Some(ids), 0);
+    enc.set_buffer(3, Some(out), 0);
+    enc.set_bytes(
+        4,
+        std::mem::size_of::<P>() as u64,
+        &params as *const _ as *const c_void,
+    );
+
+    const TILE_ROWS: u64 = 4;
+    let grid = MTLSize::new((n as u64).div_ceil(TILE_ROWS), 1, n_selected as u64);
+    let tg = MTLSize::new(32, 2, 1);
+    enc.dispatch_thread_groups(grid, tg);
+}

--- a/crates/ferrum-kernels/src/q6_k_moe_id_gemv.metal
+++ b/crates/ferrum-kernels/src/q6_k_moe_id_gemv.metal
@@ -1,0 +1,133 @@
+// Q6_K MoE indirect-dispatch GEMV — adapted from q6_k_gemv.metal
+// (which is itself a port of llama.cpp's `kernel_mul_mv_q6_K_f32_impl`).
+//
+// One Metal dispatch handles ALL `n_selected` (token, expert) pairs for
+// decode m=1, replacing the per-expert down_proj gemv loop. See the
+// matching q4_k_moe_id_gemv.metal for the broader rationale.
+//
+// Inputs:
+//   src0 : [num_experts, N, K/256] Q6_K block bytes, contiguous, with
+//          stride `nb02` (= N * K/256 * 210 bytes) between experts.
+//   src1 : [K] activations.
+//   ids  : [n_selected] selected expert IDs (i32).
+//   dst  : [n_selected, N] output rows.
+//
+// Grid: (ceil(N/4), 1, n_selected). Threadgroup: (32, 2, 1).
+
+#include <metal_stdlib>
+using namespace metal;
+
+#define QK_K 256
+#define N_R0 2
+#define N_SG 2
+#define FOR_UNROLL(x) _Pragma("clang loop unroll(full)") for (x)
+
+struct block_q6_K {
+    uchar  ql[QK_K / 2];
+    uchar  qh[QK_K / 4];
+    int8_t scales[QK_K / 16];
+    half   d;
+};
+
+struct GemvQ6KMoeParams {
+    int N;            // out_features per expert
+    int K;            // in_features (multiple of 256)
+    int nb01;         // src0 row stride per expert in BYTES = (K/256) * 210
+    int nb02;         // src0 expert stride in BYTES = N * (K/256) * 210
+    int n_selected;
+    int src1_stride;  // 0 for broadcast (gate/up), K for per-slot (down)
+};
+
+kernel void gemv_q6kw_moe_id_f32(
+    device const block_q6_K * src0  [[buffer(0)]],
+    device const float      * src1  [[buffer(1)]],
+    device const int        * ids   [[buffer(2)]],   // [n_selected]
+    device       float      * dst   [[buffer(3)]],   // [n_selected, N]
+    constant GemvQ6KMoeParams & p   [[buffer(4)]],
+    uint3  tgpig [[threadgroup_position_in_grid]],
+    ushort tiisg [[thread_index_in_simdgroup]],
+    ushort sgitg [[simdgroup_index_in_threadgroup]])
+{
+    const int slot = tgpig.z;
+    if (slot >= p.n_selected) return;
+
+    const int expert_id = ids[slot];
+
+    constexpr uint8_t kmask1 = 0x03;
+    constexpr uint8_t kmask2 = 0x0C;
+    constexpr uint8_t kmask3 = 0x30;
+    constexpr uint8_t kmask4 = 0xC0;
+
+    const int nb = p.K / QK_K;
+    const int r0 = tgpig.x;
+    const int first_row = (r0 * N_SG + sgitg) * N_R0;
+    if (first_row >= p.N) return;
+
+    // src0 base: pick the expert slab, then the simdgroup's first row.
+    device const block_q6_K * x = (device const block_q6_K *)(
+        (device const char *)src0 + expert_id * p.nb02 + first_row * p.nb01
+    );
+    // Per-slot activation base. See q4_k_moe_id_gemv.metal for the
+    // semantics of `src1_stride` (0 = broadcast, K = per-slot rows).
+    device const float * yy = src1 + slot * p.src1_stride;
+
+    float sumf[N_R0] = { 0.f };
+    float yl[16];
+
+    const short tid = tiisg / 2;
+    const short ix  = tiisg % 2;
+    const short ip  = tid / 8;
+    const short il  = tid % 8;
+    const short l0  = 4 * il;
+    const short is  = 8 * ip + l0 / 16;
+
+    const short y_offset   = 128 * ip + l0;
+    const short q_offset_l =  64 * ip + l0;
+    const short q_offset_h =  32 * ip + l0;
+
+    for (int i = ix; i < nb; i += 2) {
+        device const uchar  * q1 = x[i].ql + q_offset_l;
+        device const uchar  * q2 = q1 + 32;
+        device const uchar  * qh = x[i].qh + q_offset_h;
+        device const int8_t * sc = x[i].scales + is;
+        device const half   * dh = &x[i].d;
+
+        device const float * y = yy + i * QK_K + y_offset;
+
+        FOR_UNROLL (short l = 0; l < 4; ++l) {
+            yl[4*l + 0] = y[l +  0];
+            yl[4*l + 1] = y[l + 32];
+            yl[4*l + 2] = y[l + 64];
+            yl[4*l + 3] = y[l + 96];
+        }
+
+        for (short row = 0; row < N_R0; ++row) {
+            float4 sums = {0.f, 0.f, 0.f, 0.f};
+
+            FOR_UNROLL (short l = 0; l < 4; ++l) {
+                sums[0] += yl[4*l + 0] * ((int8_t)((q1[l] & 0x0F) | ((qh[l] & kmask1) << 4)) - 32);
+                sums[1] += yl[4*l + 1] * ((int8_t)((q2[l] & 0x0F) | ((qh[l] & kmask2) << 2)) - 32);
+                sums[2] += yl[4*l + 2] * ((int8_t)((q1[l]  >> 4) | ((qh[l] & kmask3) << 0)) - 32);
+                sums[3] += yl[4*l + 3] * ((int8_t)((q2[l]  >> 4) | ((qh[l] & kmask4) >> 2)) - 32);
+            }
+
+            sumf[row] += dh[0] * (
+                sums[0] * sc[0] + sums[1] * sc[2] + sums[2] * sc[4] + sums[3] * sc[6]
+            );
+
+            q1 += p.nb01;
+            q2 += p.nb01;
+            qh += p.nb01;
+            sc += p.nb01;
+            dh += p.nb01 / 2;
+        }
+    }
+
+    device float * dst_slot = dst + slot * p.N;
+    for (int row = 0; row < N_R0 && (first_row + row) < p.N; ++row) {
+        float sum_all = simd_sum(sumf[row]);
+        if (tiisg == 0) {
+            dst_slot[first_row + row] = sum_all;
+        }
+    }
+}

--- a/crates/ferrum-kernels/src/q6_k_moe_id_gemv.rs
+++ b/crates/ferrum-kernels/src/q6_k_moe_id_gemv.rs
@@ -1,0 +1,93 @@
+//! Q6_K MoE indirect-dispatch GEMV — Rust glue for `q6_k_moe_id_gemv.metal`.
+//!
+//! Counterpart to `q4_k_moe_id_gemv` for Q6_K-quantised expert weights
+//! (typically used for `ffn_down_exps` in Qwen3-30B-A3B Q4_K_M, where
+//! down is Q6_K and gate/up are Q4_K). One dispatch covers all
+//! `n_selected` (token, expert) pairs.
+
+#![cfg(all(target_os = "macos", feature = "metal"))]
+
+use std::ffi::c_void;
+use std::sync::OnceLock;
+
+use metal::{
+    Buffer, CompileOptions, ComputeCommandEncoderRef, ComputePipelineState, Device, MTLSize,
+};
+
+const SHADER_SRC: &str = include_str!("q6_k_moe_id_gemv.metal");
+const KERNEL_NAME: &str = "gemv_q6kw_moe_id_f32";
+
+static PIPELINE: OnceLock<ComputePipelineState> = OnceLock::new();
+
+fn pipeline(device: &Device) -> &'static ComputePipelineState {
+    PIPELINE.get_or_init(|| {
+        let lib = device
+            .new_library_with_source(SHADER_SRC, &CompileOptions::new())
+            .expect("compile q6_k_moe_id_gemv.metal");
+        let function = lib
+            .get_function(KERNEL_NAME, None)
+            .expect("find gemv_q6kw_moe_id_f32 function");
+        device
+            .new_compute_pipeline_state_with_function(&function)
+            .expect("build gemv_q6kw_moe_id_f32 pipeline")
+    })
+}
+
+/// Q6_K MoE block stride in bytes (same as the dense Q6_K GEMV uses).
+pub const Q6_K_BLOCK_BYTES: usize = 210;
+
+/// See `q4_k_moe_id_gemv::dispatch_gemv_q4k_moe_id_on_encoder` for the
+/// `src1_stride` contract.
+pub fn dispatch_gemv_q6k_moe_id_on_encoder(
+    device: &Device,
+    enc: &ComputeCommandEncoderRef,
+    a: &Buffer,
+    weights_stacked: &Buffer,
+    ids: &Buffer,
+    out: &Buffer,
+    n: usize,
+    k: usize,
+    n_selected: usize,
+    src1_stride: usize,
+) {
+    debug_assert!(k % 256 == 0);
+    debug_assert!(n % 4 == 0);
+
+    let nb01_bytes = (k / 256) * Q6_K_BLOCK_BYTES;
+    let nb02_bytes = n * nb01_bytes;
+
+    #[repr(C)]
+    struct P {
+        n: i32,
+        k: i32,
+        nb01: i32,
+        nb02: i32,
+        n_selected: i32,
+        src1_stride: i32,
+    }
+    let params = P {
+        n: n as i32,
+        k: k as i32,
+        nb01: nb01_bytes as i32,
+        nb02: nb02_bytes as i32,
+        n_selected: n_selected as i32,
+        src1_stride: src1_stride as i32,
+    };
+
+    let pipe = pipeline(device);
+    enc.set_compute_pipeline_state(pipe);
+    enc.set_buffer(0, Some(weights_stacked), 0);
+    enc.set_buffer(1, Some(a), 0);
+    enc.set_buffer(2, Some(ids), 0);
+    enc.set_buffer(3, Some(out), 0);
+    enc.set_bytes(
+        4,
+        std::mem::size_of::<P>() as u64,
+        &params as *const _ as *const c_void,
+    );
+
+    const TILE_ROWS: u64 = 4;
+    let grid = MTLSize::new((n as u64).div_ceil(TILE_ROWS), 1, n_selected as u64);
+    let tg = MTLSize::new(32, 2, 1);
+    enc.dispatch_thread_groups(grid, tg);
+}

--- a/crates/ferrum-models/src/models/qwen3_moe.rs
+++ b/crates/ferrum-models/src/models/qwen3_moe.rs
@@ -96,6 +96,30 @@ pub struct Qwen3MoeScratch<B: Backend> {
     /// hot path.
     pub zero_hidden: B::Buffer,
 
+    // ── MoE batched-fast-path scratch (Metal `gemv_q*kw_moe_id_f32`) ──
+    /// `[top_k * expert_inter]` — per-slot gate output from the batched
+    /// gate_stacked dispatch. Each slot holds `expert_inter` floats for
+    /// the corresponding selected expert.
+    pub gate_out_stacked: B::Buffer,
+    /// `[top_k * expert_inter]` — per-slot up output (same shape as gate).
+    pub up_out_stacked: B::Buffer,
+    /// `[top_k * expert_inter]` — per-slot SiLU(gate)·up output, fed into
+    /// the down stacked dispatch.
+    pub silu_stacked: B::Buffer,
+    /// `[top_k * hidden]` — per-slot down output, summed into `acc_buf`
+    /// with router weights.
+    pub down_out_stacked: B::Buffer,
+    /// `[top_k]` i32 expert IDs for the current token (rebuilt each
+    /// layer from the host-side router output).
+    pub ids_buf: B::Buffer,
+    /// `[top_k]` f32 router combine weights for the current token.
+    /// Pre-allocated alongside `ids_buf` so the per-layer update is an
+    /// in-place memcpy via `B::write_f32_into` rather than a fresh
+    /// `B::from_slice` allocation (48 × 128 = 6144 fresh buffers per
+    /// 128-token decode otherwise — same allocator-pressure pattern
+    /// `ids_buf` had before being moved to `write_i32_into`).
+    pub weights_buf: B::Buffer,
+
     // ── Final-token / lm_head outputs ────────────────────────────────
     pub last_hidden: B::Buffer,
     pub last_normed: B::Buffer,
@@ -136,6 +160,12 @@ impl<B: Backend> Qwen3MoeScratch<B> {
             acc_buf: B::alloc(h),
             moe_out: B::alloc(t * h),
             zero_hidden: B::from_slice(&vec![0.0f32; h]),
+            gate_out_stacked: B::alloc(cfg.num_experts_per_tok * inter),
+            up_out_stacked: B::alloc(cfg.num_experts_per_tok * inter),
+            silu_stacked: B::alloc(cfg.num_experts_per_tok * inter),
+            down_out_stacked: B::alloc(cfg.num_experts_per_tok * h),
+            ids_buf: B::from_slice_i32(&vec![0i32; cfg.num_experts_per_tok]),
+            weights_buf: B::from_slice(&vec![0.0f32; cfg.num_experts_per_tok]),
             last_hidden: B::alloc(h),
             last_normed: B::alloc(h),
             logits: B::alloc(vocab),
@@ -542,28 +572,45 @@ impl<B: Backend> Qwen3MoeModel<B> {
         );
 
         // 11. Per-(token, expert) MLP dispatch + weighted combine.
-        //     `moe_forward` writes acc_buf → moe_out[b] once per token,
-        //     so we don't need to pre-zero `moe_out` (every byte will be
-        //     overwritten by the per-token copy_slice from acc_buf).
-        moe_forward::<B>(
-            ctx,
-            &self.scratch.norm_out,
-            &self.scratch.router_logits,
-            &mut self.scratch.moe_out,
-            tokens,
-            h,
-            self.cfg.expert_intermediate_size,
-            self.cfg.num_experts,
-            self.cfg.num_experts_per_tok,
-            self.cfg.norm_topk_prob,
-            &moe_layer.experts,
-            &mut self.scratch.x_single,
-            &mut self.scratch.acc_buf,
-            &mut self.scratch.gate_up_buf,
-            &mut self.scratch.silu_buf,
-            &mut self.scratch.down_buf,
-            &self.scratch.zero_hidden,
-        )?;
+        //
+        // Two paths:
+        //   - **Batched fast path** (decode m=1, all stacked variants
+        //     present): single `gemv_quant_moe_id` dispatch covers all
+        //     8 selected expert × 1 token gate gemvs in parallel; same
+        //     for up and down. Cuts per-layer expert dispatches from
+        //     ~32 (8 × 4 ops/pair) to 4 (gate + up + silu + down + 1 acc).
+        //     Routes Qwen3-30B-A3B decode close to llama.cpp's
+        //     `kernel_mul_mm_id`.
+        //   - **Per-(token, expert) fallback** via `moe_forward` —
+        //     used for prefill (m > 1), or when the backend doesn't
+        //     populate stacked variants (CPU, synthetic-MoE tests).
+        let stacked_path_available = moe_layer.experts.gate_stacked.is_some()
+            && moe_layer.experts.up_stacked.is_some()
+            && moe_layer.experts.down_stacked.is_some();
+
+        if stacked_path_available {
+            self.moe_forward_stacked(ctx, li, tokens)?;
+        } else {
+            moe_forward::<B>(
+                ctx,
+                &self.scratch.norm_out,
+                &self.scratch.router_logits,
+                &mut self.scratch.moe_out,
+                tokens,
+                h,
+                self.cfg.expert_intermediate_size,
+                self.cfg.num_experts,
+                self.cfg.num_experts_per_tok,
+                self.cfg.norm_topk_prob,
+                &moe_layer.experts,
+                &mut self.scratch.x_single,
+                &mut self.scratch.acc_buf,
+                &mut self.scratch.gate_up_buf,
+                &mut self.scratch.silu_buf,
+                &mut self.scratch.down_buf,
+                &self.scratch.zero_hidden,
+            )?;
+        }
 
         // 12. residual += moe_out
         B::add_inplace(ctx, residual, &self.scratch.moe_out, tokens * h);
@@ -578,6 +625,26 @@ impl<B: Backend> Qwen3MoeModel<B> {
         }
 
         Ok(())
+    }
+
+    fn moe_forward_stacked(
+        &mut self,
+        ctx: &mut B::Context,
+        li: usize,
+        tokens: usize,
+    ) -> Result<()> {
+        let cfg = &self.cfg;
+        moe_forward_stacked_decode_impl::<B>(
+            ctx,
+            &self.moe_layers[li],
+            &mut self.scratch,
+            cfg.base.hidden_size,
+            cfg.expert_intermediate_size,
+            cfg.num_experts_per_tok,
+            cfg.num_experts,
+            cfg.norm_topk_prob,
+            tokens,
+        )
     }
 
     /// Prefill: process `tokens` prompt tokens, return last-token logits.
@@ -755,6 +822,124 @@ impl<B: Backend> DecoderOnlyLLM for Qwen3MoeModel<B> {
         self.kv_caches.clear();
         self.kv_free_pool.clear();
     }
+}
+
+/// Batched MoE FFN — decode (m=1) and per-token-prefill (m>1 looped).
+///
+/// Three batched `gemv_quant_moe_id` dispatches per token: gate (broadcast
+/// activation), up (broadcast activation), down (per-slot activation —
+/// each expert sees its own silu·up). The per-(token, expert) outer loop
+/// shrinks from `top_k * 4` dispatches per layer to **3 batched + 1
+/// silu_mul_split + 1 weighted_sum_dispatch_loop**.
+///
+/// For prefill (m > 1) we loop over tokens externally — each token's
+/// router output drives a single batched call. Still much faster than
+/// the per-(token, expert) per-Linear path because the gemvs are batched.
+///
+/// Free function (not a method) so the caller can split the borrow on
+/// `self` between `moe_layers[li]` (immutable) and `scratch` (mutable).
+#[allow(clippy::too_many_arguments)]
+fn moe_forward_stacked_decode_impl<B: Backend>(
+    ctx: &mut B::Context,
+    moe_layer: &Qwen3MoeLayerState<B>,
+    scratch: &mut Qwen3MoeScratch<B>,
+    h: usize,
+    inter: usize,
+    top_k: usize,
+    n_exp: usize,
+    norm_topk_prob: bool,
+    tokens: usize,
+) -> Result<()> {
+    // Host-side routing: pull router_logits for the whole batch, run
+    // softmax + top-K. One sync per call covers all `tokens`.
+    B::sync(ctx);
+    let logits_host = B::to_vec(&scratch.router_logits, tokens * n_exp);
+    let route = crate::moe::router::route(&logits_host, tokens, n_exp, top_k, norm_topk_prob);
+
+    let gate_stacked = moe_layer.experts.gate_stacked.as_ref().unwrap();
+    let up_stacked = moe_layer.experts.up_stacked.as_ref().unwrap();
+    let down_stacked = moe_layer.experts.down_stacked.as_ref().unwrap();
+
+    for b in 0..tokens {
+        // Upload this token's selected expert IDs in place — avoids
+        // re-allocating a fresh MTLBuffer per layer × per token.
+        let ids_i32: Vec<i32> = route.expert_ids[b * top_k..(b + 1) * top_k]
+            .iter()
+            .map(|&id| id as i32)
+            .collect();
+        B::write_i32_into(&mut scratch.ids_buf, &ids_i32);
+
+        // Stage row b of norm_out into x_single (decode m=1 has it
+        // already at offset 0; prefill needs the offset). For decode
+        // we could skip the copy, but doing it uniformly keeps the
+        // kernel's src1 base predictable.
+        B::copy_slice(ctx, &scratch.norm_out, b * h, &mut scratch.x_single, 0, h);
+
+        // 1. Batched gate gemv — broadcast input across top_k slots.
+        B::gemv_quant_moe_id(
+            ctx,
+            &scratch.x_single,
+            gate_stacked,
+            &scratch.ids_buf,
+            &mut scratch.gate_out_stacked,
+            top_k,
+            0, // broadcast
+        )?;
+
+        // 2. Batched up gemv — also broadcast.
+        B::gemv_quant_moe_id(
+            ctx,
+            &scratch.x_single,
+            up_stacked,
+            &scratch.ids_buf,
+            &mut scratch.up_out_stacked,
+            top_k,
+            0,
+        )?;
+
+        // 3. Stacked SiLU·gate → silu_stacked. Single dispatch covers
+        //    all top_k slots — replaces the per-slot loop's
+        //    (3 copy_slice + 1 silu_mul) × 8 = 32 dispatches.
+        B::silu_mul_stacked(
+            ctx,
+            &scratch.gate_out_stacked,
+            &scratch.up_out_stacked,
+            &mut scratch.silu_stacked,
+            top_k,
+            inter,
+        )?;
+
+        // 4. Batched down gemv — per-slot input via src1_stride = inter.
+        //    silu_stacked[k * inter ..] is the activation row for slot k.
+        B::gemv_quant_moe_id(
+            ctx,
+            &scratch.silu_stacked,
+            down_stacked,
+            &scratch.ids_buf,
+            &mut scratch.down_out_stacked,
+            top_k,
+            inter,
+        )?;
+
+        // 5. Stacked weighted sum: acc_buf[0..h] = Σ_k w[k] · down[k].
+        //    Upload this token's combine weights in place — same trick
+        //    as ids_buf, avoids 6144 per-decode MTLBuffer allocations.
+        let weights_slice = &route.expert_weights[b * top_k..(b + 1) * top_k];
+        B::write_f32_into(&mut scratch.weights_buf, weights_slice);
+        B::weighted_sum_stacked(
+            ctx,
+            &scratch.down_out_stacked,
+            &scratch.weights_buf,
+            &mut scratch.acc_buf,
+            top_k,
+            h,
+        )?;
+
+        // 6. Final write into moe_out[b * h ..]
+        B::copy_slice(ctx, &scratch.acc_buf, 0, &mut scratch.moe_out, b * h, h);
+    }
+
+    Ok(())
 }
 
 /// Build a stub Linear<B> with the given shape but zero weights. Used to

--- a/crates/ferrum-models/src/moe/dispatch.rs
+++ b/crates/ferrum-models/src/moe/dispatch.rs
@@ -69,6 +69,20 @@ pub struct ExpertStack<B: Backend> {
     pub gate_up: Vec<Box<dyn Linear<B>>>,
     /// `down` projection per expert. Output shape per token: `[hidden_size]`.
     pub down: Vec<Box<dyn Linear<B>>>,
+    /// Stacked-experts representation for backends that have a batched
+    /// MoE indirect-dispatch kernel (Metal `gemv_q4kw_moe_id_f32` /
+    /// `gemv_q6kw_moe_id_f32`). Holds **all experts** for one matmul
+    /// role in a single `B::QuantStore` with byte stride between expert
+    /// slabs, so a single dispatch can cover all selected (token, expert)
+    /// pairs at decode m=1.
+    ///
+    /// `None` on backends without the kernel (CPU, CUDA-without-MoE-kernel)
+    /// and on quant flavours that don't have a stacked path yet — callers
+    /// fall back to the per-expert `gate_up` / `down` Linears in those
+    /// cases.
+    pub gate_stacked: Option<B::QuantStore>,
+    pub up_stacked: Option<B::QuantStore>,
+    pub down_stacked: Option<B::QuantStore>,
 }
 
 impl<B: Backend> ExpertStack<B> {
@@ -129,7 +143,13 @@ impl<B: Backend> ExpertStack<B> {
                 expert_intermediate,
             )) as Box<dyn Linear<B>>);
         }
-        Ok(Self { gate_up, down })
+        Ok(Self {
+            gate_up,
+            down,
+            gate_stacked: None,
+            up_stacked: None,
+            down_stacked: None,
+        })
     }
 
     /// Load all experts for one MoE layer from a GGUF file. Names follow
@@ -191,6 +211,8 @@ impl<B: Backend> ExpertStack<B> {
             &format!("blk.{layer_idx}.ffn_down_exps.weight"),
             &device,
         )?;
+        // Eager-dense path leaves stacked variants as None — no MoE
+        // fast path for synthesised / non-quantised expert tensors.
         Self::from_dense_stacks(
             &gate,
             &up,
@@ -280,41 +302,91 @@ impl<B: Backend> ExpertStack<B> {
             "ffn_down_exps bytes",
         )?;
 
-        let mut gate_up: Vec<Box<dyn Linear<B>>> = Vec::with_capacity(num_experts);
-        let mut down: Vec<Box<dyn Linear<B>>> = Vec::with_capacity(num_experts);
+        // Try the stacked-experts fast path FIRST. If the backend has a
+        // batched MoE kernel (Metal `gemv_q*kw_moe_id_f32`), we want to
+        // hold the experts only as one big stacked buffer per role —
+        // not as 128 per-expert MetalQuantStores PLUS the stacked one
+        // (that would double-allocate ~17 GB on a 32 GB Mac, which on
+        // Qwen3-30B-A3B Q4_K_M sends the model into swap and tanks
+        // both load and forward time).
+        let gate_stacked = B::load_quant_experts(
+            gate_kind,
+            gate_bytes,
+            num_experts,
+            expert_intermediate,
+            hidden_size,
+        )
+        .ok();
+        let up_stacked = B::load_quant_experts(
+            up_kind,
+            up_bytes,
+            num_experts,
+            expert_intermediate,
+            hidden_size,
+        )
+        .ok();
+        let down_stacked = B::load_quant_experts(
+            down_kind,
+            down_bytes,
+            num_experts,
+            hidden_size,
+            expert_intermediate,
+        )
+        .ok();
 
-        for e in 0..num_experts {
-            let g_slice = &gate_bytes[e * gate_per..(e + 1) * gate_per];
-            let u_slice = &up_bytes[e * up_per..(e + 1) * up_per];
-            let d_slice = &down_bytes[e * down_per..(e + 1) * down_per];
+        // Decide the storage shape:
+        //   * Stacked-only (Metal MoE fast path): all three stacked
+        //     loaders succeeded — skip per-expert and use stacked
+        //     for both decode and prefill. Cuts memory in half.
+        //   * Per-expert: stacked path is incomplete or unsupported —
+        //     load 128-per-layer QuantLinears and let `moe_forward`
+        //     drive the per-(token, expert) loop on top of them.
+        let stacked_complete =
+            gate_stacked.is_some() && up_stacked.is_some() && down_stacked.is_some();
 
-            // gate || up — fused QuantStore (rows = 2*expert_inter, cols = hidden).
-            // `from_gguf_fused` requires the parts share `in_features` (cols).
-            let parts: [(GgufQuantType, &[u8], usize); 2] = [
-                (gate_kind, g_slice, expert_intermediate),
-                (up_kind, u_slice, expert_intermediate),
-            ];
-            let gate_up_e = match QuantLinear::<B>::from_gguf_fused(&parts, hidden_size) {
-                Ok(q) => q,
-                // Backend doesn't support the Fused variant — fall back
-                // entirely. The caller will retry through the dense path.
-                Err(_) => return Ok(None),
-            };
-            gate_up.push(Box::new(gate_up_e) as Box<dyn Linear<B>>);
+        let (gate_up, down) = if stacked_complete {
+            // No per-expert needed — `moe_forward_stacked_decode_impl`
+            // and the per-token prefill loop both use the stacked buffers.
+            (Vec::new(), Vec::new())
+        } else {
+            let mut gate_up: Vec<Box<dyn Linear<B>>> = Vec::with_capacity(num_experts);
+            let mut down: Vec<Box<dyn Linear<B>>> = Vec::with_capacity(num_experts);
+            for e in 0..num_experts {
+                let g_slice = &gate_bytes[e * gate_per..(e + 1) * gate_per];
+                let u_slice = &up_bytes[e * up_per..(e + 1) * up_per];
+                let d_slice = &down_bytes[e * down_per..(e + 1) * down_per];
 
-            let down_e = match QuantLinear::<B>::from_gguf_bytes(
-                down_kind,
-                d_slice,
-                hidden_size,
-                expert_intermediate,
-            ) {
-                Ok(q) => q,
-                Err(_) => return Ok(None),
-            };
-            down.push(Box::new(down_e) as Box<dyn Linear<B>>);
-        }
+                let parts: [(GgufQuantType, &[u8], usize); 2] = [
+                    (gate_kind, g_slice, expert_intermediate),
+                    (up_kind, u_slice, expert_intermediate),
+                ];
+                let gate_up_e = match QuantLinear::<B>::from_gguf_fused(&parts, hidden_size) {
+                    Ok(q) => q,
+                    Err(_) => return Ok(None),
+                };
+                gate_up.push(Box::new(gate_up_e) as Box<dyn Linear<B>>);
 
-        Ok(Some(Self { gate_up, down }))
+                let down_e = match QuantLinear::<B>::from_gguf_bytes(
+                    down_kind,
+                    d_slice,
+                    hidden_size,
+                    expert_intermediate,
+                ) {
+                    Ok(q) => q,
+                    Err(_) => return Ok(None),
+                };
+                down.push(Box::new(down_e) as Box<dyn Linear<B>>);
+            }
+            (gate_up, down)
+        };
+
+        Ok(Some(Self {
+            gate_up,
+            down,
+            gate_stacked,
+            up_stacked,
+            down_stacked,
+        }))
     }
 
     /// Convenience: open a GGUF and load layer `layer_idx`. The GGUF
@@ -338,6 +410,12 @@ impl<B: Backend> ExpertStack<B> {
     }
 
     /// `num_experts` for the layer (consistency check helper).
+    ///
+    /// Returns the per-expert Vec length, OR — when the stacked-only
+    /// path is in effect (Metal MoE fast path with empty per-expert
+    /// Vecs) — falls back to a stored count via the stacked variants.
+    /// In the stacked-only case there's no Vec to count, so this method
+    /// is mostly used by tests on the per-expert path.
     pub fn num_experts(&self) -> usize {
         debug_assert_eq!(
             self.gate_up.len(),


### PR DESCRIPTION
## Summary

Ports llama.cpp's `kernel_mul_mm_id` indirect-dispatch pattern to ferrum's MoE decode hot path. A single Metal launch covers all `top_k` selected (token, expert) gemvs via `grid.z = expert_slot` + an `ids` tensor lookup, instead of looping `top_k` times on the host.

Per-layer dispatch count: **~46 (PR #36 per-expert) → ~10 (this PR stacked + fused post-ops)**.

## What's new

### Metal kernels
- **`gemv_q4kw_moe_id_f32` / `gemv_q6kw_moe_id_f32`** — stacked-experts indirect gemv. `src1_stride` parameter selects broadcast (0, used for `gate`/`up`) vs per-slot (`K`, used for `down`).
- **`silu_mul_stacked_f32`** — `[top_k, ffn]` SiLU·gate in one dispatch. Replaces 32 staging copies + 8 silu calls per layer.
- **`weighted_sum_stacked_f32`** — `[top_k, hidden]` × `[top_k]` weights → `[hidden]` in one dispatch. Replaces 16 dispatches per layer.

### Storage
- `MetalQuantStore::Q4KExperts` / `Q6KExperts` variants hold all 128 experts contiguously (one MTLBuffer per matmul role × layer), with byte stride `nb02` between expert slabs.
- `ExpertStack::load_from_gguf` decides between **stacked-only** (Metal MoE path) and **per-expert-only** (CPU / unsupported quant) — never both. Previously loading both representations doubled memory to ~36 GB and sent the 32 GB Mac into swap.

### Backend trait additions
- `load_quant_experts` — build a stacked `QuantStore` from `[num_experts, n_rows, n_cols/256]` bytes.
- `gemv_quant_moe_id` — single-dispatch indirect gemv across all selected (token, expert) pairs.
- `silu_mul_stacked`, `weighted_sum_stacked` — fused post-op kernels.
- `write_i32_into`, `write_f32_into` — in-place buffer updates so per-layer `ids` and `weights` uploads don't alloc a fresh MTLBuffer each call (6144 fresh allocations / 128-tok decode otherwise).

## Measured (M1 Max, Metal, FERRUM_KV_CAPACITY=1024, cold 32-tok smoke)

| Stage | tok/s | Latency / tok |
|---|---:|---:|
| PR #35 (round-trip via `out`) | 2.1 | 480 ms |
| PR #36 (acc_buf accumulator) | 4.4 | 228 ms |
| **This PR** | **17-19** | **51-60 ms** |
| llama.cpp warm 5-rep mean | 44.5 | 22 ms |

**~4× faster cold-start decode vs PR #36.** Still ~2.5× behind llama.cpp warm — remaining gap is GPU-side routing + 2-D mul_mm_id batched prefill, both follow-ups.

## Caveats

- **Prefill unchanged** (pp512 ~44 t/s, equal to PR #36). The stacked path still loops per-token through `mul_mv` (gemv) for 302 tokens. Closing the 14× pp512 gap to llama.cpp's 596 t/s requires a 2-D `mul_mm_id` kernel that batches `grid.y = token-tile` in addition to `grid.z = expert`. **Next PR.**
- 5-rep tg128 bench means showed high variance (10-19 t/s) due to OS-level swap sensitivity on a 17 GB model on a 32 GB Mac. Best reps consistent with smoke. Cleaning up other apps (closed Lark / WeChat / DBeaver) reduced but didn't eliminate the variance — root cause is the bench harness reloading the 17 GB GGUF per rep, which thrashes filesystem cache. llama.cpp's `llama-bench` runs all reps in one process. Switching to a similar harness is a separate housekeeping task.

## Validation

- `cargo fmt --all -- --check` clean
- `cargo clippy --workspace --all-targets -- -A warnings` clean
- `cargo test --workspace` 88/88 passes (CPU)
- `cargo test --workspace --features metal` 88/88 passes (Metal)
- End-to-end smoke on Qwen3-30B-A3B-Q4_K_M GGUF — coherent token generation

## Test plan

- [x] CPU + Metal unit tests pass
- [x] Smoke on Qwen3-30B-A3B
- [ ] Bench harness rewrite (out of scope — separate housekeeping PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)