### PR TITLE
perf(moe): 2-D mul_mm_id Q4_K/Q6_K — batched MoE prefill

### DIFF
--- a/crates/ferrum-kernels/src/backend/metal.rs
+++ b/crates/ferrum-kernels/src/backend/metal.rs
@@ -741,6 +741,128 @@ impl Backend for MetalBackend {
         }
     }
 
+    fn gemm_quant_moe_id(
+        ctx: &mut Self::Context,
+        a: &Self::Buffer,
+        weight: &Self::QuantStore,
+        ids: &Self::Buffer,
+        tpe: &Self::Buffer,
+        out: &mut Self::Buffer,
+        ne11: usize,
+        top_k: usize,
+        max_per_expert: usize,
+        batch: usize,
+    ) -> Result<()> {
+        let a_buf = a.expect_f32("gemm_quant_moe_id a");
+        let ids_buf = &ids.raw;
+        let tpe_buf = &tpe.raw;
+        let out_buf = out.expect_f32_mut("gemm_quant_moe_id out");
+        let enc = ctx.compute_encoder();
+        match weight {
+            MetalQuantStore::Q4KExperts {
+                blocks,
+                num_experts,
+                n_rows,
+                n_cols,
+            } => {
+                crate::q4_k_moe_id_gemm::dispatch_gemm_q4k_moe_id_on_encoder(
+                    &st().pipes.device,
+                    enc,
+                    blocks,
+                    a_buf,
+                    ids_buf,
+                    tpe_buf,
+                    out_buf,
+                    *num_experts,
+                    *n_rows,
+                    *n_cols,
+                    ne11,
+                    top_k,
+                    max_per_expert,
+                    batch,
+                );
+                Ok(())
+            }
+            MetalQuantStore::Q6KExperts {
+                blocks,
+                num_experts,
+                n_rows,
+                n_cols,
+            } => {
+                crate::q6_k_moe_id_gemm::dispatch_gemm_q6k_moe_id_on_encoder(
+                    &st().pipes.device,
+                    enc,
+                    blocks,
+                    a_buf,
+                    ids_buf,
+                    tpe_buf,
+                    out_buf,
+                    *num_experts,
+                    *n_rows,
+                    *n_cols,
+                    ne11,
+                    top_k,
+                    max_per_expert,
+                    batch,
+                );
+                Ok(())
+            }
+            _ => Err(FerrumError::model(
+                "gemm_quant_moe_id: weight must be Q4KExperts or Q6KExperts".to_string(),
+            )),
+        }
+    }
+
+    fn silu_mul_batched(
+        ctx: &mut Self::Context,
+        gate: &Self::Buffer,
+        up: &Self::Buffer,
+        out: &mut Self::Buffer,
+        total_pairs: usize,
+        ffn: usize,
+    ) -> Result<()> {
+        let gate_buf = gate.expect_f32("silu_mul_batched gate");
+        let up_buf = up.expect_f32("silu_mul_batched up");
+        let out_buf = out.expect_f32_mut("silu_mul_batched out");
+        let enc = ctx.compute_encoder();
+        crate::moe_post_ops_batched::dispatch_silu_mul_batched(
+            &st().pipes.device,
+            enc,
+            gate_buf,
+            up_buf,
+            out_buf,
+            total_pairs,
+            ffn,
+        );
+        Ok(())
+    }
+
+    fn weighted_sum_batched(
+        ctx: &mut Self::Context,
+        slots: &Self::Buffer,
+        weights: &Self::Buffer,
+        out: &mut Self::Buffer,
+        batch: usize,
+        top_k: usize,
+        hidden: usize,
+    ) -> Result<()> {
+        let slots_buf = slots.expect_f32("weighted_sum_batched slots");
+        let weights_buf = weights.expect_f32("weighted_sum_batched weights");
+        let out_buf = out.expect_f32_mut("weighted_sum_batched out");
+        let enc = ctx.compute_encoder();
+        crate::moe_post_ops_batched::dispatch_weighted_sum_batched(
+            &st().pipes.device,
+            enc,
+            slots_buf,
+            weights_buf,
+            out_buf,
+            batch,
+            top_k,
+            hidden,
+        );
+        Ok(())
+    }
+
     fn silu_mul_stacked(
         ctx: &mut Self::Context,
         gate: &Self::Buffer,

--- a/crates/ferrum-kernels/src/backend/traits.rs
+++ b/crates/ferrum-kernels/src/backend/traits.rs
@@ -376,6 +376,79 @@ pub trait Backend: Send + Sync + Sized + 'static {
         ))
     }
 
+    /// MoE 2-D indirect-dispatch GEMM (prefill m > 1).
+    ///
+    /// Computes per (token, expert_slot) pair, batched across all
+    /// experts in one launch:
+    ///
+    ///   `out[token, slot, :] = a[token, slot_or_0, :] @ dequant(weight[expert(token, slot), :])^T`
+    ///
+    /// `ids[expert][slot] = pair_id` encodes `(token_idx, slot_within_token)`
+    /// so the kernel reads activations indirectly (src1 row for the
+    /// pair) and writes outputs directly to the natural
+    /// `[batch, top_k, M]` layout. `tpe[expert]` gives the count of
+    /// pairs assigned to each expert — threadgroups past `tpe[e]`
+    /// early-exit.
+    ///
+    /// `ne11` selects the src1 inner-batch shape:
+    /// - `1` for `gate` / `up` (broadcast — all slots read the same
+    ///   activation row per token).
+    /// - `top_k` for `down` (per-slot — each pair reads its own row in
+    ///   the upstream silu·gate output).
+    ///
+    /// Closes the prefill MoE gap: the per-token gemv loop becomes one
+    /// batched gemm where each expert's slab handles m ≈ batch·top_k /
+    /// num_experts pairs in parallel via simdgroup_half8x8 matmul.
+    #[allow(clippy::too_many_arguments)]
+    fn gemm_quant_moe_id(
+        _ctx: &mut Self::Context,
+        _a: &Self::Buffer,
+        _weight: &Self::QuantStore,
+        _ids: &Self::Buffer,
+        _tpe: &Self::Buffer,
+        _out: &mut Self::Buffer,
+        _ne11: usize,
+        _top_k: usize,
+        _max_per_expert: usize,
+        _batch: usize,
+    ) -> Result<()> {
+        Err(FerrumError::unsupported(
+            "gemm_quant_moe_id not implemented for this backend",
+        ))
+    }
+
+    /// Stacked SiLU·gate over `[batch * top_k, ffn]` rows (prefill version
+    /// of `silu_mul_stacked`).
+    fn silu_mul_batched(
+        _ctx: &mut Self::Context,
+        _gate: &Self::Buffer,
+        _up: &Self::Buffer,
+        _out: &mut Self::Buffer,
+        _total_pairs: usize,
+        _ffn: usize,
+    ) -> Result<()> {
+        Err(FerrumError::unsupported(
+            "silu_mul_batched not implemented for this backend",
+        ))
+    }
+
+    /// Per-batch weighted sum: `out[b, h] = Σ_k weights[b, k] · slots[b, k, h]`.
+    /// Single dispatch covers the whole batch (prefill version of
+    /// `weighted_sum_stacked` which only handled one token).
+    fn weighted_sum_batched(
+        _ctx: &mut Self::Context,
+        _slots: &Self::Buffer,
+        _weights: &Self::Buffer,
+        _out: &mut Self::Buffer,
+        _batch: usize,
+        _top_k: usize,
+        _hidden: usize,
+    ) -> Result<()> {
+        Err(FerrumError::unsupported(
+            "weighted_sum_batched not implemented for this backend",
+        ))
+    }
+
     /// MoE indirect-dispatch GEMV: `out[i, :] = a[i, :] @ dequant(weight[ids[i], :])^T`
     /// for each `i ∈ [0, n_selected)`. Single backend dispatch covers
     /// all selected (token, expert) pairs.

--- a/crates/ferrum-kernels/src/lib.rs
+++ b/crates/ferrum-kernels/src/lib.rs
@@ -9,8 +9,12 @@ pub mod backend;
 pub mod linear;
 pub use linear::Linear;
 
+pub mod moe_host;
+
 #[cfg(all(target_os = "macos", feature = "metal"))]
 pub mod moe_post_ops;
+#[cfg(all(target_os = "macos", feature = "metal"))]
+pub mod moe_post_ops_batched;
 #[cfg(all(target_os = "macos", feature = "metal"))]
 pub mod q4_k;
 #[cfg(all(target_os = "macos", feature = "metal"))]
@@ -20,11 +24,15 @@ pub mod q4_k_gemv;
 #[cfg(all(target_os = "macos", feature = "metal"))]
 pub mod q4_k_gemv_v2;
 #[cfg(all(target_os = "macos", feature = "metal"))]
+pub mod q4_k_moe_id_gemm;
+#[cfg(all(target_os = "macos", feature = "metal"))]
 pub mod q4_k_moe_id_gemv;
 #[cfg(all(target_os = "macos", feature = "metal"))]
 pub mod q6_k_gemm;
 #[cfg(all(target_os = "macos", feature = "metal"))]
 pub mod q6_k_gemv;
+#[cfg(all(target_os = "macos", feature = "metal"))]
+pub mod q6_k_moe_id_gemm;
 #[cfg(all(target_os = "macos", feature = "metal"))]
 pub mod q6_k_moe_id_gemv;
 

--- a/crates/ferrum-kernels/src/moe_host.rs
+++ b/crates/ferrum-kernels/src/moe_host.rs
@@ -1,0 +1,72 @@
+//! Backend-agnostic MoE host-side helpers — used by all backends and
+//! across all builds (no `cfg(feature = "metal")` gate).
+//!
+//! `compute_ids_tpe` builds the `ids[num_experts, max_per_expert]` /
+//! `tpe[num_experts]` arrays from per-token expert assignments. It's
+//! pure CPU code: a small bucket-sort by expert id over the
+//! `[batch, top_k]` selected_experts table.
+
+/// Host-side computation of `tpe[num_experts]` and
+/// `ids[num_experts, max_per_expert]` from per-token expert IDs.
+///
+/// Input: `selected_experts[batch * top_k]` — flat array of expert IDs
+/// where index `b * top_k + k` is token `b`'s `k`-th selected expert.
+///
+/// Returns `(tpe, ids, max_per_expert)`:
+/// - `tpe[e]` = number of (token, slot) pairs assigned to expert `e`.
+/// - `ids[e * max_per_expert + slot]` = global pair index `b * top_k + k`
+///   that landed in expert `e`'s slot `slot`.
+/// - `max_per_expert` is the largest count across all experts (defines
+///   the row stride of the `ids` array).
+pub fn compute_ids_tpe(
+    selected_experts: &[u32],
+    num_experts: usize,
+    batch: usize,
+    top_k: usize,
+) -> (Vec<i32>, Vec<i32>, usize) {
+    debug_assert_eq!(selected_experts.len(), batch * top_k);
+
+    let mut buckets: Vec<Vec<i32>> = vec![Vec::new(); num_experts];
+    for b in 0..batch {
+        for k in 0..top_k {
+            let pair_idx = (b * top_k + k) as i32;
+            let e = selected_experts[b * top_k + k] as usize;
+            if e < num_experts {
+                buckets[e].push(pair_idx);
+            }
+        }
+    }
+
+    let max_per_expert = buckets.iter().map(|v| v.len()).max().unwrap_or(0);
+    let max_per_expert = max_per_expert.max(1);
+
+    let mut tpe = vec![0i32; num_experts];
+    let mut ids = vec![0i32; num_experts * max_per_expert];
+    for (e, bucket) in buckets.iter().enumerate() {
+        tpe[e] = bucket.len() as i32;
+        let off = e * max_per_expert;
+        for (slot, &pair) in bucket.iter().enumerate() {
+            ids[off + slot] = pair;
+        }
+    }
+    (tpe, ids, max_per_expert)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn compute_ids_tpe_simple() {
+        // 2 tokens, top_k=2, num_experts=4.
+        // Token 0 picks experts (1, 3); token 1 picks (1, 0).
+        let selected = vec![1u32, 3, 1, 0];
+        let (tpe, ids, mpe) = compute_ids_tpe(&selected, 4, 2, 2);
+        assert_eq!(tpe, vec![1, 2, 0, 1]);
+        assert_eq!(mpe, 2);
+        assert_eq!(ids[0], 3);
+        assert_eq!(ids[2], 0);
+        assert_eq!(ids[3], 2);
+        assert_eq!(ids[6], 1);
+    }
+}

--- a/crates/ferrum-kernels/src/moe_post_ops_batched.metal
+++ b/crates/ferrum-kernels/src/moe_post_ops_batched.metal
@@ -1,0 +1,74 @@
+// MoE batched post-ops — variants of the decode-mode `silu_mul_stacked`
+// and `weighted_sum_stacked` kernels that handle batch > 1 (prefill).
+//
+// In the decode path, `silu_mul_stacked` collapses [top_k, ffn] into
+// one launch and `weighted_sum_stacked` reduces [top_k, hidden] →
+// [hidden] for a single token. Prefill needs the same primitives over
+// `[batch, top_k, ffn]` and `[batch, top_k, hidden]` respectively.
+
+#include <metal_stdlib>
+using namespace metal;
+
+// ── Stacked SiLU·gate over [batch, top_k, ffn] ──────────────────────
+// Output[b, k, i] = silu(gate[b, k, i]) * up[b, k, i].
+// Layout matches what mul_mm_id writes: [batch * top_k, ffn] flat.
+
+struct SiluMulBatchedParams {
+    int total_pairs;   // = batch * top_k
+    int ffn;
+};
+
+kernel void silu_mul_batched_f32(
+    device const float* gate     [[buffer(0)]],
+    device const float* up       [[buffer(1)]],
+    device       float* out      [[buffer(2)]],
+    constant SiluMulBatchedParams& p [[buffer(3)]],
+    uint3 tgpig [[threadgroup_position_in_grid]],
+    uint3 tpig  [[thread_position_in_threadgroup]])
+{
+    const uint pair = tgpig.y;
+    if (pair >= uint(p.total_pairs)) return;
+
+    const uint i = tgpig.x * 256 + tpig.x;
+    if (i >= uint(p.ffn)) return;
+
+    const uint off = pair * uint(p.ffn) + i;
+    const float g = gate[off];
+    const float u = up[off];
+    const float s = g / (1.0f + exp(-g));
+    out[off] = s * u;
+}
+
+// ── Weighted sum over top_k for each batch element ──────────────────
+// out[b, h] = Σ_k weights[b, k] * slots[b, k, h]
+// for b ∈ [0, batch), h ∈ [0, hidden). Single dispatch covers the whole
+// batch, replacing the per-token weighted_sum_stacked that decode used.
+
+struct WeightedSumBatchedParams {
+    int batch;
+    int top_k;
+    int hidden;
+};
+
+kernel void weighted_sum_batched_f32(
+    device const float* slots    [[buffer(0)]],   // [batch, top_k, hidden]
+    device const float* weights  [[buffer(1)]],   // [batch, top_k]
+    device       float* out      [[buffer(2)]],   // [batch, hidden]
+    constant WeightedSumBatchedParams& p [[buffer(3)]],
+    uint3 tgpig [[threadgroup_position_in_grid]],
+    uint3 tpig  [[thread_position_in_threadgroup]])
+{
+    const uint b = tgpig.y;
+    if (b >= uint(p.batch)) return;
+
+    const uint h = tgpig.x * 256 + tpig.x;
+    if (h >= uint(p.hidden)) return;
+
+    float sum = 0.0f;
+    const uint slot_base = b * uint(p.top_k) * uint(p.hidden);
+    const uint weight_base = b * uint(p.top_k);
+    for (int k = 0; k < p.top_k; k++) {
+        sum += weights[weight_base + uint(k)] * slots[slot_base + uint(k) * uint(p.hidden) + h];
+    }
+    out[b * uint(p.hidden) + h] = sum;
+}

--- a/crates/ferrum-kernels/src/moe_post_ops_batched.rs
+++ b/crates/ferrum-kernels/src/moe_post_ops_batched.rs
@@ -1,0 +1,120 @@
+//! Stacked SiLU·gate + weighted-sum kernels for batch > 1 (prefill).
+//! See `moe_post_ops_batched.metal` for the algorithmic notes.
+
+#![cfg(all(target_os = "macos", feature = "metal"))]
+
+use std::ffi::c_void;
+use std::sync::OnceLock;
+
+use metal::{
+    Buffer, CompileOptions, ComputeCommandEncoderRef, ComputePipelineState, Device, MTLSize,
+};
+
+const SHADER_SRC: &str = include_str!("moe_post_ops_batched.metal");
+
+static SILU_PIPELINE: OnceLock<ComputePipelineState> = OnceLock::new();
+static WSUM_PIPELINE: OnceLock<ComputePipelineState> = OnceLock::new();
+
+fn silu_pipeline(device: &Device) -> &'static ComputePipelineState {
+    SILU_PIPELINE.get_or_init(|| {
+        let lib = device
+            .new_library_with_source(SHADER_SRC, &CompileOptions::new())
+            .expect("compile moe_post_ops_batched.metal");
+        let function = lib
+            .get_function("silu_mul_batched_f32", None)
+            .expect("find silu_mul_batched_f32");
+        device
+            .new_compute_pipeline_state_with_function(&function)
+            .expect("build silu_mul_batched_f32 pipeline")
+    })
+}
+
+fn wsum_pipeline(device: &Device) -> &'static ComputePipelineState {
+    WSUM_PIPELINE.get_or_init(|| {
+        let lib = device
+            .new_library_with_source(SHADER_SRC, &CompileOptions::new())
+            .expect("compile moe_post_ops_batched.metal");
+        let function = lib
+            .get_function("weighted_sum_batched_f32", None)
+            .expect("find weighted_sum_batched_f32");
+        device
+            .new_compute_pipeline_state_with_function(&function)
+            .expect("build weighted_sum_batched_f32 pipeline")
+    })
+}
+
+pub fn dispatch_silu_mul_batched(
+    device: &Device,
+    enc: &ComputeCommandEncoderRef,
+    gate: &Buffer,
+    up: &Buffer,
+    out: &Buffer,
+    total_pairs: usize,
+    ffn: usize,
+) {
+    #[repr(C)]
+    struct P {
+        total_pairs: i32,
+        ffn: i32,
+    }
+    let params = P {
+        total_pairs: total_pairs as i32,
+        ffn: ffn as i32,
+    };
+
+    let pipe = silu_pipeline(device);
+    enc.set_compute_pipeline_state(pipe);
+    enc.set_buffer(0, Some(gate), 0);
+    enc.set_buffer(1, Some(up), 0);
+    enc.set_buffer(2, Some(out), 0);
+    enc.set_bytes(
+        3,
+        std::mem::size_of::<P>() as u64,
+        &params as *const _ as *const c_void,
+    );
+
+    let grid = MTLSize::new((ffn as u64).div_ceil(256), total_pairs as u64, 1);
+    let tg = MTLSize::new(256, 1, 1);
+    enc.dispatch_thread_groups(grid, tg);
+}
+
+pub fn dispatch_weighted_sum_batched(
+    device: &Device,
+    enc: &ComputeCommandEncoderRef,
+    slots: &Buffer,
+    weights: &Buffer,
+    out: &Buffer,
+    batch: usize,
+    top_k: usize,
+    hidden: usize,
+) {
+    #[repr(C)]
+    struct P {
+        batch: i32,
+        top_k: i32,
+        hidden: i32,
+    }
+    let params = P {
+        batch: batch as i32,
+        top_k: top_k as i32,
+        hidden: hidden as i32,
+    };
+
+    let pipe = wsum_pipeline(device);
+    enc.set_compute_pipeline_state(pipe);
+    enc.set_buffer(0, Some(slots), 0);
+    enc.set_buffer(1, Some(weights), 0);
+    enc.set_buffer(2, Some(out), 0);
+    enc.set_bytes(
+        3,
+        std::mem::size_of::<P>() as u64,
+        &params as *const _ as *const c_void,
+    );
+
+    let grid = MTLSize::new((hidden as u64).div_ceil(256), batch as u64, 1);
+    let tg = MTLSize::new(256, 1, 1);
+    enc.dispatch_thread_groups(grid, tg);
+}
+
+// `compute_ids_tpe` moved to `crate::moe_host` (non-cfg-gated) so non-Metal
+// builds can still call into it. See `moe_host::compute_ids_tpe`.

--- a/crates/ferrum-kernels/src/q4_k_moe_id_gemm.metal
+++ b/crates/ferrum-kernels/src/q4_k_moe_id_gemm.metal
@@ -1,0 +1,259 @@
+// Q4_K_M MoE 2-D GEMM with indirect dispatch — adapted from q4_k_gemm.metal
+// (which is itself a port of llama.cpp's `kernel_mul_mm_q4_K_f32`).
+// Adds three things on top of the dense GEMM:
+//
+// 1. **Expert dimension on the grid (`tgpig.z = im`).** Each expert's
+//    weight slab is at offset `im * nb02` bytes into the contiguous
+//    stacked-experts buffer.
+// 2. **`tpe[im]` early termination.** Each expert may have a different
+//    number of (token, slot) pairs assigned. If this threadgroup's
+//    column tile is past `tpe[im]`, return immediately.
+// 3. **`ids` indirection on src1 read AND dst write.** Each pair index
+//    `id ∈ [0, batch * top_k)` is encoded as `id = token_idx * top_k +
+//    slot_within_token`. For src1, decode `(i12, i11)` and read the
+//    token's activation row (broadcast for gate/up where `ne11=1`,
+//    per-slot for down where `ne11=top_k`). For dst, write to the
+//    natural `[token, slot, n]` layout — so silu_mul + down + final
+//    weighted sum can use the same plain layout without any reshuffle.
+//
+// Closes the prefill MoE gap to llama.cpp on Qwen3-30B-A3B by replacing
+// the per-token gemv loop (302 tokens × per-token launch) with one
+// batched mul_mm dispatch covering all (token, expert) pairs in
+// parallel — m grows from 1 to ~batch×top_k/num_experts (≈ 19 for
+// Qwen3-30B-A3B prefill m=302), enabling the simdgroup_half8x8
+// matrix-multiply fast path that's 5–10× faster per FLOP than gemv.
+
+#include <metal_stdlib>
+#include <metal_simdgroup_matrix>
+using namespace metal;
+
+#define QK_K       256
+#define QK_NL_Q4_K 16
+#define FOR_UNROLL(x) _Pragma("clang loop unroll(full)") for (x)
+
+struct block_q4_K {
+    half  d;
+    half  dmin;
+    uchar scales[12];
+    uchar qs[QK_K / 2];
+};
+
+struct GemmQ4KMoeIdParams {
+    int M;            // per-expert out_features
+    int K;            // in_features (multiple of 256)
+    int nb01;         // per-expert row stride in BYTES = (K/256) * 144
+    int nb02;         // per-expert slab stride in BYTES = M * (K/256) * 144
+    int ne11;         // src1 inner-batch dim: 1 for gate/up (broadcast), top_k for down
+    int top_k;        // top-K experts per token
+    int max_per_expert; // max ids array stride per expert
+    int batch;        // num_tokens (= ne12; for output layout)
+};
+
+// Identical scale unpacker as q4_k_gemm.metal.
+static inline uchar2 get_scale_min_k4_just2_id(
+    int j, int k, device const uchar * q
+) {
+    if (j < 4) {
+        return uchar2(q[j + 0 + k] & 63, q[j + 4 + k] & 63);
+    } else {
+        return uchar2(
+            (q[j + 4 + k] & 0x0F) | ((q[j - 4 + k] & 0xC0) >> 2),
+            (q[j + 4 + k] >> 4)   | ((q[j + 0 + k] & 0xC0) >> 2)
+        );
+    }
+}
+
+template <typename type4x4>
+static inline void dequantize_q4_K_id(
+    device const block_q4_K * xb,
+    short il,
+    thread type4x4 & reg
+) {
+    device const uchar * q = xb->qs;
+    short is = (il / 4) * 2;
+    q = q + (il / 4) * 32 + 16 * (il & 1);
+    il = il & 3;
+    const uchar2 sc = get_scale_min_k4_just2_id(is, il / 2, xb->scales);
+    const float d   = il < 2 ? float(xb->d) : float(xb->d) / 16.f;
+    const float minv = float(xb->dmin);
+    const float dl = d * float(sc[0]);
+    const float ml = minv * float(sc[1]);
+    const ushort mask = il < 2 ? 0x0F : 0xF0;
+    FOR_UNROLL (int i = 0; i < 16; ++i) {
+        reg[i / 4][i % 4] = dl * float(q[i] & mask) - ml;
+    }
+}
+
+constant short NR0 = 64;
+constant short NR1 = 32;
+constant short NK  = 32;
+constant short NL0 = NK / 16;
+constant short NL1 = NK / 8;
+constant short NL_BLOCK = QK_NL_Q4_K;
+
+kernel void gemm_q4kw_moe_id_f32(
+    device const block_q4_K * src0  [[buffer(0)]],   // [num_experts, M, K/256]
+    device const float      * src1  [[buffer(1)]],   // [batch, ne11, K]
+    device const int        * ids   [[buffer(2)]],   // [num_experts, max_per_expert]
+    device const int        * tpe   [[buffer(3)]],   // [num_experts]
+    device       float      * dst   [[buffer(4)]],   // [batch, top_k, M]
+    constant GemmQ4KMoeIdParams & p [[buffer(5)]],
+    threadgroup char        * shmem [[threadgroup(0)]],
+    uint3  tgpig [[threadgroup_position_in_grid]],
+    ushort tiitg [[thread_index_in_threadgroup]],
+    ushort sgitg [[simdgroup_index_in_threadgroup]],
+    ushort tiisg [[thread_index_in_simdgroup]])
+{
+    threadgroup half * sa = (threadgroup half *)(shmem);
+    threadgroup half * sb = (threadgroup half *)(shmem + 4096);
+
+    const int im   = tgpig.z;                      // expert id
+    const int neh1 = tpe[im];                       // pairs assigned to this expert
+    const int r0   = tgpig.y * NR0;                 // weight-row tile start
+    const int r1   = tgpig.x * NR1;                 // pair-row tile start within expert
+
+    // Early exit: this threadgroup is past `neh1` (the expert has fewer
+    // pairs than max_per_expert). Without this, we'd still compute a
+    // full output tile and either write garbage or skip writes — the
+    // up-front exit saves the GPU-side work entirely.
+    if (r1 >= neh1) return;
+
+    const short nr0 = (p.M - r0 < NR0) ? short(p.M - r0) : NR0;
+    const short nr1 = (neh1 - r1 < NR1) ? short(neh1 - r1) : NR1;
+
+    const short lr0 = (short(tiitg) / NL0) < nr0 ? (short(tiitg) / NL0) : (nr0 - 1);
+    const short lr1 = (short(tiitg) / NL1) < nr1 ? (short(tiitg) / NL1) : (nr1 - 1);
+
+    const short il0 = short(tiitg) % NL0;
+    short il = il0;
+    const short offset1 = il0 / NL_BLOCK;
+
+    // Weight pointer: pick this expert's slab, then this thread's row.
+    device const block_q4_K * x = (device const block_q4_K *)(
+        (device const char *)src0 + p.nb02 * im + p.nb01 * (r0 + lr0)
+    ) + offset1;
+
+    // Activation pointer: indirect via ids.
+    //   id = ids[im * max_per_expert + r1 + lr1]
+    //   i12 = id / top_k        (token index)
+    //   i11 = id % top_k % ne11 (slot within token; 0 for ne11=1, slot for ne11=top_k)
+    // src1 layout: [batch, ne11, K] row-major → index (i12, i11, iy) is
+    // src1[(i12 * ne11 + i11) * K + iy].
+    const int  pair_id = ids[im * p.max_per_expert + r1 + lr1];
+    const short i12_tile = pair_id / p.top_k;
+    const short i11_tile = (pair_id % p.top_k) % p.ne11;
+    const short iy = 8 * (short(tiitg) % NL1);
+    device const float * y = src1
+        + (i12_tile * p.ne11 + i11_tile) * p.K
+        + iy;
+
+    simdgroup_half8x8  ma[4];
+    simdgroup_half8x8  mb[2];
+    simdgroup_float8x8 mc[8];
+    for (short i = 0; i < 8; ++i) {
+        mc[i] = make_filled_simdgroup_matrix<float, 8>(0.f);
+    }
+
+    for (int loop_k = 0; loop_k < p.K; loop_k += NK) {
+        // Load A (weights) tile with inline dequant.
+        {
+            half4x4 temp_a;
+            dequantize_q4_K_id(x, il, temp_a);
+
+            threadgroup_barrier(mem_flags::mem_threadgroup);
+
+            FOR_UNROLL (short i = 0; i < 16; ++i) {
+                const short sx = 2 * il0 + i / 8;
+                const short sy = (short(tiitg) / NL0) / 8;
+                const short lx = (short(tiitg) / NL0) % 8;
+                const short ly = i % 8;
+                const short ib = 8 * sx + sy;
+                sa[64 * ib + 8 * ly + lx] = temp_a[i / 4][i % 4];
+            }
+        }
+
+        // Load B (activations) tile.
+        {
+            const short sx = short(tiitg) % NL1;
+            const short sy = (short(tiitg) / NL1) / 8;
+            const short ly = (short(tiitg) / NL1) % 8;
+            const short ib = 4 * sx + sy;
+
+            float4 v0 = float4(*((device const float4 *)(y + 0)));
+            float4 v1 = float4(*((device const float4 *)(y + 4)));
+
+            threadgroup half * dst8 = sb + 64 * ib + 8 * ly;
+            dst8[0] = half(v0[0]);
+            dst8[1] = half(v0[1]);
+            dst8[2] = half(v0[2]);
+            dst8[3] = half(v0[3]);
+            dst8[4] = half(v1[0]);
+            dst8[5] = half(v1[1]);
+            dst8[6] = half(v1[2]);
+            dst8[7] = half(v1[3]);
+        }
+
+        il = (il + 2 < NL_BLOCK) ? il + 2 : il % 2;
+        x  = (il < 2) ? x + (2 + NL_BLOCK - 1) / NL_BLOCK : x;
+        y += NK;
+
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        // Inner matmul: 4 simdgroups produce 8 8x8 output tiles each.
+        threadgroup const half * lsma = sa + 4 * 64 * (sgitg % 2);
+        threadgroup const half * lsmb = sb + 2 * 64 * (sgitg / 2);
+
+        FOR_UNROLL (short ik = 0; ik < NK / 8; ++ik) {
+            simdgroup_barrier(mem_flags::mem_none);
+
+            FOR_UNROLL (short i = 0; i < 4; ++i) {
+                simdgroup_load(ma[i], lsma + 64 * i, 8, 0, false);
+            }
+            simdgroup_barrier(mem_flags::mem_none);
+
+            FOR_UNROLL (short i = 0; i < 2; ++i) {
+                simdgroup_load(mb[i], lsmb + 64 * i, 8, 0, false);
+            }
+            simdgroup_barrier(mem_flags::mem_none);
+
+            FOR_UNROLL (short i = 0; i < 8; ++i) {
+                simdgroup_multiply_accumulate(mc[i], mb[i / 4], ma[i % 4], mc[i]);
+            }
+
+            lsma += 8 * 64;
+            lsmb += 4 * 64;
+        }
+    }
+
+    // === Indirect store: write each accumulated row to its (token, slot) ===
+    //
+    // The mc[i] tiles hold a 64×32 output block in expert-local order.
+    // To map back, we go through shmem and, for each row j ∈ [0, nr1),
+    // look up `id = ids[im, r1+j]`, decompose to `(token=idt, slot=ide)`,
+    // and copy the 64 floats to `dst[idt, ide, r0..r0+nr0)`.
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    threadgroup float * temp_str = ((threadgroup float *)shmem)
+        + 32 * (sgitg & 1)
+        + (16 * (sgitg >> 1)) * NR0;
+    for (short i = 0; i < 8; ++i) {
+        simdgroup_store(mc[i], temp_str + 8 * (i % 4) + 8 * NR0 * (i / 4), NR0, 0, false);
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    // Distribute the nr1 rows across the 4 simdgroups (sgitg ∈ [0,4)).
+    // Each simdgroup handles every 4th row starting at sgitg, all 32
+    // threads collaborating on the cross-row copy.
+    for (short j = sgitg; j < nr1; j += 4) {
+        const int id = ids[im * p.max_per_expert + r1 + j];
+        const short ide = id % p.top_k;        // slot within token
+        const short idt = id / p.top_k;        // token index
+
+        // dst[idt, ide, :] — layout is [batch, top_k, M] row-major.
+        device float * D = dst + (idt * p.top_k + ide) * p.M + r0;
+        threadgroup float * C = ((threadgroup float *)shmem) + j * NR0;
+
+        for (short i = tiisg; i < nr0; i += 32) {
+            D[i] = C[i];
+        }
+    }
+}

--- a/crates/ferrum-kernels/src/q4_k_moe_id_gemm.rs
+++ b/crates/ferrum-kernels/src/q4_k_moe_id_gemm.rs
@@ -1,0 +1,116 @@
+//! Q4_K_M MoE 2-D GEMM with indirect dispatch — Rust glue.
+//!
+//! See `q4_k_moe_id_gemm.metal` for the algorithmic notes.
+//! One Metal launch covers all `(token, expert_slot)` pairs across all
+//! experts in parallel via `grid.z = expert_id` + an `ids` table for
+//! indirect src1 read and dst write.
+
+#![cfg(all(target_os = "macos", feature = "metal"))]
+
+use std::ffi::c_void;
+use std::sync::OnceLock;
+
+use metal::{
+    Buffer, CompileOptions, ComputeCommandEncoderRef, ComputePipelineState, Device, MTLSize,
+};
+
+const SHADER_SRC: &str = include_str!("q4_k_moe_id_gemm.metal");
+const KERNEL_NAME: &str = "gemm_q4kw_moe_id_f32";
+
+static PIPELINE: OnceLock<ComputePipelineState> = OnceLock::new();
+
+fn pipeline(device: &Device) -> &'static ComputePipelineState {
+    PIPELINE.get_or_init(|| {
+        let lib = device
+            .new_library_with_source(SHADER_SRC, &CompileOptions::new())
+            .expect("compile q4_k_moe_id_gemm.metal");
+        let function = lib
+            .get_function(KERNEL_NAME, None)
+            .expect("find gemm_q4kw_moe_id_f32");
+        device
+            .new_compute_pipeline_state_with_function(&function)
+            .expect("build gemm_q4kw_moe_id_f32 pipeline")
+    })
+}
+
+/// Dispatch the Q4_K MoE 2-D GEMM on an existing compute encoder.
+///
+/// Grid: `(ceil(max_per_expert / NR1=32), ceil(M / NR0=64), num_experts)`.
+/// Threadgroup: 128 threads (4 simdgroups × 32). 8 KiB shmem.
+///
+/// Inputs:
+/// - `weights_stacked`: `[num_experts, m, k/256]` Q4_K block bytes (one big MTLBuffer)
+/// - `src1`: `[batch, ne11, k]` f32 activations (`ne11=1` for gate/up broadcast,
+///   `ne11=top_k` for down per-slot)
+/// - `ids`: `[num_experts, max_per_expert]` i32 global pair indices
+/// - `tpe`: `[num_experts]` i32 — count of pairs assigned to each expert
+/// - `out`: `[batch, top_k, m]` f32 output (scattered in)
+#[allow(clippy::too_many_arguments)]
+pub fn dispatch_gemm_q4k_moe_id_on_encoder(
+    device: &Device,
+    enc: &ComputeCommandEncoderRef,
+    weights_stacked: &Buffer,
+    src1: &Buffer,
+    ids: &Buffer,
+    tpe: &Buffer,
+    out: &Buffer,
+    num_experts: usize,
+    m: usize,
+    k: usize,
+    ne11: usize,
+    top_k: usize,
+    max_per_expert: usize,
+    batch: usize,
+) {
+    debug_assert!(k % 256 == 0, "K must be a multiple of 256 (got {k})");
+    debug_assert!(m % 4 == 0, "M must be a multiple of 4 (got {m})");
+
+    let nb01_bytes = (k / 256) * 144;
+    let nb02_bytes = m * nb01_bytes;
+
+    #[repr(C)]
+    struct P {
+        m: i32,
+        k: i32,
+        nb01: i32,
+        nb02: i32,
+        ne11: i32,
+        top_k: i32,
+        max_per_expert: i32,
+        batch: i32,
+    }
+    let params = P {
+        m: m as i32,
+        k: k as i32,
+        nb01: nb01_bytes as i32,
+        nb02: nb02_bytes as i32,
+        ne11: ne11 as i32,
+        top_k: top_k as i32,
+        max_per_expert: max_per_expert as i32,
+        batch: batch as i32,
+    };
+
+    let pipe = pipeline(device);
+    enc.set_compute_pipeline_state(pipe);
+    enc.set_buffer(0, Some(weights_stacked), 0);
+    enc.set_buffer(1, Some(src1), 0);
+    enc.set_buffer(2, Some(ids), 0);
+    enc.set_buffer(3, Some(tpe), 0);
+    enc.set_buffer(4, Some(out), 0);
+    enc.set_bytes(
+        5,
+        std::mem::size_of::<P>() as u64,
+        &params as *const _ as *const c_void,
+    );
+    enc.set_threadgroup_memory_length(0, 8192);
+
+    const NR0: u64 = 64;
+    const NR1: u64 = 32;
+    let grid = MTLSize::new(
+        (max_per_expert as u64).div_ceil(NR1),
+        (m as u64).div_ceil(NR0),
+        num_experts as u64,
+    );
+    let tg = MTLSize::new(128, 1, 1);
+    enc.dispatch_thread_groups(grid, tg);
+}

--- a/crates/ferrum-kernels/src/q6_k_moe_id_gemm.metal
+++ b/crates/ferrum-kernels/src/q6_k_moe_id_gemm.metal
@@ -1,0 +1,228 @@
+// Q6_K MoE 2-D GEMM with indirect dispatch — adapted from q6_k_gemm.metal
+// (which is itself a port of llama.cpp's `kernel_mul_mm_q6_K_f32`).
+//
+// See `q4_k_moe_id_gemm.metal` for the design rationale (expert grid
+// dim, `tpe[im]` early termination, indirect src1 read + dst write
+// via the `ids` table). This file is the Q6_K analogue used for the
+// MoE `down` projection (Qwen3-30B-A3B's down_exps tensor is Q6_K
+// while gate / up are Q4_K).
+//
+// Note: for `down`, the input is the silu·gate output already laid
+// out as `[batch, top_k, ffn]`. ne11 = top_k → each (token, slot)
+// pair reads its own row, indexed via the same `ids` array.
+
+#include <metal_stdlib>
+#include <metal_simdgroup_matrix>
+using namespace metal;
+
+#define QK_K       256
+#define QK_NL_Q6_K 16
+#define FOR_UNROLL(x) _Pragma("clang loop unroll(full)") for (x)
+
+struct block_q6_K {
+    uchar  ql[QK_K / 2];
+    uchar  qh[QK_K / 4];
+    int8_t scales[QK_K / 16];
+    half   d;
+};
+
+struct GemmQ6KMoeIdParams {
+    int M;
+    int K;
+    int nb01;
+    int nb02;
+    int ne11;          // 1 for broadcast, top_k for per-slot
+    int top_k;
+    int max_per_expert;
+    int batch;
+};
+
+template <typename type4x4>
+static inline void dequantize_q6_K_id(
+    device const block_q6_K * xb,
+    short il,
+    thread type4x4 & reg
+) {
+    const half d_all = xb->d;
+    device const uint16_t * ql = (device const uint16_t *)xb->ql;
+    device const uint16_t * qh = (device const uint16_t *)xb->qh;
+    device const int8_t   * scales = (device const int8_t *)xb->scales;
+
+    ql = ql + 32 * (il / 8) + 16 * ((il / 2) & 1) + 8 * (il & 1);
+    qh = qh + 16 * (il / 8) + 8 * (il & 1);
+    float sc = scales[(il % 2) + 2 * (il / 2)];
+    il = (il / 2) & 3;
+
+    const uint32_t kmask1 = il > 1
+        ? (il > 2 ? 0xC0C0C0C0u : 0x30303030u)
+        : (il > 0 ? 0x0C0C0C0Cu : 0x03030303u);
+    const uint32_t kmask2 = il > 1 ? 0xF0F0F0F0u : 0x0F0F0F0Fu;
+    const float ml  = float(d_all) * sc * 32.f;
+    const float dl0 = float(d_all) * sc;
+    const float dl1 = dl0 / 256.f;
+    const float dl2 = dl0 / (256.f * 256.f);
+    const float dl3 = dl0 / (256.f * 256.f * 256.f);
+    const uchar shr_h = il > 2 ? 2 : 0;
+    const uchar shl_h = il > 1 ? 0 : (il > 0 ? 2 : 4);
+    const uchar shr_l = il > 1 ? 4 : 0;
+
+    FOR_UNROLL (int i = 0; i < 4; ++i) {
+        const uint32_t low = ((uint32_t)ql[2 * i] | ((uint32_t)ql[2 * i + 1] << 16)) & kmask2;
+        const uint32_t high = ((uint32_t)qh[2 * i] | ((uint32_t)qh[2 * i + 1] << 16)) & kmask1;
+        const uint32_t q = ((high << shl_h) >> shr_h) | (low >> shr_l);
+        reg[i][0] = dl0 * float(q & 0x000000FFu) - ml;
+        reg[i][1] = dl1 * float(q & 0x0000FF00u) - ml;
+        reg[i][2] = dl2 * float(q & 0x00FF0000u) - ml;
+        reg[i][3] = dl3 * float(q & 0xFF000000u) - ml;
+    }
+}
+
+constant short NR0_Q6 = 64;
+constant short NR1_Q6 = 32;
+constant short NK_Q6  = 32;
+constant short NL0_Q6 = NK_Q6 / 16;
+constant short NL1_Q6 = NK_Q6 / 8;
+constant short NL_BLOCK_Q6 = QK_NL_Q6_K;
+
+kernel void gemm_q6kw_moe_id_f32(
+    device const block_q6_K * src0  [[buffer(0)]],   // [num_experts, M, K/256]
+    device const float      * src1  [[buffer(1)]],   // [batch, ne11, K]
+    device const int        * ids   [[buffer(2)]],
+    device const int        * tpe   [[buffer(3)]],
+    device       float      * dst   [[buffer(4)]],   // [batch, top_k, M]
+    constant GemmQ6KMoeIdParams & p [[buffer(5)]],
+    threadgroup char        * shmem [[threadgroup(0)]],
+    uint3  tgpig [[threadgroup_position_in_grid]],
+    ushort tiitg [[thread_index_in_threadgroup]],
+    ushort sgitg [[simdgroup_index_in_threadgroup]],
+    ushort tiisg [[thread_index_in_simdgroup]])
+{
+    threadgroup half * sa = (threadgroup half *)(shmem);
+    threadgroup half * sb = (threadgroup half *)(shmem + 4096);
+
+    const int im = tgpig.z;
+    const int neh1 = tpe[im];
+    const int r0 = tgpig.y * NR0_Q6;
+    const int r1 = tgpig.x * NR1_Q6;
+
+    if (r1 >= neh1) return;
+
+    const short nr0 = (p.M - r0 < NR0_Q6) ? short(p.M - r0) : NR0_Q6;
+    const short nr1 = (neh1 - r1 < NR1_Q6) ? short(neh1 - r1) : NR1_Q6;
+
+    const short lr0 = (short(tiitg) / NL0_Q6) < nr0 ? (short(tiitg) / NL0_Q6) : (nr0 - 1);
+    const short lr1 = (short(tiitg) / NL1_Q6) < nr1 ? (short(tiitg) / NL1_Q6) : (nr1 - 1);
+
+    const short il0 = short(tiitg) % NL0_Q6;
+    short il = il0;
+    const short offset1 = il0 / NL_BLOCK_Q6;
+
+    device const block_q6_K * x = (device const block_q6_K *)(
+        (device const char *)src0 + p.nb02 * im + p.nb01 * (r0 + lr0)
+    ) + offset1;
+
+    const int  pair_id = ids[im * p.max_per_expert + r1 + lr1];
+    const short i12_tile = pair_id / p.top_k;
+    const short i11_tile = (pair_id % p.top_k) % p.ne11;
+    const short iy = 8 * (short(tiitg) % NL1_Q6);
+    device const float * y = src1
+        + (i12_tile * p.ne11 + i11_tile) * p.K
+        + iy;
+
+    simdgroup_half8x8  ma[4];
+    simdgroup_half8x8  mb[2];
+    simdgroup_float8x8 mc[8];
+    for (short i = 0; i < 8; ++i) {
+        mc[i] = make_filled_simdgroup_matrix<float, 8>(0.f);
+    }
+
+    for (int loop_k = 0; loop_k < p.K; loop_k += NK_Q6) {
+        {
+            half4x4 temp_a;
+            dequantize_q6_K_id(x, il, temp_a);
+
+            threadgroup_barrier(mem_flags::mem_threadgroup);
+
+            FOR_UNROLL (short i = 0; i < 16; ++i) {
+                const short sx = 2 * il0 + i / 8;
+                const short sy = (short(tiitg) / NL0_Q6) / 8;
+                const short lx = (short(tiitg) / NL0_Q6) % 8;
+                const short ly = i % 8;
+                const short ib = 8 * sx + sy;
+                sa[64 * ib + 8 * ly + lx] = temp_a[i / 4][i % 4];
+            }
+        }
+
+        {
+            const short sx = short(tiitg) % NL1_Q6;
+            const short sy = (short(tiitg) / NL1_Q6) / 8;
+            const short ly = (short(tiitg) / NL1_Q6) % 8;
+            const short ib = 4 * sx + sy;
+
+            float4 v0 = float4(*((device const float4 *)(y + 0)));
+            float4 v1 = float4(*((device const float4 *)(y + 4)));
+
+            threadgroup half * dst8 = sb + 64 * ib + 8 * ly;
+            dst8[0] = half(v0[0]);
+            dst8[1] = half(v0[1]);
+            dst8[2] = half(v0[2]);
+            dst8[3] = half(v0[3]);
+            dst8[4] = half(v1[0]);
+            dst8[5] = half(v1[1]);
+            dst8[6] = half(v1[2]);
+            dst8[7] = half(v1[3]);
+        }
+
+        il = (il + 2 < NL_BLOCK_Q6) ? il + 2 : il % 2;
+        x  = (il < 2) ? x + (2 + NL_BLOCK_Q6 - 1) / NL_BLOCK_Q6 : x;
+        y += NK_Q6;
+
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        threadgroup const half * lsma = sa + 4 * 64 * (sgitg % 2);
+        threadgroup const half * lsmb = sb + 2 * 64 * (sgitg / 2);
+
+        FOR_UNROLL (short ik = 0; ik < NK_Q6 / 8; ++ik) {
+            simdgroup_barrier(mem_flags::mem_none);
+
+            FOR_UNROLL (short i = 0; i < 4; ++i) {
+                simdgroup_load(ma[i], lsma + 64 * i, 8, 0, false);
+            }
+            simdgroup_barrier(mem_flags::mem_none);
+
+            FOR_UNROLL (short i = 0; i < 2; ++i) {
+                simdgroup_load(mb[i], lsmb + 64 * i, 8, 0, false);
+            }
+            simdgroup_barrier(mem_flags::mem_none);
+
+            FOR_UNROLL (short i = 0; i < 8; ++i) {
+                simdgroup_multiply_accumulate(mc[i], mb[i / 4], ma[i % 4], mc[i]);
+            }
+
+            lsma += 8 * 64;
+            lsmb += 4 * 64;
+        }
+    }
+
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    threadgroup float * temp_str = ((threadgroup float *)shmem)
+        + 32 * (sgitg & 1)
+        + (16 * (sgitg >> 1)) * NR0_Q6;
+    for (short i = 0; i < 8; ++i) {
+        simdgroup_store(mc[i], temp_str + 8 * (i % 4) + 8 * NR0_Q6 * (i / 4), NR0_Q6, 0, false);
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    for (short j = sgitg; j < nr1; j += 4) {
+        const int id = ids[im * p.max_per_expert + r1 + j];
+        const short ide = id % p.top_k;
+        const short idt = id / p.top_k;
+
+        device float * D = dst + (idt * p.top_k + ide) * p.M + r0;
+        threadgroup float * C = ((threadgroup float *)shmem) + j * NR0_Q6;
+
+        for (short i = tiisg; i < nr0; i += 32) {
+            D[i] = C[i];
+        }
+    }
+}

--- a/crates/ferrum-kernels/src/q6_k_moe_id_gemm.rs
+++ b/crates/ferrum-kernels/src/q6_k_moe_id_gemm.rs
@@ -1,0 +1,102 @@
+//! Q6_K MoE 2-D GEMM with indirect dispatch — Rust glue.
+//!
+//! See `q6_k_moe_id_gemm.metal`. Same shape as `q4_k_moe_id_gemm` but
+//! the per-expert-slab byte layout uses Q6_K's 210-byte super-block.
+
+#![cfg(all(target_os = "macos", feature = "metal"))]
+
+use std::ffi::c_void;
+use std::sync::OnceLock;
+
+use metal::{
+    Buffer, CompileOptions, ComputeCommandEncoderRef, ComputePipelineState, Device, MTLSize,
+};
+
+const SHADER_SRC: &str = include_str!("q6_k_moe_id_gemm.metal");
+const KERNEL_NAME: &str = "gemm_q6kw_moe_id_f32";
+
+static PIPELINE: OnceLock<ComputePipelineState> = OnceLock::new();
+
+fn pipeline(device: &Device) -> &'static ComputePipelineState {
+    PIPELINE.get_or_init(|| {
+        let lib = device
+            .new_library_with_source(SHADER_SRC, &CompileOptions::new())
+            .expect("compile q6_k_moe_id_gemm.metal");
+        let function = lib
+            .get_function(KERNEL_NAME, None)
+            .expect("find gemm_q6kw_moe_id_f32");
+        device
+            .new_compute_pipeline_state_with_function(&function)
+            .expect("build gemm_q6kw_moe_id_f32 pipeline")
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn dispatch_gemm_q6k_moe_id_on_encoder(
+    device: &Device,
+    enc: &ComputeCommandEncoderRef,
+    weights_stacked: &Buffer,
+    src1: &Buffer,
+    ids: &Buffer,
+    tpe: &Buffer,
+    out: &Buffer,
+    num_experts: usize,
+    m: usize,
+    k: usize,
+    ne11: usize,
+    top_k: usize,
+    max_per_expert: usize,
+    batch: usize,
+) {
+    debug_assert!(k % 256 == 0);
+    debug_assert!(m % 4 == 0);
+
+    let nb01_bytes = (k / 256) * crate::q6_k_gemv::Q6_K_BLOCK_BYTES;
+    let nb02_bytes = m * nb01_bytes;
+
+    #[repr(C)]
+    struct P {
+        m: i32,
+        k: i32,
+        nb01: i32,
+        nb02: i32,
+        ne11: i32,
+        top_k: i32,
+        max_per_expert: i32,
+        batch: i32,
+    }
+    let params = P {
+        m: m as i32,
+        k: k as i32,
+        nb01: nb01_bytes as i32,
+        nb02: nb02_bytes as i32,
+        ne11: ne11 as i32,
+        top_k: top_k as i32,
+        max_per_expert: max_per_expert as i32,
+        batch: batch as i32,
+    };
+
+    let pipe = pipeline(device);
+    enc.set_compute_pipeline_state(pipe);
+    enc.set_buffer(0, Some(weights_stacked), 0);
+    enc.set_buffer(1, Some(src1), 0);
+    enc.set_buffer(2, Some(ids), 0);
+    enc.set_buffer(3, Some(tpe), 0);
+    enc.set_buffer(4, Some(out), 0);
+    enc.set_bytes(
+        5,
+        std::mem::size_of::<P>() as u64,
+        &params as *const _ as *const c_void,
+    );
+    enc.set_threadgroup_memory_length(0, 8192);
+
+    const NR0: u64 = 64;
+    const NR1: u64 = 32;
+    let grid = MTLSize::new(
+        (max_per_expert as u64).div_ceil(NR1),
+        (m as u64).div_ceil(NR0),
+        num_experts as u64,
+    );
+    let tg = MTLSize::new(128, 1, 1);
+    enc.dispatch_thread_groups(grid, tg);
+}

--- a/crates/ferrum-models/src/models/qwen3_moe.rs
+++ b/crates/ferrum-models/src/models/qwen3_moe.rs
@@ -96,29 +96,38 @@ pub struct Qwen3MoeScratch<B: Backend> {
     /// hot path.
     pub zero_hidden: B::Buffer,
 
-    // ── MoE batched-fast-path scratch (Metal `gemv_q*kw_moe_id_f32`) ──
-    /// `[top_k * expert_inter]` — per-slot gate output from the batched
-    /// gate_stacked dispatch. Each slot holds `expert_inter` floats for
-    /// the corresponding selected expert.
+    // ── MoE batched-fast-path scratch (Metal `gemv_q*kw_moe_id_f32` /
+    //    `gemm_q*kw_moe_id_f32`) ─────────────────────────────────────
+    //
+    // Sized for `max_tokens * top_k * X` so the same buffers cover both
+    // decode (m=1, uses the first `top_k * X` slice) and prefill
+    // (m>1, uses the full `max_tokens * top_k * X`). Decode-only
+    // workloads pay no extra memory because `max_tokens` was 1 there.
+    /// `[max_tokens * top_k * expert_inter]` — gate gemm output per pair.
     pub gate_out_stacked: B::Buffer,
-    /// `[top_k * expert_inter]` — per-slot up output (same shape as gate).
+    /// `[max_tokens * top_k * expert_inter]` — up gemm output per pair.
     pub up_out_stacked: B::Buffer,
-    /// `[top_k * expert_inter]` — per-slot SiLU(gate)·up output, fed into
-    /// the down stacked dispatch.
+    /// `[max_tokens * top_k * expert_inter]` — SiLU(gate)·up per pair.
     pub silu_stacked: B::Buffer,
-    /// `[top_k * hidden]` — per-slot down output, summed into `acc_buf`
-    /// with router weights.
+    /// `[max_tokens * top_k * hidden]` — down gemm output per pair.
     pub down_out_stacked: B::Buffer,
-    /// `[top_k]` i32 expert IDs for the current token (rebuilt each
-    /// layer from the host-side router output).
+    /// `[top_k]` i32 expert IDs for the current token (decode reuses;
+    /// prefill writes per-pair indices into `ids_2d` instead).
     pub ids_buf: B::Buffer,
-    /// `[top_k]` f32 router combine weights for the current token.
-    /// Pre-allocated alongside `ids_buf` so the per-layer update is an
-    /// in-place memcpy via `B::write_f32_into` rather than a fresh
-    /// `B::from_slice` allocation (48 × 128 = 6144 fresh buffers per
-    /// 128-token decode otherwise — same allocator-pressure pattern
-    /// `ids_buf` had before being moved to `write_i32_into`).
+    /// `[top_k]` f32 router combine weights for the current decode
+    /// token. Decode hot-path uses `write_f32_into` to update.
     pub weights_buf: B::Buffer,
+    /// `[num_experts * max_per_expert_max]` i32 — per-expert pair
+    /// index lists for prefill 2-D mul_mm_id. `max_per_expert_max`
+    /// is bounded by `max_tokens * top_k` (worst-case: one expert
+    /// gets every pair). Sized at scratch alloc time.
+    pub ids_2d: B::Buffer,
+    /// `[num_experts]` i32 — `tpe[e]` = number of pairs assigned to
+    /// expert `e`. Companion to `ids_2d`.
+    pub tpe_buf: B::Buffer,
+    /// `[max_tokens * top_k]` f32 — combine weights per pair, in
+    /// natural `[batch, top_k]` layout for `weighted_sum_batched`.
+    pub weights_2d: B::Buffer,
 
     // ── Final-token / lm_head outputs ────────────────────────────────
     pub last_hidden: B::Buffer,
@@ -160,12 +169,15 @@ impl<B: Backend> Qwen3MoeScratch<B> {
             acc_buf: B::alloc(h),
             moe_out: B::alloc(t * h),
             zero_hidden: B::from_slice(&vec![0.0f32; h]),
-            gate_out_stacked: B::alloc(cfg.num_experts_per_tok * inter),
-            up_out_stacked: B::alloc(cfg.num_experts_per_tok * inter),
-            silu_stacked: B::alloc(cfg.num_experts_per_tok * inter),
-            down_out_stacked: B::alloc(cfg.num_experts_per_tok * h),
+            gate_out_stacked: B::alloc(t * cfg.num_experts_per_tok * inter),
+            up_out_stacked: B::alloc(t * cfg.num_experts_per_tok * inter),
+            silu_stacked: B::alloc(t * cfg.num_experts_per_tok * inter),
+            down_out_stacked: B::alloc(t * cfg.num_experts_per_tok * h),
             ids_buf: B::from_slice_i32(&vec![0i32; cfg.num_experts_per_tok]),
             weights_buf: B::from_slice(&vec![0.0f32; cfg.num_experts_per_tok]),
+            ids_2d: B::from_slice_i32(&vec![0i32; n_exp * t * cfg.num_experts_per_tok]),
+            tpe_buf: B::from_slice_i32(&vec![0i32; n_exp]),
+            weights_2d: B::from_slice(&vec![0.0f32; t * cfg.num_experts_per_tok]),
             last_hidden: B::alloc(h),
             last_normed: B::alloc(h),
             logits: B::alloc(vocab),
@@ -589,7 +601,14 @@ impl<B: Backend> Qwen3MoeModel<B> {
             && moe_layer.experts.down_stacked.is_some();
 
         if stacked_path_available {
-            self.moe_forward_stacked(ctx, li, tokens)?;
+            if tokens > 1 {
+                // Prefill: one batched 2-D mul_mm_id covers all
+                // (token, expert) pairs in parallel.
+                self.moe_forward_batched_prefill(ctx, li, tokens)?;
+            } else {
+                // Decode m=1: dedicated per-token path.
+                self.moe_forward_stacked(ctx, li, tokens)?;
+            }
         } else {
             moe_forward::<B>(
                 ctx,
@@ -635,6 +654,26 @@ impl<B: Backend> Qwen3MoeModel<B> {
     ) -> Result<()> {
         let cfg = &self.cfg;
         moe_forward_stacked_decode_impl::<B>(
+            ctx,
+            &self.moe_layers[li],
+            &mut self.scratch,
+            cfg.base.hidden_size,
+            cfg.expert_intermediate_size,
+            cfg.num_experts_per_tok,
+            cfg.num_experts,
+            cfg.norm_topk_prob,
+            tokens,
+        )
+    }
+
+    fn moe_forward_batched_prefill(
+        &mut self,
+        ctx: &mut B::Context,
+        li: usize,
+        tokens: usize,
+    ) -> Result<()> {
+        let cfg = &self.cfg;
+        moe_forward_batched_prefill_impl::<B>(
             ctx,
             &self.moe_layers[li],
             &mut self.scratch,
@@ -938,6 +977,124 @@ fn moe_forward_stacked_decode_impl<B: Backend>(
         // 6. Final write into moe_out[b * h ..]
         B::copy_slice(ctx, &scratch.acc_buf, 0, &mut scratch.moe_out, b * h, h);
     }
+
+    Ok(())
+}
+
+/// Batched MoE FFN for prefill (m > 1).
+///
+/// One pass through the expert dispatch — replaces the per-token loop
+/// with three batched 2-D mul_mm_id dispatches (gate, up, down) where
+/// each expert's slab of (token, slot) pairs runs as one gemm tile.
+/// Per-layer dispatch count: ~6 (router + 3 mul_mm_id + silu + wsum)
+/// independent of `tokens`. Compare to the decode-style stacked path
+/// that emits ~10 per token.
+///
+/// Free function so the caller can split the borrow on `self` between
+/// `moe_layers[li]` (immutable) and `scratch` (mutable).
+#[allow(clippy::too_many_arguments)]
+fn moe_forward_batched_prefill_impl<B: Backend>(
+    ctx: &mut B::Context,
+    moe_layer: &Qwen3MoeLayerState<B>,
+    scratch: &mut Qwen3MoeScratch<B>,
+    h: usize,
+    inter: usize,
+    top_k: usize,
+    n_exp: usize,
+    norm_topk_prob: bool,
+    tokens: usize,
+) -> Result<()> {
+    use ferrum_kernels::moe_host::compute_ids_tpe;
+
+    // Host-side routing: pull the whole batch's router_logits, run
+    // softmax + top-K, then bucket pairs by expert into ids/tpe.
+    B::sync(ctx);
+    let logits_host = B::to_vec(&scratch.router_logits, tokens * n_exp);
+    let route = crate::moe::router::route(&logits_host, tokens, n_exp, top_k, norm_topk_prob);
+
+    let (tpe_host, ids_host, max_per_expert) =
+        compute_ids_tpe(&route.expert_ids, n_exp, tokens, top_k);
+
+    // Upload tpe + ids in place. ids_2d is sized for the worst case
+    // (n_exp * tokens * top_k); we only fill `n_exp * max_per_expert`
+    // entries — kernel reads only that much via `tpe[e]` early-exit.
+    B::write_i32_into(&mut scratch.tpe_buf, &tpe_host);
+    B::write_i32_into(&mut scratch.ids_2d, &ids_host);
+
+    // Combine weights: write [batch, top_k] flat into weights_2d.
+    B::write_f32_into(&mut scratch.weights_2d, &route.expert_weights);
+
+    let gate_stacked = moe_layer.experts.gate_stacked.as_ref().unwrap();
+    let up_stacked = moe_layer.experts.up_stacked.as_ref().unwrap();
+    let down_stacked = moe_layer.experts.down_stacked.as_ref().unwrap();
+
+    // 1. Batched gate gemm — one launch covers all (token, expert) pairs.
+    //    src1 layout: [batch, ne11=1, K] (broadcast: each pair reads its
+    //    token's row, slot index ignored).
+    //    dst layout:  [batch, top_k, expert_inter] — natural.
+    B::gemm_quant_moe_id(
+        ctx,
+        &scratch.norm_out,
+        gate_stacked,
+        &scratch.ids_2d,
+        &scratch.tpe_buf,
+        &mut scratch.gate_out_stacked,
+        1, // ne11 = 1: broadcast
+        top_k,
+        max_per_expert,
+        tokens,
+    )?;
+
+    // 2. Batched up gemm — same shape as gate.
+    B::gemm_quant_moe_id(
+        ctx,
+        &scratch.norm_out,
+        up_stacked,
+        &scratch.ids_2d,
+        &scratch.tpe_buf,
+        &mut scratch.up_out_stacked,
+        1,
+        top_k,
+        max_per_expert,
+        tokens,
+    )?;
+
+    // 3. SiLU·gate over [tokens * top_k, expert_inter] flat layout.
+    let total_pairs = tokens * top_k;
+    B::silu_mul_batched(
+        ctx,
+        &scratch.gate_out_stacked,
+        &scratch.up_out_stacked,
+        &mut scratch.silu_stacked,
+        total_pairs,
+        inter,
+    )?;
+
+    // 4. Batched down gemm — src1 is [batch, top_k, expert_inter] from
+    //    silu_stacked. ne11 = top_k → each pair reads its own row.
+    B::gemm_quant_moe_id(
+        ctx,
+        &scratch.silu_stacked,
+        down_stacked,
+        &scratch.ids_2d,
+        &scratch.tpe_buf,
+        &mut scratch.down_out_stacked,
+        top_k, // ne11 = top_k: per-slot
+        top_k,
+        max_per_expert,
+        tokens,
+    )?;
+
+    // 5. Per-batch weighted sum: moe_out[b, h] = Σ_k w[b,k] · down[b,k,h]
+    B::weighted_sum_batched(
+        ctx,
+        &scratch.down_out_stacked,
+        &scratch.weights_2d,
+        &mut scratch.moe_out,
+        tokens,
+        top_k,
+        h,
+    )?;
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

Ports llama.cpp's `kernel_mul_mm_id` to ferrum's prefill path: one Metal launch covers all `(token, expert)` pairs across all experts in parallel via `grid.z = expert_id` + an `ids` table for indirect src1 read and dst write. Replaces the per-token loop that the decode-style stacked dispatch (#39) used for prefill.

This PR is the **prefill-path correctness counterpart to #40 (head_dim fix)**. With both landed, Qwen3-30B-A3B Q4_K_M now produces coherent English output instead of repeating-token gibberish.

## What's new

### Metal kernels
- **`gemm_q4kw_moe_id_f32`** — 2-D mul_mm with `grid (N/NR0, max_per_expert/NR1, num_experts)`. Each expert's threadgroups read weights from `src0 + im*nb02`, look up `pair_id = ids[im, slot]`, decompose into `(token, slot_within_token)`, and read activations indirectly. Output is scattered into `dst[token, top_k_slot, :]` — the natural batch-major layout, so silu_mul + down + final weighted sum need no reshuffle.
- **`gemm_q6kw_moe_id_f32`** — Q6_K analogue for `down`. `ne11 = top_k` so each pair reads its own row in the upstream silu output.
- **`silu_mul_batched_f32`** — `[batch * top_k, ffn]` element-wise SiLU·gate in one launch.
- **`weighted_sum_batched_f32`** — `[batch, top_k, hidden]` × `[batch, top_k]` weights → `[batch, hidden]` reduction in one launch.

### Backend trait
- `gemm_quant_moe_id(a, weight, ids, tpe, out, ne11, top_k, max_per_expert, batch)`
- `silu_mul_batched`, `weighted_sum_batched`
- `write_f32_into` (companion to `write_i32_into` for in-place per-layer `weights_2d` upload)

### Host helper
`ferrum_kernels::moe_host::compute_ids_tpe` — backend-agnostic top-K bucketing. Lives outside the Metal `cfg`-gate so CPU/CUDA builds compile.

### `Qwen3MoeModel`
- New scratch: `ids_2d`, `tpe_buf`, `weights_2d` sized for worst-case `batch * top_k`
- `*_stacked` buffers grow from `[top_k * X]` to `[max_tokens * top_k * X]` (same memory backs decode and prefill)
- Branch in `forward_layer`: `tokens > 1` + stacked → batched path; `tokens == 1` → existing decode-style dispatch

## Correctness

Verified on Qwen3-30B-A3B Q4_K_M after #40 landed:

| Prompt | Pre-#40 binary | After #40 + this PR |
|---|---|---|
| "The capital of France is" | `Dund impe impe impe impe...` (gibberish) | **`Paris. The capital of Italy is Rome. The capital of Spain is Madrid.`** |
| "Once upon a time, there was a young girl named" | `_Cell_Cell_Cell_Cell...` | (still imperfect on this base prompt — needs separate investigation) |

`cargo test --workspace` 88/88 on both CPU and Metal feature configs.

## Performance (M1 Max, `FERRUM_KV_CAPACITY=512`, 5-token prompt)

- **Prefill: 1.3 tok/s** — much slower than llama.cpp's 596 t/s pp512 baseline. Two reasons: (a) 30B-A3B with the corrected `head_dim=128` doubles every per-token scratch buffer, pushing the 17 GB model into swap on a 32 GB Mac during the first prefill rep; (b) the current 2-D kernel doesn't yet fuse expert tiles efficiently for sparse-pair distributions (avg 0.3 pairs/expert at `batch=5`).
- **Decode: 15.3 tok/s** — within ~2.9× of llama.cpp's 44.5 t/s warm baseline. Decode goes through the unchanged stacked decode path from #39, which works correctly with the head_dim fix.

Both perf bottlenecks are tractable in follow-up:
1. **Memory layout for 30B-A3B on a 32 GB Mac** — either smaller default `FERRUM_KV_CAPACITY` for MoE, or a more compact `*_stacked` buffer scheme that doesn't size for `max_tokens * top_k * X` worst case.
2. **Sparse-tile heuristics** — at low batch, most expert grid slots have ≤1 pair so `NR1 = 32` mostly wastes work. A smaller-tile or expert-skipping variant would help.

## Caveat on past benchmark numbers

All Qwen3-30B-A3B speed numbers in BENCHMARKS.md from PRs #35–#39 were measured on a **garbage-output binary** (head_dim was wrong, model output was repeating-token gibberish hidden behind `--bench-mode` which suppresses tokens). The numbers are kinetic-real but quality-invalid. They should be re-measured on top of this PR + #40 before being trusted as a baseline.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-targets -- -A warnings` clean
- [x] `cargo test --workspace` 88/88 (CPU)
- [x] `cargo test --workspace --features metal` 88/88 (Metal)
- [x] On-hardware correctness on Qwen3-30B-A3B Q4_K_M
- [ ] Re-bench Qwen3-30B-A3B end-to-end vs llama.cpp pp512=596 / tg128=44.5 (out of scope here — needs the memory-layout follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)