### PR TITLE
fix(models): read head_dim from GGUF metadata instead of hidden/heads

### DIFF
--- a/crates/ferrum-models/src/gguf_config.rs
+++ b/crates/ferrum-models/src/gguf_config.rs
@@ -95,14 +95,22 @@ impl LlamaFamilyConfig {
             Err(_) => infer_vocab_from_embed(gguf)?,
         };
 
-        // head_dim: GGUF doesn't always store it; derive from hidden / heads.
-        // (All known Llama-family checkpoints satisfy hidden_size % num_heads == 0.)
-        if num_heads == 0 || hidden_size % num_heads != 0 {
-            return Err(FerrumError::model(format!(
-                "GGUF config: hidden_size {hidden_size} not divisible by num_heads {num_heads}"
-            )));
-        }
-        let head_dim = hidden_size / num_heads;
+        // head_dim: prefer the explicit `<arch>.attention.key_length` key
+        // when present — Qwen3-MoE / Qwen3-30B-A3B has hidden_size=2048
+        // but num_heads*head_dim=4096 (head_dim=128), so the
+        // `hidden_size / num_heads` shortcut is WRONG for that family.
+        // Fall back to the divide only for older GGUFs that omit the key.
+        let head_dim = match read_u32(gguf, &format!("{arch}.attention.key_length")) {
+            Ok(v) => v as usize,
+            Err(_) => {
+                if num_heads == 0 || hidden_size % num_heads != 0 {
+                    return Err(FerrumError::model(format!(
+                        "GGUF config: head_dim missing AND hidden_size {hidden_size} not divisible by num_heads {num_heads}"
+                    )));
+                }
+                hidden_size / num_heads
+            }
+        };
 
         Ok(LlamaFamilyConfig {
             hidden_size,
@@ -164,12 +172,22 @@ impl Qwen3MoeConfig {
             Err(_) => infer_vocab_from_embed(gguf)?,
         };
 
-        if num_heads == 0 || hidden_size % num_heads != 0 {
-            return Err(FerrumError::model(format!(
-                "GGUF Qwen3-MoE: hidden_size {hidden_size} not divisible by num_heads {num_heads}"
-            )));
-        }
-        let head_dim = hidden_size / num_heads;
+        // See LlamaFamilyConfig::from_gguf for the rationale: prefer the
+        // explicit `qwen3moe.attention.key_length` GGUF key. For
+        // Qwen3-30B-A3B specifically, hidden=2048 but head_dim=128
+        // (num_heads*head_dim=4096 ≠ hidden), so the shortcut divide
+        // gives 64 → wrong q_dim → garbage attention output.
+        let head_dim = match read_u32(gguf, "qwen3moe.attention.key_length") {
+            Ok(v) => v as usize,
+            Err(_) => {
+                if num_heads == 0 || hidden_size % num_heads != 0 {
+                    return Err(FerrumError::model(format!(
+                        "GGUF Qwen3-MoE: head_dim missing AND hidden_size {hidden_size} not divisible by num_heads {num_heads}"
+                    )));
+                }
+                hidden_size / num_heads
+            }
+        };
 
         // MoE-specific keys.
         let num_experts = read_u32(gguf, "qwen3moe.expert_count")? as usize;


### PR DESCRIPTION
## Summary

**Critical correctness fix.** `Qwen3-30B-A3B` has `hidden_size=2048, num_heads=32, head_dim=128` — i.e. `num_heads * head_dim = 4096 ≠ hidden_size`. The shortcut `head_dim = hidden_size / num_heads` produced 64 (wrong by 2×) for this family, sending q_dim/kv_dim and the entire attention path to nonsense numbers.

**Symptom:** 30B-A3B-Q4_K_M generated repeating-token gibberish (`"Dund impe impe impe..."` or `"_Cell_Cell_Cell..."`), while Qwen3-8B (where `hidden=4096=32×128` happens to satisfy the shortcut) worked fine.

**Fix:** read the explicit `<arch>.attention.key_length` GGUF key first (set by all modern Qwen3 / Qwen3-MoE conversions). Fall back to the shortcut only if the key is missing — preserves backward compat for older GGUFs. Applied to both `LlamaFamilyConfig::from_gguf` (dense path) and `Qwen3MoeConfig::from_gguf` (MoE path).

## Latency on prior benchmarks

This bug had been latent across PRs #35, #36, #39 — every benchmark ran in `--bench-mode` which suppresses token output, so the speed numbers were real but the output text was always garbage. **All decode/prefill speed numbers from those PRs were measured on a buggy implementation.** With this fix, 30B-A3B now generates plausible English continuations (`"The capital of France is 2019, and the..."` — content imperfect but tokens are real English, not repeating noise).

## Discovery sequence

1. After landing the 2-D `mul_mm_id` prefill kernels on a separate branch, ran `--max-tokens 16` without `--bench-mode` → saw repeating-token gibberish.
2. Verified `Qwen3-8B Q4_K_M` is fine on the same binary → bug is MoE-specific.
3. Set `FERRUM_MOE_DISABLE_STACKED=1` to force the per-expert MoE fallback path → still garbage. Bug is upstream of FFN dispatch.
4. Inspected GGUF tensor shapes via `llama-gguf`: `attn_q_norm.weight` is 128 elements (matches `head_dim=128` from the HF config), but ferrum was deriving `head_dim = 2048/32 = 64`. The model code trusted the divide instead of consulting metadata.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-targets -- -A warnings` clean
- [x] `cargo test --workspace` 88/88 passes
- [x] `cargo test --workspace --features metal` 88/88 passes
- [x] On-hardware: Qwen3-30B-A3B Q4_K_M `"The capital of France is"` now produces coherent English (was repeating-token gibberish before this PR)
- [ ] Re-bench Qwen3-30B-A3B speed numbers — head_dim doubled means buffers and attention compute increased, expect a slowdown until the perf side is rewired (separate follow-up)

## Follow-ups

- The doubled scratch buffers (`q_buf`, `k_head_major`, `v_head_major`, etc.) push 30B-A3B into swap on a 32 GB Mac. Need either tighter `FERRUM_KV_CAPACITY` defaults for MoE models or a more compact buffer layout.
- All BENCHMARKS.md numbers for Qwen3-30B-A3B from PRs #35–#39 are invalid (measured on garbage output). To be re-measured after this fix lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)