### PR TITLE
perf(moe): GPU-side router (softmax + top-K) — tg128 21.6 → 26.7 t/s

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -320,18 +320,24 @@ Decode (m=1) already uses the fused path (`gemv_q4kw_v2` /
 > **Prefill batched fast path correctness fixed in PR #41**
 > (2-D `mul_mm_id` Q4_K/Q6_K kernels — see below).
 >
-> **Real numbers post #40 + #41 (M1 Max, single-rep, FERRUM_KV_CAPACITY=512):**
+> **Real numbers post #40 + #41 (M1 Max, single-rep cold start, FERRUM_KV_CAPACITY=512):**
 >
-> | Test | ferrum | vs llama.cpp baseline |
-> |---|---:|---:|
-> | Prefill, 205-token prompt | **43.3 t/s** | 7% of 596 |
-> | Decode @ kv_len ≤ 5 | **15.3 t/s** | 35% of 44.5 |
-> | Decode @ kv_len = 205 | 3.4 t/s | 8% — large attention scaling cost |
+> | Test | ferrum | vs llama.cpp baseline | Ratio |
+> |---|---:|---:|---:|
+> | tg128 (1 prompt → 128 decode) | **21.6 t/s** | 44.5 t/s | **49%** |
+> | Prefill, 205-token prompt | **43.3 t/s** | 596 t/s | **7%** |
+> | Decode @ kv_len ≤ 5 | 15.3 t/s | 44.5 t/s | 35% |
+> | Decode @ kv_len = 205 | 3.4 t/s | 44.5 t/s | 8% — attention scales with kv_len |
 >
-> The pre-fix and post-fix prefill numbers are coincidentally close
-> (~44 t/s) — same kernel work, different output quality.
-> The full 5-rep regression suite needs a re-run on the new binary
-> before the entries below can be replaced; tracked separately.
+> **Headline: decode is 49% of llama.cpp on the standard tg128
+> protocol** — usable for chat. Prefill still 14× behind; closing
+> that gap is the next focus.
+>
+> The pre-fix and post-fix `pp512`-style prefill numbers are
+> coincidentally close (~44 t/s) — same kernel work, different
+> output quality. Decode tg128 climbed from #39's 13.22 t/s mean
+> (on garbage output) to 21.6 t/s (correct output) — the fix path
+> through #40+#41 also cleaned up some kv-scaling overhead.
 
 ### Qwen3-30B-A3B MoE — first measurement, 2026-04-29 (PRE-FIX, INVALID)
 

--- a/crates/ferrum-kernels/src/backend/metal.rs
+++ b/crates/ferrum-kernels/src/backend/metal.rs
@@ -813,6 +813,34 @@ impl Backend for MetalBackend {
         }
     }
 
+    fn route_topk_softmax(
+        ctx: &mut Self::Context,
+        logits: &Self::Buffer,
+        out_ids: &mut Self::Buffer,
+        out_weights: &mut Self::Buffer,
+        batch: usize,
+        num_experts: usize,
+        top_k: usize,
+        norm_topk_prob: bool,
+    ) -> Result<()> {
+        let logits_buf = logits.expect_f32("route_topk_softmax logits");
+        let ids_buf = &out_ids.raw;
+        let weights_buf = out_weights.expect_f32_mut("route_topk_softmax out_weights");
+        let enc = ctx.compute_encoder();
+        crate::moe_router::dispatch_route_topk_softmax(
+            &st().pipes.device,
+            enc,
+            logits_buf,
+            ids_buf,
+            weights_buf,
+            batch,
+            num_experts,
+            top_k,
+            norm_topk_prob,
+        );
+        Ok(())
+    }
+
     fn silu_mul_batched(
         ctx: &mut Self::Context,
         gate: &Self::Buffer,

--- a/crates/ferrum-kernels/src/backend/traits.rs
+++ b/crates/ferrum-kernels/src/backend/traits.rs
@@ -417,6 +417,32 @@ pub trait Backend: Send + Sync + Sized + 'static {
         ))
     }
 
+    /// GPU-side MoE router: `[batch, num_experts]` logits → `[batch, top_k]`
+    /// expert IDs (i32) + `[batch, top_k]` combine weights (f32).
+    ///
+    /// Replaces the per-layer `B::sync + B::to_vec(router_logits) + host route()`
+    /// round trip. The output buffers stay device-side for downstream
+    /// `gemv_quant_moe_id` / `gemm_quant_moe_id` consumption — no host
+    /// pipeline drain in the inner loop.
+    ///
+    /// `norm_topk_prob`: if true, divide each row's K weights by their
+    /// sum so they total 1.0 (Qwen3-MoE / Mixtral default).
+    #[allow(clippy::too_many_arguments)]
+    fn route_topk_softmax(
+        _ctx: &mut Self::Context,
+        _logits: &Self::Buffer,
+        _out_ids: &mut Self::Buffer,
+        _out_weights: &mut Self::Buffer,
+        _batch: usize,
+        _num_experts: usize,
+        _top_k: usize,
+        _norm_topk_prob: bool,
+    ) -> Result<()> {
+        Err(FerrumError::unsupported(
+            "route_topk_softmax not implemented for this backend",
+        ))
+    }
+
     /// Stacked SiLU·gate over `[batch * top_k, ffn]` rows (prefill version
     /// of `silu_mul_stacked`).
     fn silu_mul_batched(

--- a/crates/ferrum-kernels/src/lib.rs
+++ b/crates/ferrum-kernels/src/lib.rs
@@ -16,6 +16,8 @@ pub mod moe_post_ops;
 #[cfg(all(target_os = "macos", feature = "metal"))]
 pub mod moe_post_ops_batched;
 #[cfg(all(target_os = "macos", feature = "metal"))]
+pub mod moe_router;
+#[cfg(all(target_os = "macos", feature = "metal"))]
 pub mod q4_k;
 #[cfg(all(target_os = "macos", feature = "metal"))]
 pub mod q4_k_gemm;

--- a/crates/ferrum-kernels/src/moe_router.metal
+++ b/crates/ferrum-kernels/src/moe_router.metal
@@ -1,0 +1,133 @@
+// MoE router: per-row softmax + top-K + optional renormalize.
+//
+// Replaces the host-side `B::sync(ctx) + B::to_vec(router_logits) +
+// crate::moe::router::route(...)` sequence used in the existing MoE
+// path. Each per-layer call previously paid one full Metal pipeline
+// drain (~1 ms on M1 Max) plus a host softmax/sort. Doing it on the
+// GPU removes the sync entirely (the kernel writes ids/weights into
+// device buffers that the next mul_mm_id pass reads directly).
+//
+// Algorithm: one threadgroup per token row.
+//   1. Stable softmax (max-subtract → exp → sum-reduce → divide).
+//   2. Repeated argmax to extract top-K — k ≤ 32 expected, so a
+//      simple loop that masks each picked entry to -INFINITY suffices
+//      (vs a partial sort, which would over-engineer for tiny K).
+//   3. Optional renormalize: if `norm_topk_prob`, divide selected
+//      weights by their sum so they total 1.0.
+//
+// Threadgroup: 32 threads. Each thread covers `ceil(num_experts/32)`
+// logits during the softmax and argmax reductions. Shared memory
+// holds the post-softmax probability vector for the row.
+
+#include <metal_stdlib>
+using namespace metal;
+
+struct RouterParams {
+    int num_experts;
+    int top_k;
+    int norm_topk_prob;  // 0 / 1
+};
+
+kernel void moe_router_topk_softmax_f32(
+    device const float * logits        [[buffer(0)]],   // [batch, num_experts]
+    device       int   * out_ids       [[buffer(1)]],   // [batch, top_k]
+    device       float * out_weights   [[buffer(2)]],   // [batch, top_k]
+    constant RouterParams & p          [[buffer(3)]],
+    threadgroup float  * shmem         [[threadgroup(0)]],
+    uint3  tgpig [[threadgroup_position_in_grid]],
+    ushort tiisg [[thread_index_in_simdgroup]])
+{
+    const int row = tgpig.x;
+    const int n_exp = p.num_experts;
+    const int top_k = p.top_k;
+
+    threadgroup float * probs = shmem;       // [num_experts]
+    // Cooperative load of logits into shmem, finding row max along the way.
+    float thread_max = -INFINITY;
+    for (int i = tiisg; i < n_exp; i += 32) {
+        const float v = logits[row * n_exp + i];
+        probs[i] = v;
+        thread_max = max(thread_max, v);
+    }
+    // Reduce max across simdgroup.
+    float row_max = simd_max(thread_max);
+
+    // exp(logit - max) and partial sum.
+    float thread_sum = 0.0f;
+    for (int i = tiisg; i < n_exp; i += 32) {
+        const float e = exp(probs[i] - row_max);
+        probs[i] = e;
+        thread_sum += e;
+    }
+    float row_sum = simd_sum(thread_sum);
+    float inv_sum = 1.0f / row_sum;
+
+    // Normalise.
+    for (int i = tiisg; i < n_exp; i += 32) {
+        probs[i] *= inv_sum;
+    }
+
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    // Repeated argmax for top-K. k ≤ 32 in all known MoE configs;
+    // this is a 32-thread cooperative scan per pick (k passes total).
+    // The picked entry is overwritten with -INFINITY so the next pass
+    // sees the next-best value.
+    //
+    // Tie-breaking: simd_max returns the largest float. We follow
+    // ferrum's host-side `route` convention of "smaller index wins"
+    // by storing `(prob, -index)` pairs and reducing on prob first,
+    // index-as-tiebreaker. Here we encode that as: when the max prob
+    // is observed, threads with that prob race-write their index into
+    // a shmem slot, and only `min(index)` survives (one extra reduce).
+    threadgroup float * sel_weights  = (threadgroup float *)(probs + n_exp);
+    threadgroup int   * sel_idxs     = (threadgroup int   *)(sel_weights + top_k);
+    // One slot for the running renorm sum so it's visible to every
+    // thread when the final write phase computes `scale = 1/sum`.
+    threadgroup float * renorm_slot  = (threadgroup float *)(sel_idxs + top_k);
+    if (tiisg == 0) {
+        renorm_slot[0] = 0.0f;
+    }
+
+    for (int k = 0; k < top_k; k++) {
+        // Find max prob this round.
+        float thread_best = -INFINITY;
+        int   thread_idx  = -1;
+        for (int i = tiisg; i < n_exp; i += 32) {
+            const float v = probs[i];
+            if (v > thread_best) {
+                thread_best = v;
+                thread_idx = i;
+            }
+        }
+        const float best = simd_max(thread_best);
+
+        // Race: each thread that holds `best` reports its index; we
+        // pick the smallest one as the winner. simd_min over threads
+        // that don't match writes INT_MAX so they lose the race.
+        int my_idx_for_min = (thread_best == best) ? thread_idx : 0x7fffffff;
+        const int win_idx = simd_min(my_idx_for_min);
+
+        if (tiisg == 0) {
+            sel_weights[k] = best;
+            sel_idxs[k] = win_idx;
+            renorm_slot[0] += best;
+            // Mask the picked entry from future passes.
+            probs[win_idx] = -INFINITY;
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+
+    // Optional renormalise so the K weights sum to 1.0.
+    float scale = 1.0f;
+    if (p.norm_topk_prob != 0) {
+        // Clamp like llama.cpp's `ggml_clamp` to avoid div-by-zero on
+        // degenerate inputs (all logits -INFINITY).
+        scale = 1.0f / max(renorm_slot[0], 6.103515625e-5f);
+    }
+
+    if (tiisg < top_k) {
+        out_ids[row * top_k + tiisg] = sel_idxs[tiisg];
+        out_weights[row * top_k + tiisg] = sel_weights[tiisg] * scale;
+    }
+}

--- a/crates/ferrum-kernels/src/moe_router.rs
+++ b/crates/ferrum-kernels/src/moe_router.rs
@@ -1,0 +1,200 @@
+//! GPU-side MoE router — softmax + top-K + optional renormalize over
+//! `[batch, num_experts]` router logits, output `[batch, top_k]` ids
+//! and weights. See `moe_router.metal` for the algorithmic notes.
+//!
+//! Eliminates the per-layer `B::sync + B::to_vec + host route()` round
+//! trip used by the previous decode-style stacked dispatch path.
+
+#![cfg(all(target_os = "macos", feature = "metal"))]
+
+use std::ffi::c_void;
+use std::sync::OnceLock;
+
+use metal::{
+    Buffer, CompileOptions, ComputeCommandEncoderRef, ComputePipelineState, Device, MTLSize,
+};
+
+const SHADER_SRC: &str = include_str!("moe_router.metal");
+const KERNEL_NAME: &str = "moe_router_topk_softmax_f32";
+
+static PIPELINE: OnceLock<ComputePipelineState> = OnceLock::new();
+
+fn pipeline(device: &Device) -> &'static ComputePipelineState {
+    PIPELINE.get_or_init(|| {
+        let lib = device
+            .new_library_with_source(SHADER_SRC, &CompileOptions::new())
+            .expect("compile moe_router.metal");
+        let function = lib
+            .get_function(KERNEL_NAME, None)
+            .expect("find moe_router_topk_softmax_f32");
+        device
+            .new_compute_pipeline_state_with_function(&function)
+            .expect("build moe_router_topk_softmax_f32 pipeline")
+    })
+}
+
+/// Dispatch the GPU-side router kernel on an existing compute encoder.
+///
+/// Inputs:
+/// - `logits`: `[batch, num_experts]` f32
+///
+/// Outputs:
+/// - `out_ids`: `[batch, top_k]` i32 (selected expert indices, smaller-
+///   index-wins tie-breaking to match the host `route()` reference)
+/// - `out_weights`: `[batch, top_k]` f32 (post-softmax probabilities,
+///   optionally renormalised so each row sums to 1)
+pub fn dispatch_route_topk_softmax(
+    device: &Device,
+    enc: &ComputeCommandEncoderRef,
+    logits: &Buffer,
+    out_ids: &Buffer,
+    out_weights: &Buffer,
+    batch: usize,
+    num_experts: usize,
+    top_k: usize,
+    norm_topk_prob: bool,
+) {
+    debug_assert!(top_k <= num_experts);
+    debug_assert!(top_k > 0);
+
+    #[repr(C)]
+    struct P {
+        num_experts: i32,
+        top_k: i32,
+        norm_topk_prob: i32,
+    }
+    let params = P {
+        num_experts: num_experts as i32,
+        top_k: top_k as i32,
+        norm_topk_prob: if norm_topk_prob { 1 } else { 0 },
+    };
+
+    let pipe = pipeline(device);
+    enc.set_compute_pipeline_state(pipe);
+    enc.set_buffer(0, Some(logits), 0);
+    enc.set_buffer(1, Some(out_ids), 0);
+    enc.set_buffer(2, Some(out_weights), 0);
+    enc.set_bytes(
+        3,
+        std::mem::size_of::<P>() as u64,
+        &params as *const _ as *const c_void,
+    );
+
+    // Threadgroup memory: probs[num_experts] f32 + sel_weights[top_k] f32
+    //                   + sel_idxs[top_k] i32 + renorm_slot[1] f32.
+    let shmem_bytes = (num_experts * 4 + top_k * 4 + top_k * 4 + 4).max(64);
+    enc.set_threadgroup_memory_length(0, shmem_bytes as u64);
+
+    let grid = MTLSize::new(batch as u64, 1, 1);
+    let tg = MTLSize::new(32, 1, 1);
+    enc.dispatch_thread_groups(grid, tg);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use metal::MTLResourceOptions;
+
+    /// Compare GPU router output against a host softmax+top-K reference
+    /// for a small synthetic logits matrix. Catches mass-misordering
+    /// bugs (e.g. using wrong tie-break, off-by-one in masking, weights
+    /// not normalised).
+    #[test]
+    fn router_matches_host_reference() {
+        let Some(device) = Device::system_default() else {
+            eprintln!("no Metal device — skipping");
+            return;
+        };
+        let queue = device.new_command_queue();
+
+        let batch = 3;
+        let num_experts = 16;
+        let top_k = 4;
+
+        // Build deterministic logits with one clear winner per row.
+        let mut logits: Vec<f32> = Vec::with_capacity(batch * num_experts);
+        for b in 0..batch {
+            for e in 0..num_experts {
+                let v = ((b as f32) * 0.7 + (e as f32) * 0.13).sin() + (e as f32) * 0.05;
+                logits.push(v);
+            }
+        }
+
+        let logits_buf = device.new_buffer_with_data(
+            logits.as_ptr() as *const _,
+            (logits.len() * 4) as u64,
+            MTLResourceOptions::StorageModeShared,
+        );
+        let ids_buf = device.new_buffer(
+            (batch * top_k * 4) as u64,
+            MTLResourceOptions::StorageModeShared,
+        );
+        let w_buf = device.new_buffer(
+            (batch * top_k * 4) as u64,
+            MTLResourceOptions::StorageModeShared,
+        );
+
+        let cmd = queue.new_command_buffer();
+        let enc = cmd.new_compute_command_encoder();
+        dispatch_route_topk_softmax(
+            &device,
+            enc,
+            &logits_buf,
+            &ids_buf,
+            &w_buf,
+            batch,
+            num_experts,
+            top_k,
+            true,
+        );
+        enc.end_encoding();
+        cmd.commit();
+        cmd.wait_until_completed();
+
+        let gpu_ids: &[i32] =
+            unsafe { std::slice::from_raw_parts(ids_buf.contents() as *const i32, batch * top_k) };
+        let gpu_w: &[f32] =
+            unsafe { std::slice::from_raw_parts(w_buf.contents() as *const f32, batch * top_k) };
+
+        for b in 0..batch {
+            // Host softmax + top-K + renorm reference.
+            let row = &logits[b * num_experts..(b + 1) * num_experts];
+            let max = row.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
+            let exps: Vec<f32> = row.iter().map(|x| (x - max).exp()).collect();
+            let sum: f32 = exps.iter().sum();
+            let probs: Vec<f32> = exps.iter().map(|e| e / sum).collect();
+
+            // Top-K via partial sort, smaller-index tie-break.
+            let mut indexed: Vec<(usize, f32)> =
+                probs.iter().enumerate().map(|(i, &p)| (i, p)).collect();
+            indexed.sort_by(|a, b| {
+                b.1.partial_cmp(&a.1)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+                    .then_with(|| a.0.cmp(&b.0))
+            });
+            let topk: Vec<usize> = indexed.iter().take(top_k).map(|(i, _)| *i).collect();
+            let renorm_sum: f32 = topk.iter().map(|&i| probs[i]).sum();
+            let weights_ref: Vec<f32> = topk.iter().map(|&i| probs[i] / renorm_sum).collect();
+
+            for k in 0..top_k {
+                let gpu_id = gpu_ids[b * top_k + k] as usize;
+                let gpu_weight = gpu_w[b * top_k + k];
+                assert_eq!(
+                    gpu_id, topk[k],
+                    "row {} slot {}: gpu id {} != host id {}",
+                    b, k, gpu_id, topk[k]
+                );
+                let diff = (gpu_weight - weights_ref[k]).abs();
+                assert!(
+                    diff < 1e-5,
+                    "row {} slot {}: gpu weight {} vs host {} (diff {})",
+                    b,
+                    k,
+                    gpu_weight,
+                    weights_ref[k],
+                    diff
+                );
+            }
+        }
+    }
+}

--- a/crates/ferrum-models/src/models/qwen3_moe.rs
+++ b/crates/ferrum-models/src/models/qwen3_moe.rs
@@ -889,24 +889,29 @@ fn moe_forward_stacked_decode_impl<B: Backend>(
     norm_topk_prob: bool,
     tokens: usize,
 ) -> Result<()> {
-    // Host-side routing: pull router_logits for the whole batch, run
-    // softmax + top-K. One sync per call covers all `tokens`.
-    B::sync(ctx);
-    let logits_host = B::to_vec(&scratch.router_logits, tokens * n_exp);
-    let route = crate::moe::router::route(&logits_host, tokens, n_exp, top_k, norm_topk_prob);
+    // GPU-side routing: one Metal launch reads router_logits and writes
+    // selected ids + combine weights directly into device-side scratch
+    // buffers. Eliminates the per-layer `B::sync + B::to_vec(router_logits)
+    // + host route()` round trip — the dominant remaining cost in the
+    // decode hot path (~10% of total decode latency).
+    B::route_topk_softmax(
+        ctx,
+        &scratch.router_logits,
+        &mut scratch.ids_buf,
+        &mut scratch.weights_buf,
+        tokens,
+        n_exp,
+        top_k,
+        norm_topk_prob,
+    )?;
 
     let gate_stacked = moe_layer.experts.gate_stacked.as_ref().unwrap();
     let up_stacked = moe_layer.experts.up_stacked.as_ref().unwrap();
     let down_stacked = moe_layer.experts.down_stacked.as_ref().unwrap();
 
     for b in 0..tokens {
-        // Upload this token's selected expert IDs in place — avoids
-        // re-allocating a fresh MTLBuffer per layer × per token.
-        let ids_i32: Vec<i32> = route.expert_ids[b * top_k..(b + 1) * top_k]
-            .iter()
-            .map(|&id| id as i32)
-            .collect();
-        B::write_i32_into(&mut scratch.ids_buf, &ids_i32);
+        // ids_buf and weights_buf populated by the GPU router above —
+        // no host writes needed here in the decode path.
 
         // Stage row b of norm_out into x_single (decode m=1 has it
         // already at offset 0; prefill needs the offset). For decode
@@ -961,10 +966,8 @@ fn moe_forward_stacked_decode_impl<B: Backend>(
         )?;
 
         // 5. Stacked weighted sum: acc_buf[0..h] = Σ_k w[k] · down[k].
-        //    Upload this token's combine weights in place — same trick
-        //    as ids_buf, avoids 6144 per-decode MTLBuffer allocations.
-        let weights_slice = &route.expert_weights[b * top_k..(b + 1) * top_k];
-        B::write_f32_into(&mut scratch.weights_buf, weights_slice);
+        //    weights_buf was populated by the GPU router — no host
+        //    upload needed here.
         B::weighted_sum_stacked(
             ctx,
             &scratch.down_out_stacked,


### PR DESCRIPTION
## Summary

Replaces the per-layer host round-trip (`B::sync + B::to_vec(router_logits) + crate::moe::router::route()`) with a single Metal kernel that does softmax + top-K + optional renormalize on `[batch, num_experts]` logits and writes `[batch, top_k]` ids and weights directly into device-side scratch buffers. Removes the dominant remaining sync point in the decode hot path.

## Algorithm

One threadgroup per row, 32 threads:
1. **Stable softmax**: max-subtract → exp → sum-reduce → divide
2. **Repeated argmax for top-K**: k passes, each finds the row's max and masks it to `-INFINITY`. Smaller-index-wins tie-break (matches the host `route()` reference) via parallel `simd_min` over thread indices that hold the current max value
3. **Optional renormalize**: divide selected weights by their sum so they total 1.0 (Qwen3-MoE / Mixtral default)

## Measurements (M1 Max, single-rep cold start, `FERRUM_KV_CAPACITY=512`)

| Test | Pre-PR | This PR | Δ |
|---|---:|---:|---:|
| tg128 (1 prompt → 128 decode) | 21.6 t/s | **26.7 t/s** | **+24%** |
| Decode @ kv ≤ 5 | 15.3 t/s | 18.7 t/s | +22% |

vs llama.cpp's 44.5 t/s tg128 baseline: ferrum is now at **60% of llama.cpp** (was 49% before this PR).

## Validation

- Unit test (`router_matches_host_reference`) compares GPU output against the host reference on a 3×16 logits matrix, asserting exact id match (smaller-index tie-break) and weight closeness (1e-5)
- On-hardware: "The capital of France is Paris. The capital of Italy is Rome. The capital of Spain is Madrid." ✓
- `cargo test --workspace` 88/88 (CPU)
- `cargo test --workspace --features metal` 88/88 + new router test

## Caveats / Follow-ups

- Prefill path still uses host top-K + bucketing — the `mul_mm_id` kernel needs `tpe[num_experts]` + `ids[num_experts, max_per_expert]` which require host-side bucketing. Porting llama.cpp's `kernel_mul_mm_id_map0` would unlock GPU-only routing for prefill too.
- Long-kv decode is still attention-bound (kv=205 = 3.4 t/s = 8% of llama.cpp). Separate `flash_attention` optimization needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)