### PR TITLE
perf(decode): fuse split_qkv + 3× qk_norm_rope (saves 144 dispatches/token)

### DIFF
--- a/crates/ferrum-attention/src/metal/pipelines.rs
+++ b/crates/ferrum-attention/src/metal/pipelines.rs
@@ -74,6 +74,7 @@ impl MetalPipelines {
                     "qk_norm_rope_transpose_f32",
                     "transpose_out_f32",
                     "kv_cache_append_f32",
+                    "split_qkv_norm_rope_f32",
                 ][..],
             ),
             (
@@ -554,6 +555,75 @@ impl MetalPipelines {
             &params as *const _ as *const c_void as *const _,
         );
         let grid = MTLSize::new(tokens as u64, heads as u64, 1);
+        let tg = MTLSize::new(32, 1, 1);
+        enc.dispatch_thread_groups(grid, tg);
+    }
+
+    /// Fused split-QKV + QK-norm + RoPE + transpose.
+    ///
+    /// Replaces (`split_qkv` → 3× `qk_norm_rope_transpose`) with a single
+    /// dispatch that reads the linear-layer fused-QKV output once and
+    /// writes head-major Q/K (with norm+RoPE) and V (transpose only)
+    /// directly to attention scratch.
+    ///
+    /// `qk_mode`: 1 = norm + RoPE for Q/K (Qwen3 with QK-norm),
+    ///            2 = RoPE only for Q/K (no QK-norm; Llama-style).
+    #[allow(clippy::too_many_arguments)]
+    pub fn split_qkv_norm_rope(
+        &self,
+        enc: &ComputeCommandEncoderRef,
+        qkv: &Buffer,
+        q_norm_w: &Buffer,
+        k_norm_w: &Buffer,
+        cos: &Buffer,
+        sin: &Buffer,
+        q_out: &Buffer,
+        k_out: &Buffer,
+        v_out: &Buffer,
+        tokens: usize,
+        q_heads: usize,
+        kv_heads: usize,
+        head_dim: usize,
+        pos_offset: usize,
+        eps: f32,
+        qk_mode: i32,
+    ) {
+        #[repr(C)]
+        struct P {
+            tokens: i32,
+            q_heads: i32,
+            kv_heads: i32,
+            head_dim: i32,
+            half_dim: i32,
+            pos_offset: i32,
+            eps: f32,
+            qk_mode: i32,
+        }
+        let params = P {
+            tokens: tokens as i32,
+            q_heads: q_heads as i32,
+            kv_heads: kv_heads as i32,
+            head_dim: head_dim as i32,
+            half_dim: (head_dim / 2) as i32,
+            pos_offset: pos_offset as i32,
+            eps,
+            qk_mode,
+        };
+        enc.set_compute_pipeline_state(self.pipeline("split_qkv_norm_rope_f32"));
+        enc.set_buffer(0, Some(qkv), 0);
+        enc.set_buffer(1, Some(q_norm_w), 0);
+        enc.set_buffer(2, Some(k_norm_w), 0);
+        enc.set_buffer(3, Some(cos), 0);
+        enc.set_buffer(4, Some(sin), 0);
+        enc.set_buffer(5, Some(q_out), 0);
+        enc.set_buffer(6, Some(k_out), 0);
+        enc.set_buffer(7, Some(v_out), 0);
+        enc.set_bytes(
+            8,
+            std::mem::size_of::<P>() as u64,
+            &params as *const _ as *const c_void as *const _,
+        );
+        let grid = MTLSize::new(tokens as u64, (q_heads + 2 * kv_heads) as u64, 1);
         let tg = MTLSize::new(32, 1, 1);
         enc.dispatch_thread_groups(grid, tg);
     }

--- a/crates/ferrum-attention/src/metal/shaders/norm_rope.metal
+++ b/crates/ferrum-attention/src/metal/shaders/norm_rope.metal
@@ -153,3 +153,119 @@ kernel void kv_cache_append_f32(
     // Dest:   [head * max_len * hd + (old_len + tok) * hd + d]
     cache[head * p.max_len * hd + (p.old_len + tok) * hd + d] = new_data[tid];
 }
+
+// ── Fused Split-QKV + QK-Norm + RoPE + Transpose ─────────────────────────
+// Replaces the (split_qkv → 3× qk_norm_rope_transpose) chain with one
+// dispatch. Reads the fused-QKV linear output once, applies RMSNorm
+// (Q/K) + RoPE (Q/K) + transpose (Q/K/V) in a single pass, and writes
+// directly into the head-major Q/K/V scratch buffers used by attention.
+//
+// Layout:
+//   qkv  : [tokens, q_heads*hd + 2*kv_heads*hd] flat
+//   q_out: [q_heads,  tokens, hd]
+//   k_out: [kv_heads, tokens, hd]
+//   v_out: [kv_heads, tokens, hd]
+//
+// Grid: (tokens, q_heads + 2*kv_heads). Threadgroup: 32 threads (1 simd).
+// head_global ∈ [0, q_heads)                              → Q (norm+RoPE)
+// head_global ∈ [q_heads, q_heads+kv_heads)               → K (norm+RoPE, k_norm_w)
+// head_global ∈ [q_heads+kv_heads, q_heads+2*kv_heads)    → V (transpose only)
+//
+// qk_mode: 1 = full QK-norm + RoPE (Qwen3); 2 = RoPE only no norm
+// (vocoder Q/K). V always passes apply_norm=0.
+
+struct SplitQkvNormRopeParams {
+    int tokens;
+    int q_heads;
+    int kv_heads;
+    int head_dim;
+    int half_dim;
+    int pos_offset;
+    float eps;
+    int qk_mode;       // 1 = norm+RoPE for Q/K, 2 = RoPE only for Q/K
+};
+
+kernel void split_qkv_norm_rope_f32(
+    device const float* qkv      [[buffer(0)]],   // [tokens, q_dim+2*kv_dim]
+    device const float* q_norm_w [[buffer(1)]],   // [head_dim] (unused if qk_mode==2)
+    device const float* k_norm_w [[buffer(2)]],   // [head_dim] (unused if qk_mode==2)
+    device const float* cos_tab  [[buffer(3)]],
+    device const float* sin_tab  [[buffer(4)]],
+    device       float* q_out    [[buffer(5)]],   // [q_heads,  tokens, hd]
+    device       float* k_out    [[buffer(6)]],   // [kv_heads, tokens, hd]
+    device       float* v_out    [[buffer(7)]],   // [kv_heads, tokens, hd]
+    constant SplitQkvNormRopeParams& p [[buffer(8)]],
+    uint2 tgpig [[threadgroup_position_in_grid]],   // (token, head_global)
+    uint  tiisg [[thread_index_in_simdgroup]])
+{
+    const int tok = tgpig.x;
+    const int head_g = tgpig.y;
+    if (tok >= p.tokens) return;
+
+    const int hd = p.head_dim;
+    const int half_d = p.half_dim;
+    const int q_dim = p.q_heads * hd;
+    const int kv_dim = p.kv_heads * hd;
+    const int qkv_stride = q_dim + 2 * kv_dim;
+
+    // Region selection: 0 = Q, 1 = K, 2 = V.
+    int region;
+    int local_head;
+    int src_off;
+    if (head_g < uint(p.q_heads)) {
+        region = 0;
+        local_head = head_g;
+        src_off = tok * qkv_stride + local_head * hd;
+    } else if (head_g < uint(p.q_heads + p.kv_heads)) {
+        region = 1;
+        local_head = head_g - p.q_heads;
+        src_off = tok * qkv_stride + q_dim + local_head * hd;
+    } else {
+        region = 2;
+        local_head = head_g - p.q_heads - p.kv_heads;
+        src_off = tok * qkv_stride + q_dim + kv_dim + local_head * hd;
+    }
+
+    device const float* src = qkv + src_off;
+    // Pick destination buffer + per-region tokens stride (head_major).
+    device float* dst_base = (region == 0) ? q_out
+                            : (region == 1) ? k_out : v_out;
+    device float* dst = dst_base + local_head * p.tokens * hd + tok * hd;
+
+    if (region == 2) {
+        // V: transpose only. Each thread handles HD / 32 elements.
+        for (int i = tiisg; i < hd; i += 32) {
+            dst[i] = src[i];
+        }
+        return;
+    }
+
+    // Q or K: optional norm + RoPE.
+    const bool apply_norm = (p.qk_mode == 1);
+    float scale = 1.0f;
+    device const float* norm_w = (region == 0) ? q_norm_w : k_norm_w;
+    if (apply_norm) {
+        float sum_sq = 0.0f;
+        for (int i = tiisg; i < hd; i += 32) {
+            float v = src[i];
+            sum_sq += v * v;
+        }
+        sum_sq = simd_sum(sum_sq);
+        scale = 1.0f / sqrt(sum_sq / float(hd) + p.eps);
+    }
+
+    const int pos = p.pos_offset + tok;
+    device const float* cos_row = cos_tab + pos * half_d;
+    device const float* sin_row = sin_tab + pos * half_d;
+
+    for (int i = tiisg; i < half_d; i += 32) {
+        float w0 = apply_norm ? (scale * norm_w[i])          : 1.0f;
+        float w1 = apply_norm ? (scale * norm_w[i + half_d]) : 1.0f;
+        float x0 = src[i]          * w0;
+        float x1 = src[i + half_d] * w1;
+        float c = cos_row[i];
+        float s = sin_row[i];
+        dst[i]          = x0 * c - x1 * s;
+        dst[i + half_d] = x1 * c + x0 * s;
+    }
+}

--- a/crates/ferrum-kernels/src/backend/metal.rs
+++ b/crates/ferrum-kernels/src/backend/metal.rs
@@ -1446,6 +1446,40 @@ impl Backend for MetalBackend {
         );
     }
 
+    fn split_qkv_norm_rope(
+        ctx: &mut Self::Context,
+        qkv: &Self::Buffer,
+        q_norm_w: &Self::Buffer,
+        k_norm_w: &Self::Buffer,
+        cos: &Self::Buffer,
+        sin: &Self::Buffer,
+        q_out: &mut Self::Buffer,
+        k_out: &mut Self::Buffer,
+        v_out: &mut Self::Buffer,
+        tokens: usize,
+        q_heads: usize,
+        kv_heads: usize,
+        head_dim: usize,
+        pos_offset: usize,
+        eps: f32,
+        qk_mode: i32,
+    ) -> Result<()> {
+        let qkv = qkv.expect_f32("split_qkv_norm_rope qkv");
+        let q_norm_w = q_norm_w.expect_f32("split_qkv_norm_rope q_norm_w");
+        let k_norm_w = k_norm_w.expect_f32("split_qkv_norm_rope k_norm_w");
+        let cos = cos.expect_f32("split_qkv_norm_rope cos");
+        let sin = sin.expect_f32("split_qkv_norm_rope sin");
+        let q_out = q_out.expect_f32_mut("split_qkv_norm_rope q_out");
+        let k_out = k_out.expect_f32_mut("split_qkv_norm_rope k_out");
+        let v_out = v_out.expect_f32_mut("split_qkv_norm_rope v_out");
+        let enc = ctx.compute_encoder();
+        st().pipes.split_qkv_norm_rope(
+            enc, qkv, q_norm_w, k_norm_w, cos, sin, q_out, k_out, v_out, tokens, q_heads, kv_heads,
+            head_dim, pos_offset, eps, qk_mode,
+        );
+        Ok(())
+    }
+
     fn kv_cache_append_head_major(
         ctx: &mut Self::Context,
         cache_k: &mut Self::Buffer,

--- a/crates/ferrum-kernels/src/backend/traits.rs
+++ b/crates/ferrum-kernels/src/backend/traits.rs
@@ -758,6 +758,45 @@ pub trait Backend: Send + Sync + Sized + 'static {
         mode: i32,
     );
 
+    /// Fused split-QKV + QK-norm + RoPE + head-major transpose.
+    ///
+    /// Single-dispatch replacement for the (`split_qkv` → 3× `qk_norm_rope`)
+    /// chain on the decode-attention prelude. Reads the linear-layer
+    /// fused-QKV output once and writes head-major Q/K/V directly into
+    /// attention scratch.
+    ///
+    /// `qkv` layout: `[tokens, q_heads*hd + 2*kv_heads*hd]`.
+    /// `q_out`: `[q_heads, tokens, hd]`. `k_out`/`v_out`: `[kv_heads, tokens, hd]`.
+    /// `qk_mode`: 1 = norm + RoPE for Q/K (Qwen3 with QK-norm),
+    ///            2 = RoPE only for Q/K (no QK-norm; Llama-style).
+    /// V always falls through to transpose-only.
+    ///
+    /// Default returns Unsupported. Backends that implement it are
+    /// expected to be dramatically faster than the four-dispatch chain.
+    #[allow(clippy::too_many_arguments)]
+    fn split_qkv_norm_rope(
+        _ctx: &mut Self::Context,
+        _qkv: &Self::Buffer,
+        _q_norm_w: &Self::Buffer,
+        _k_norm_w: &Self::Buffer,
+        _cos: &Self::Buffer,
+        _sin: &Self::Buffer,
+        _q_out: &mut Self::Buffer,
+        _k_out: &mut Self::Buffer,
+        _v_out: &mut Self::Buffer,
+        _tokens: usize,
+        _q_heads: usize,
+        _kv_heads: usize,
+        _head_dim: usize,
+        _pos_offset: usize,
+        _eps: f32,
+        _qk_mode: i32,
+    ) -> Result<()> {
+        Err(FerrumError::unsupported(
+            "split_qkv_norm_rope not implemented for this backend",
+        ))
+    }
+
     /// Append new K/V into a pre-allocated head-major cache buffer.
     ///
     /// `cache_k` / `cache_v`: `[nkv, capacity, hd]` (head-major, pre-allocated)

--- a/crates/ferrum-models/src/models/qwen3_moe.rs
+++ b/crates/ferrum-models/src/models/qwen3_moe.rs
@@ -424,65 +424,95 @@ impl<B: Backend> Qwen3MoeModel<B> {
             tokens,
         );
 
-        // 3. split QKV
-        B::split_qkv(
-            ctx,
-            &self.scratch.qkv_out,
-            &mut self.scratch.q_buf,
-            &mut self.scratch.k_buf,
-            &mut self.scratch.v_buf,
-            tokens,
-            q_dim,
-            kv_dim,
-        );
-
-        // 4. QK-norm + RoPE → head-major Q/K, transpose-only V
+        // 3-4. Fused split-QKV + QK-norm + RoPE + head-major transpose.
+        //
+        // One Metal dispatch replaces (split_qkv → 3× qk_norm_rope), the
+        // four-launch chain that used to dominate the attention prelude.
+        // Reads qkv_out once, writes head-major Q/K (norm+RoPE) and V
+        // (transpose only) directly into attention scratch. Saves 3
+        // dispatches per layer (×48 = 144 dispatches per decode token).
+        //
+        // CPU and other backends without the fused kernel return
+        // Unsupported and we fall through to the original four-launch
+        // path. q_buf / k_buf / v_buf stay in scratch because that path
+        // and the per-expert MoE fallback still want them.
         let qk_mode: i32 = if cfg_base.has_qk_norm { 1 } else { 2 };
         let dummy = &attn_layer.input_ln_w;
         let q_norm_w = attn_layer.q_norm_w.as_ref().unwrap_or(dummy);
         let k_norm_w = attn_layer.k_norm_w.as_ref().unwrap_or(dummy);
-        B::qk_norm_rope(
+        let used_fused_qkv = B::split_qkv_norm_rope(
             ctx,
-            &self.scratch.q_buf,
+            &self.scratch.qkv_out,
             q_norm_w,
-            &self.rope.cos,
-            &self.rope.sin,
-            &mut self.scratch.q_head_major,
-            tokens,
-            nh,
-            hd,
-            pos_offset,
-            eps,
-            qk_mode,
-        );
-        B::qk_norm_rope(
-            ctx,
-            &self.scratch.k_buf,
             k_norm_w,
             &self.rope.cos,
             &self.rope.sin,
+            &mut self.scratch.q_head_major,
             &mut self.scratch.k_head_major,
+            &mut self.scratch.v_head_major,
             tokens,
+            nh,
             nkv,
             hd,
             pos_offset,
             eps,
             qk_mode,
-        );
-        B::qk_norm_rope(
-            ctx,
-            &self.scratch.v_buf,
-            dummy,
-            &self.rope.cos,
-            &self.rope.sin,
-            &mut self.scratch.v_head_major,
-            tokens,
-            nkv,
-            hd,
-            pos_offset,
-            eps,
-            0,
-        );
+        )
+        .is_ok();
+        if !used_fused_qkv {
+            B::split_qkv(
+                ctx,
+                &self.scratch.qkv_out,
+                &mut self.scratch.q_buf,
+                &mut self.scratch.k_buf,
+                &mut self.scratch.v_buf,
+                tokens,
+                q_dim,
+                kv_dim,
+            );
+            B::qk_norm_rope(
+                ctx,
+                &self.scratch.q_buf,
+                q_norm_w,
+                &self.rope.cos,
+                &self.rope.sin,
+                &mut self.scratch.q_head_major,
+                tokens,
+                nh,
+                hd,
+                pos_offset,
+                eps,
+                qk_mode,
+            );
+            B::qk_norm_rope(
+                ctx,
+                &self.scratch.k_buf,
+                k_norm_w,
+                &self.rope.cos,
+                &self.rope.sin,
+                &mut self.scratch.k_head_major,
+                tokens,
+                nkv,
+                hd,
+                pos_offset,
+                eps,
+                qk_mode,
+            );
+            B::qk_norm_rope(
+                ctx,
+                &self.scratch.v_buf,
+                dummy,
+                &self.rope.cos,
+                &self.rope.sin,
+                &mut self.scratch.v_head_major,
+                tokens,
+                nkv,
+                hd,
+                pos_offset,
+                eps,
+                0,
+            );
+        }
 
         // 5. KV append + 6. flash attention.
         let caches = self


### PR DESCRIPTION
## Summary

Fuse the four-launch attention prelude (`split_qkv` → `qk_norm_rope` × 3) into a single Metal kernel. On Qwen3-30B-A3B that drops **144 dispatches per decode token** (3 per layer × 48 layers).

## Background

Decode attention prelude used to be:

1. `split_qkv` — slice `qkv_out [tokens, q_dim+2*kv_dim]` into `q_buf` / `k_buf` / `v_buf`
2. `qk_norm_rope(q_buf)` → `q_head_major` (RMSNorm + RoPE)
3. `qk_norm_rope(k_buf)` → `k_head_major` (RMSNorm + RoPE, `k_norm_w`)
4. `qk_norm_rope(v_buf)` → `v_head_major` (transpose only, no norm)

Four kernel launches × ~50 µs each = ~200 µs CPU/GPU sync per layer just for the prelude.

## Change

New Metal kernel `split_qkv_norm_rope_f32`:
- One threadgroup per `(token, head_global)` where `head_global ∈ [0, q_heads + 2*kv_heads)`.
- Region selection by `head_global`: Q (norm + RoPE), K (norm + RoPE, k_norm_w), V (transpose only).
- Reads `qkv_out` once, writes head-major Q/K/V directly to attention scratch.

For Qwen3-30B-A3B (q_heads=32, kv_heads=4): grid = `(1, 40)` threadgroups, 32 threads each. Same total work; one launch.

## Wiring

- `Backend::split_qkv_norm_rope` trait method, default returns `Unsupported`.
- Metal impl wired in via the existing pipeline cache.
- `Qwen3MoeModel::forward_layer` calls the fused kernel; on `Err` (CPU, future backends) it falls back to the four-launch chain. `q_buf` / `k_buf` / `v_buf` stay around for the fallback and the per-expert MoE path that still uses them.

## Test plan

- [x] `cargo check --workspace --all-targets`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test --workspace --features metal --lib` — all green
- [x] Coherence (Qwen3-30B-A3B, greedy, 16 tokens, prompt "The capital of France is"):
      → "Paris. The capital of Italy is Rome. The capital of Spain is Madrid." — same as the unfused path.
- [ ] Re-bench `tg128` on memory-clean machine to record the speedup. The dev machine is RAM-tight after the 17 GB GGUF mmap so cold-cache numbers in this session were swap-poisoned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)