### PR TITLE
perf(decode): MoE residual-fusion + transpose-skip (saves ~96 dispatches/token)

### DIFF
--- a/crates/ferrum-kernels/src/backend/metal.rs
+++ b/crates/ferrum-kernels/src/backend/metal.rs
@@ -865,6 +865,30 @@ impl Backend for MetalBackend {
         Ok(())
     }
 
+    fn weighted_sum_residual_stacked(
+        ctx: &mut Self::Context,
+        slots: &Self::Buffer,
+        weights: &Self::Buffer,
+        residual: &mut Self::Buffer,
+        n_slots: usize,
+        hidden: usize,
+    ) -> Result<()> {
+        let slots_buf = slots.expect_f32("weighted_sum_residual_stacked slots");
+        let weights_buf = weights.expect_f32("weighted_sum_residual_stacked weights");
+        let residual_buf = residual.expect_f32_mut("weighted_sum_residual_stacked residual");
+        let enc = ctx.compute_encoder();
+        crate::moe_post_ops::dispatch_weighted_sum_residual_stacked(
+            &st().pipes.device,
+            enc,
+            slots_buf,
+            weights_buf,
+            residual_buf,
+            n_slots,
+            hidden,
+        );
+        Ok(())
+    }
+
     fn weighted_sum_batched(
         ctx: &mut Self::Context,
         slots: &Self::Buffer,

--- a/crates/ferrum-kernels/src/backend/traits.rs
+++ b/crates/ferrum-kernels/src/backend/traits.rs
@@ -458,6 +458,22 @@ pub trait Backend: Send + Sync + Sized + 'static {
         ))
     }
 
+    /// Fused weighted-sum + residual-add: `residual[i] += Σ_k weights[k] · slots[k, i]`.
+    /// Single dispatch replaces the (weighted_sum → moe_out) +
+    /// (add_inplace residual += moe_out) pair on the decode hot path.
+    fn weighted_sum_residual_stacked(
+        _ctx: &mut Self::Context,
+        _slots: &Self::Buffer,
+        _weights: &Self::Buffer,
+        _residual: &mut Self::Buffer,
+        _n_slots: usize,
+        _hidden: usize,
+    ) -> Result<()> {
+        Err(FerrumError::unsupported(
+            "weighted_sum_residual_stacked not implemented for this backend",
+        ))
+    }
+
     /// Per-batch weighted sum: `out[b, h] = Σ_k weights[b, k] · slots[b, k, h]`.
     /// Single dispatch covers the whole batch (prefill version of
     /// `weighted_sum_stacked` which only handled one token).

--- a/crates/ferrum-kernels/src/moe_post_ops.metal
+++ b/crates/ferrum-kernels/src/moe_post_ops.metal
@@ -69,6 +69,33 @@ struct WeightedSumStackedParams {
     int n_slots;
 };
 
+// ── Weighted sum + residual add (fused) ──────────────────────────────
+// Inputs:
+//   slots    : [n_slots, hidden]
+//   weights  : [n_slots]
+//   residual : [hidden] — read AND written: residual[i] += Σ_s w[s] * slots[s,i]
+// One dispatch replaces (weighted_sum_stacked → moe_out) + (add_inplace
+// residual += moe_out): saves 1 dispatch per decode token-layer plus
+// the moe_out scratch traffic.
+
+kernel void weighted_sum_residual_stacked_f32(
+    device const float* slots    [[buffer(0)]],
+    device const float* weights  [[buffer(1)]],
+    device       float* residual [[buffer(2)]],
+    constant WeightedSumStackedParams& p [[buffer(3)]],
+    uint3 tgpig [[threadgroup_position_in_grid]],
+    uint3 tpig  [[thread_position_in_threadgroup]])
+{
+    const uint i = tgpig.x * 256 + tpig.x;
+    if (i >= uint(p.hidden)) return;
+
+    float sum = 0.0f;
+    for (int s = 0; s < p.n_slots; s++) {
+        sum += weights[s] * slots[s * uint(p.hidden) + i];
+    }
+    residual[i] += sum;
+}
+
 kernel void weighted_sum_stacked_f32(
     device const float* slots    [[buffer(0)]],
     device const float* weights  [[buffer(1)]],

--- a/crates/ferrum-kernels/src/moe_post_ops.rs
+++ b/crates/ferrum-kernels/src/moe_post_ops.rs
@@ -14,6 +14,7 @@ const SHADER_SRC: &str = include_str!("moe_post_ops.metal");
 
 static SILU_PIPELINE: OnceLock<ComputePipelineState> = OnceLock::new();
 static WSUM_PIPELINE: OnceLock<ComputePipelineState> = OnceLock::new();
+static WSUM_RES_PIPELINE: OnceLock<ComputePipelineState> = OnceLock::new();
 
 fn silu_pipeline(device: &Device) -> &'static ComputePipelineState {
     SILU_PIPELINE.get_or_init(|| {
@@ -40,6 +41,20 @@ fn wsum_pipeline(device: &Device) -> &'static ComputePipelineState {
         device
             .new_compute_pipeline_state_with_function(&function)
             .expect("build weighted_sum_stacked_f32 pipeline")
+    })
+}
+
+fn wsum_res_pipeline(device: &Device) -> &'static ComputePipelineState {
+    WSUM_RES_PIPELINE.get_or_init(|| {
+        let lib = device
+            .new_library_with_source(SHADER_SRC, &CompileOptions::new())
+            .expect("compile moe_post_ops.metal");
+        let function = lib
+            .get_function("weighted_sum_residual_stacked_f32", None)
+            .expect("find weighted_sum_residual_stacked_f32");
+        device
+            .new_compute_pipeline_state_with_function(&function)
+            .expect("build weighted_sum_residual_stacked_f32 pipeline")
     })
 }
 
@@ -109,6 +124,47 @@ pub fn dispatch_weighted_sum_stacked(
     enc.set_buffer(0, Some(slots), 0);
     enc.set_buffer(1, Some(weights), 0);
     enc.set_buffer(2, Some(out), 0);
+    enc.set_bytes(
+        3,
+        std::mem::size_of::<P>() as u64,
+        &params as *const _ as *const c_void,
+    );
+
+    let grid_x = (hidden as u64).div_ceil(256);
+    let grid = MTLSize::new(grid_x, 1, 1);
+    let tg = MTLSize::new(256, 1, 1);
+    enc.dispatch_thread_groups(grid, tg);
+}
+
+/// Fused weighted-sum + residual-add: `residual[i] += Σ_s w[s] · slots[s, i]`.
+///
+/// `slots`: `[n_slots, hidden]`. `weights`: `[n_slots]`. `residual`: `[hidden]`,
+/// read-AND-written. Replaces the (`weighted_sum_stacked` → `moe_out`) +
+/// (`add_inplace` `residual += moe_out`) pair on the decode hot path.
+pub fn dispatch_weighted_sum_residual_stacked(
+    device: &Device,
+    enc: &ComputeCommandEncoderRef,
+    slots: &Buffer,
+    weights: &Buffer,
+    residual: &Buffer,
+    n_slots: usize,
+    hidden: usize,
+) {
+    #[repr(C)]
+    struct P {
+        hidden: i32,
+        n_slots: i32,
+    }
+    let params = P {
+        hidden: hidden as i32,
+        n_slots: n_slots as i32,
+    };
+
+    let pipe = wsum_res_pipeline(device);
+    enc.set_compute_pipeline_state(pipe);
+    enc.set_buffer(0, Some(slots), 0);
+    enc.set_buffer(1, Some(weights), 0);
+    enc.set_buffer(2, Some(residual), 0);
     enc.set_bytes(
         3,
         std::mem::size_of::<P>() as u64,

--- a/crates/ferrum-models/src/models/llama_family.rs
+++ b/crates/ferrum-models/src/models/llama_family.rs
@@ -834,21 +834,31 @@ impl<B: Backend> LlamaFamilyModel<B> {
             ATTN_CALLS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         }
 
-        // 7. Untranspose head-major → token-major for O-proj input
+        // 7. Untranspose head-major → token-major for O-proj input.
+        //
+        // For tokens=1 the head-major and token-major layouts collapse
+        // to the same flat [heads * head_dim] vector, so the dispatch is
+        // an identity memcpy — skip it and point o_proj at the
+        // head-major buffer directly.
         let _t0 = if std::env::var("FERRUM_DECODE_OP_PROFILE").is_ok() {
             B::sync(ctx);
             Some(std::time::Instant::now())
         } else {
             None
         };
-        B::transpose_head_to_token(
-            ctx,
-            &self.scratch.attn_head_major_out,
-            &mut self.scratch.attn_flat,
-            tokens,
-            nh,
-            hd,
-        );
+        let attn_token_major = if tokens == 1 {
+            &self.scratch.attn_head_major_out
+        } else {
+            B::transpose_head_to_token(
+                ctx,
+                &self.scratch.attn_head_major_out,
+                &mut self.scratch.attn_flat,
+                tokens,
+                nh,
+                hd,
+            );
+            &self.scratch.attn_flat
+        };
         if let Some(t0) = _t0 {
             B::sync(ctx);
             OTHER_TIME_US.fetch_add(
@@ -867,7 +877,7 @@ impl<B: Backend> LlamaFamilyModel<B> {
         };
         layer.o_proj.forward(
             ctx,
-            &self.scratch.attn_flat,
+            attn_token_major,
             &mut self.scratch.o_proj_out,
             tokens,
         );
@@ -1846,20 +1856,16 @@ impl<B: Backend> LlamaFamilyModel<B> {
                 &attn_cfg,
             );
 
-            // Untranspose head-major → token-major (tokens=1 → just contiguous).
-            B::transpose_head_to_token(
-                ctx,
-                &self.scratch.attn_head_major_single,
-                &mut self.scratch.attn_flat_single,
-                1,
-                nh,
-                hd,
-            );
-
-            // Inject item i's attn output into batched attn_flat [M, Q].
+            // Untranspose head-major → token-major + inject into batched
+            // attn_flat[M, Q]. For tokens=1 the head-major and
+            // token-major layouts are byte-identical (both flat to
+            // [heads * head_dim] = [q_dim] floats), so we skip the
+            // transpose dispatch entirely and copy attn_head_major_single
+            // straight into the per-item slot. Saves 1 dispatch per
+            // batch-item per layer.
             B::copy_slice(
                 ctx,
-                &self.scratch.attn_flat_single,
+                &self.scratch.attn_head_major_single,
                 0,
                 &mut self.scratch.attn_flat,
                 i * q_dim,

--- a/crates/ferrum-models/src/models/llama_family.rs
+++ b/crates/ferrum-models/src/models/llama_family.rs
@@ -875,12 +875,9 @@ impl<B: Backend> LlamaFamilyModel<B> {
         } else {
             None
         };
-        layer.o_proj.forward(
-            ctx,
-            attn_token_major,
-            &mut self.scratch.o_proj_out,
-            tokens,
-        );
+        layer
+            .o_proj
+            .forward(ctx, attn_token_major, &mut self.scratch.o_proj_out, tokens);
         if let Some(t0) = _t0 {
             B::sync(ctx);
             MATMUL_TIME_US.fetch_add(

--- a/crates/ferrum-models/src/models/qwen3_moe.rs
+++ b/crates/ferrum-models/src/models/qwen3_moe.rs
@@ -538,19 +538,30 @@ impl<B: Backend> Qwen3MoeModel<B> {
         }
 
         // 7. transpose head-major → token-major.
-        B::transpose_head_to_token(
-            ctx,
-            &self.scratch.attn_head_major_out,
-            &mut self.scratch.attn_flat,
-            tokens,
-            nh,
-            hd,
-        );
+        //
+        // For tokens=1 the two layouts are byte-identical: both
+        // collapse to the flat [heads * head_dim] vector at offset
+        // `head*hd + d`. Skip the dispatch and point o_proj at
+        // attn_head_major_out directly. Saves 1 dispatch per layer
+        // (×48 = 48 dispatches per decode token) on Qwen3-30B-A3B.
+        let attn_token_major = if tokens == 1 {
+            &self.scratch.attn_head_major_out
+        } else {
+            B::transpose_head_to_token(
+                ctx,
+                &self.scratch.attn_head_major_out,
+                &mut self.scratch.attn_flat,
+                tokens,
+                nh,
+                hd,
+            );
+            &self.scratch.attn_flat
+        };
 
         // 8. O-proj.
         attn_layer.o_proj.forward(
             ctx,
-            &self.scratch.attn_flat,
+            attn_token_major,
             &mut self.scratch.o_proj_out,
             tokens,
         );

--- a/crates/ferrum-models/src/models/qwen3_moe.rs
+++ b/crates/ferrum-models/src/models/qwen3_moe.rs
@@ -559,12 +559,9 @@ impl<B: Backend> Qwen3MoeModel<B> {
         };
 
         // 8. O-proj.
-        attn_layer.o_proj.forward(
-            ctx,
-            attn_token_major,
-            &mut self.scratch.o_proj_out,
-            tokens,
-        );
+        attn_layer
+            .o_proj
+            .forward(ctx, attn_token_major, &mut self.scratch.o_proj_out, tokens);
 
         // 9. fused residual-add + post-attention RMSNorm.
         B::fused_add_rms_norm(

--- a/crates/ferrum-models/src/models/qwen3_moe.rs
+++ b/crates/ferrum-models/src/models/qwen3_moe.rs
@@ -600,14 +600,23 @@ impl<B: Backend> Qwen3MoeModel<B> {
             && moe_layer.experts.up_stacked.is_some()
             && moe_layer.experts.down_stacked.is_some();
 
+        // Fast path for decode (tokens=1): the stacked decode impl
+        // writes the weighted-sum result *directly* into `residual` via
+        // `weighted_sum_residual_stacked`, skipping the moe_out scratch
+        // and the trailing `add_inplace`. Saves 1 dispatch per layer.
+        // Prefill (m>1) and the per-expert fallback still go through
+        // moe_out + add_inplace.
+        let decode_fast_path = stacked_path_available && tokens == 1;
+
         if stacked_path_available {
             if tokens > 1 {
                 // Prefill: one batched 2-D mul_mm_id covers all
                 // (token, expert) pairs in parallel.
                 self.moe_forward_batched_prefill(ctx, li, tokens)?;
             } else {
-                // Decode m=1: dedicated per-token path.
-                self.moe_forward_stacked(ctx, li, tokens)?;
+                // Decode m=1: dedicated per-token path that fuses
+                // residual-add into the final weighted-sum.
+                self.moe_forward_stacked(ctx, li, tokens, residual)?;
             }
         } else {
             moe_forward::<B>(
@@ -631,8 +640,11 @@ impl<B: Backend> Qwen3MoeModel<B> {
             )?;
         }
 
-        // 12. residual += moe_out
-        B::add_inplace(ctx, residual, &self.scratch.moe_out, tokens * h);
+        // 12. residual += moe_out (skipped on decode fast path — already
+        //     accumulated by `weighted_sum_residual_stacked`).
+        if !decode_fast_path {
+            B::add_inplace(ctx, residual, &self.scratch.moe_out, tokens * h);
+        }
 
         if let Some(t0) = moe_t0 {
             B::sync(ctx);
@@ -651,6 +663,7 @@ impl<B: Backend> Qwen3MoeModel<B> {
         ctx: &mut B::Context,
         li: usize,
         tokens: usize,
+        residual: &mut B::Buffer,
     ) -> Result<()> {
         let cfg = &self.cfg;
         moe_forward_stacked_decode_impl::<B>(
@@ -663,6 +676,7 @@ impl<B: Backend> Qwen3MoeModel<B> {
             cfg.num_experts,
             cfg.norm_topk_prob,
             tokens,
+            residual,
         )
     }
 
@@ -888,6 +902,7 @@ fn moe_forward_stacked_decode_impl<B: Backend>(
     n_exp: usize,
     norm_topk_prob: bool,
     tokens: usize,
+    residual: &mut B::Buffer,
 ) -> Result<()> {
     // GPU-side routing: one Metal launch reads router_logits and writes
     // selected ids + combine weights directly into device-side scratch
@@ -973,17 +988,17 @@ fn moe_forward_stacked_decode_impl<B: Backend>(
             inter,
         )?;
 
-        // 5. Weighted sum: moe_out[0..h] = Σ_k w[k] · down[k].
-        //    For tokens=1 we write directly to moe_out (the caller's
-        //    `add_inplace(residual, moe_out, tokens*h)` then accumulates
-        //    into the residual stream). The previous indirection via
-        //    `acc_buf` + `copy_slice` was a leftover from the per-token
-        //    prefill loop; not needed for decode.
-        B::weighted_sum_stacked(
+        // 5. Fused weighted-sum + residual-add:
+        //    residual[i] += Σ_k w[k] · down[k, i]. Writes directly into
+        //    the residual stream, skipping the moe_out scratch and the
+        //    trailing `add_inplace` the caller used to do. Saves 1
+        //    dispatch per layer (×48 = 48 dispatches per decode token)
+        //    plus the moe_out → residual memory traffic.
+        B::weighted_sum_residual_stacked(
             ctx,
             &scratch.down_out_stacked,
             &scratch.weights_buf,
-            &mut scratch.moe_out,
+            residual,
             top_k,
             h,
         )?;


### PR DESCRIPTION
## Summary

Two stacked fusions on the Qwen3-MoE decode hot path, plus an analogous transpose-skip for LlamaFamilyModel decode:

1. **Fused weighted-sum + residual-add** (commit 1):
   New Metal kernel `weighted_sum_residual_stacked_f32` folds the residual-add directly into the final MoE weighted-sum. Decode-path MoE FFN now emits **one dispatch** instead of two for the residual stage.

2. **Skip head→token transpose for q_len=1** (commit 2):
   For decode the head-major and token-major attention outputs are byte-identical (both collapse to `[heads * head_dim]`). Drop the dispatch and feed o_proj directly off the head-major buffer.

On Qwen3-30B-A3B both wins together remove **96 dispatches per decode token** (48 from the residual fusion, 48 from the transpose skip).

## Why this matters

At ~31 tok/s baseline (TPOT ~32 ms) the decode hot path is dispatch-overhead-bound: each of the ~620 dispatches/token costs ~50 µs of CPU/GPU sync. Killing 96 of them is a 5 ms / token cut → expected 31 → ~36-38 tok/s.

The Mac this was developed on is RAM-tight (17 GB GGUF + scratch on a 32 GB Mac), so cold-cache bench numbers in this session were swap-poisoned. Final tok/s gain will be confirmed on a fresh-boot machine and recorded in `BENCHMARKS.md` as a follow-up.

## Test plan

- [x] `cargo check --workspace --all-targets`
- [x] `cargo test --workspace --features metal --lib` — all green
- [x] Coherence (Qwen3-30B-A3B, greedy, 32 tokens, prompt "The capital of France is"):
      → "Paris. The capital of Italy is Rome. The capital of Spain is Madrid. The capital of Germany is Berlin. The capital of the United Kingdom is London." — same as the pre-fusion path.
- [ ] Re-bench `tg128` on memory-clean machine; update `BENCHMARKS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)