### PR TITLE
perf(decode): fused QKV → KV cache (saves 96 more dispatches/token across MoE+Llama)

### DIFF
--- a/crates/ferrum-attention/src/metal/pipelines.rs
+++ b/crates/ferrum-attention/src/metal/pipelines.rs
@@ -75,6 +75,7 @@ impl MetalPipelines {
                     "transpose_out_f32",
                     "kv_cache_append_f32",
                     "split_qkv_norm_rope_f32",
+                    "split_qkv_norm_rope_kvc_f32",
                 ][..],
             ),
             (
@@ -618,6 +619,75 @@ impl MetalPipelines {
         enc.set_buffer(5, Some(q_out), 0);
         enc.set_buffer(6, Some(k_out), 0);
         enc.set_buffer(7, Some(v_out), 0);
+        enc.set_bytes(
+            8,
+            std::mem::size_of::<P>() as u64,
+            &params as *const _ as *const c_void as *const _,
+        );
+        let grid = MTLSize::new(tokens as u64, (q_heads + 2 * kv_heads) as u64, 1);
+        let tg = MTLSize::new(32, 1, 1);
+        enc.dispatch_thread_groups(grid, tg);
+    }
+
+    /// Variant of `split_qkv_norm_rope` that writes K/V straight into the
+    /// pre-allocated head-major KV cache at slot `cache_len + tok`.
+    /// Eliminates the trailing `kv_cache_append_head_major` dispatch.
+    #[allow(clippy::too_many_arguments)]
+    pub fn split_qkv_norm_rope_into_cache(
+        &self,
+        enc: &ComputeCommandEncoderRef,
+        qkv: &Buffer,
+        q_norm_w: &Buffer,
+        k_norm_w: &Buffer,
+        cos: &Buffer,
+        sin: &Buffer,
+        q_out: &Buffer,
+        cache_k: &Buffer,
+        cache_v: &Buffer,
+        tokens: usize,
+        q_heads: usize,
+        kv_heads: usize,
+        head_dim: usize,
+        pos_offset: usize,
+        eps: f32,
+        qk_mode: i32,
+        cache_len: usize,
+        cache_capacity: usize,
+    ) {
+        #[repr(C)]
+        struct P {
+            tokens: i32,
+            q_heads: i32,
+            kv_heads: i32,
+            head_dim: i32,
+            half_dim: i32,
+            pos_offset: i32,
+            eps: f32,
+            qk_mode: i32,
+            cache_len: i32,
+            cache_capacity: i32,
+        }
+        let params = P {
+            tokens: tokens as i32,
+            q_heads: q_heads as i32,
+            kv_heads: kv_heads as i32,
+            head_dim: head_dim as i32,
+            half_dim: (head_dim / 2) as i32,
+            pos_offset: pos_offset as i32,
+            eps,
+            qk_mode,
+            cache_len: cache_len as i32,
+            cache_capacity: cache_capacity as i32,
+        };
+        enc.set_compute_pipeline_state(self.pipeline("split_qkv_norm_rope_kvc_f32"));
+        enc.set_buffer(0, Some(qkv), 0);
+        enc.set_buffer(1, Some(q_norm_w), 0);
+        enc.set_buffer(2, Some(k_norm_w), 0);
+        enc.set_buffer(3, Some(cos), 0);
+        enc.set_buffer(4, Some(sin), 0);
+        enc.set_buffer(5, Some(q_out), 0);
+        enc.set_buffer(6, Some(cache_k), 0);
+        enc.set_buffer(7, Some(cache_v), 0);
         enc.set_bytes(
             8,
             std::mem::size_of::<P>() as u64,

--- a/crates/ferrum-attention/src/metal/shaders/norm_rope.metal
+++ b/crates/ferrum-attention/src/metal/shaders/norm_rope.metal
@@ -269,3 +269,119 @@ kernel void split_qkv_norm_rope_f32(
         dst[i + half_d] = x1 * c + x0 * s;
     }
 }
+
+// ── Variant: write K/V straight into the KV cache ────────────────────────
+// Same fused split-QKV + QK-Norm + RoPE + transpose, but K and V land
+// directly in the pre-allocated head-major KV cache at position
+// (cache_len + tok) instead of in a separate per-token scratch buffer.
+// Eliminates the trailing `kv_cache_append_head_major` dispatch on the
+// decode path (one extra dispatch saved per layer × 48 layers).
+//
+// q_out stays the per-token head-major scratch since flash_attention
+// reads it as the query.
+//
+// Cache layout: [kv_heads, cache_capacity, hd]; only the slice
+// [kv_heads, cache_len .. cache_len + tokens, hd] is written.
+
+struct SplitQkvNormRopeKvcParams {
+    int tokens;
+    int q_heads;
+    int kv_heads;
+    int head_dim;
+    int half_dim;
+    int pos_offset;
+    float eps;
+    int qk_mode;
+    int cache_len;       // existing seq length in cache (write offset)
+    int cache_capacity;  // cache stride along token axis
+};
+
+kernel void split_qkv_norm_rope_kvc_f32(
+    device const float* qkv      [[buffer(0)]],
+    device const float* q_norm_w [[buffer(1)]],
+    device const float* k_norm_w [[buffer(2)]],
+    device const float* cos_tab  [[buffer(3)]],
+    device const float* sin_tab  [[buffer(4)]],
+    device       float* q_out    [[buffer(5)]],   // [q_heads, tokens, hd]
+    device       float* cache_k  [[buffer(6)]],   // [kv_heads, cache_capacity, hd]
+    device       float* cache_v  [[buffer(7)]],   // [kv_heads, cache_capacity, hd]
+    constant SplitQkvNormRopeKvcParams& p [[buffer(8)]],
+    uint2 tgpig [[threadgroup_position_in_grid]],
+    uint  tiisg [[thread_index_in_simdgroup]])
+{
+    const int tok = tgpig.x;
+    const int head_g = tgpig.y;
+    if (tok >= p.tokens) return;
+
+    const int hd = p.head_dim;
+    const int half_d = p.half_dim;
+    const int q_dim = p.q_heads * hd;
+    const int kv_dim = p.kv_heads * hd;
+    const int qkv_stride = q_dim + 2 * kv_dim;
+
+    int region;
+    int local_head;
+    int src_off;
+    if (head_g < uint(p.q_heads)) {
+        region = 0;
+        local_head = head_g;
+        src_off = tok * qkv_stride + local_head * hd;
+    } else if (head_g < uint(p.q_heads + p.kv_heads)) {
+        region = 1;
+        local_head = head_g - p.q_heads;
+        src_off = tok * qkv_stride + q_dim + local_head * hd;
+    } else {
+        region = 2;
+        local_head = head_g - p.q_heads - p.kv_heads;
+        src_off = tok * qkv_stride + q_dim + kv_dim + local_head * hd;
+    }
+
+    device const float* src = qkv + src_off;
+    // Q stays in per-token head-major scratch; K/V go straight into the
+    // cache at slot `cache_len + tok`.
+    device float* dst;
+    if (region == 0) {
+        dst = q_out + local_head * p.tokens * hd + tok * hd;
+    } else if (region == 1) {
+        dst = cache_k + local_head * p.cache_capacity * hd
+                      + (p.cache_len + tok) * hd;
+    } else {
+        dst = cache_v + local_head * p.cache_capacity * hd
+                      + (p.cache_len + tok) * hd;
+    }
+
+    if (region == 2) {
+        for (int i = tiisg; i < hd; i += 32) {
+            dst[i] = src[i];
+        }
+        return;
+    }
+
+    const bool apply_norm = (p.qk_mode == 1);
+    float scale = 1.0f;
+    device const float* norm_w = (region == 0) ? q_norm_w : k_norm_w;
+    if (apply_norm) {
+        float sum_sq = 0.0f;
+        for (int i = tiisg; i < hd; i += 32) {
+            float v = src[i];
+            sum_sq += v * v;
+        }
+        sum_sq = simd_sum(sum_sq);
+        scale = 1.0f / sqrt(sum_sq / float(hd) + p.eps);
+    }
+
+    const int pos = p.pos_offset + tok;
+    device const float* cos_row = cos_tab + pos * half_d;
+    device const float* sin_row = sin_tab + pos * half_d;
+
+    for (int i = tiisg; i < half_d; i += 32) {
+        float w0 = apply_norm ? (scale * norm_w[i])          : 1.0f;
+        float w1 = apply_norm ? (scale * norm_w[i + half_d]) : 1.0f;
+        float x0 = src[i]          * w0;
+        float x1 = src[i + half_d] * w1;
+        float c = cos_row[i];
+        float s = sin_row[i];
+        dst[i]          = x0 * c - x1 * s;
+        dst[i + half_d] = x1 * c + x0 * s;
+    }
+}

--- a/crates/ferrum-kernels/src/backend/metal.rs
+++ b/crates/ferrum-kernels/src/backend/metal.rs
@@ -1480,6 +1480,58 @@ impl Backend for MetalBackend {
         Ok(())
     }
 
+    fn split_qkv_norm_rope_into_cache(
+        ctx: &mut Self::Context,
+        qkv: &Self::Buffer,
+        q_norm_w: &Self::Buffer,
+        k_norm_w: &Self::Buffer,
+        cos: &Self::Buffer,
+        sin: &Self::Buffer,
+        q_out: &mut Self::Buffer,
+        cache_k: &mut Self::Buffer,
+        cache_v: &mut Self::Buffer,
+        tokens: usize,
+        q_heads: usize,
+        kv_heads: usize,
+        head_dim: usize,
+        pos_offset: usize,
+        eps: f32,
+        qk_mode: i32,
+        cache_len: usize,
+        cache_capacity: usize,
+    ) -> Result<()> {
+        let qkv = qkv.expect_f32("split_qkv_norm_rope_kvc qkv");
+        let q_norm_w = q_norm_w.expect_f32("split_qkv_norm_rope_kvc q_norm_w");
+        let k_norm_w = k_norm_w.expect_f32("split_qkv_norm_rope_kvc k_norm_w");
+        let cos = cos.expect_f32("split_qkv_norm_rope_kvc cos");
+        let sin = sin.expect_f32("split_qkv_norm_rope_kvc sin");
+        let q_out = q_out.expect_f32_mut("split_qkv_norm_rope_kvc q_out");
+        let cache_k = cache_k.expect_f32_mut("split_qkv_norm_rope_kvc cache_k");
+        let cache_v = cache_v.expect_f32_mut("split_qkv_norm_rope_kvc cache_v");
+        let enc = ctx.compute_encoder();
+        st().pipes.split_qkv_norm_rope_into_cache(
+            enc,
+            qkv,
+            q_norm_w,
+            k_norm_w,
+            cos,
+            sin,
+            q_out,
+            cache_k,
+            cache_v,
+            tokens,
+            q_heads,
+            kv_heads,
+            head_dim,
+            pos_offset,
+            eps,
+            qk_mode,
+            cache_len,
+            cache_capacity,
+        );
+        Ok(())
+    }
+
     fn kv_cache_append_head_major(
         ctx: &mut Self::Context,
         cache_k: &mut Self::Buffer,

--- a/crates/ferrum-kernels/src/backend/traits.rs
+++ b/crates/ferrum-kernels/src/backend/traits.rs
@@ -797,6 +797,41 @@ pub trait Backend: Send + Sync + Sized + 'static {
         ))
     }
 
+    /// Variant of [`Backend::split_qkv_norm_rope`] that writes the new
+    /// K and V directly into pre-allocated head-major KV cache buffers
+    /// at slot `[kv_heads, cache_len .. cache_len + tokens, hd]`.
+    /// Eliminates the trailing `kv_cache_append_head_major` dispatch on
+    /// the decode hot path. Q still lands in per-token head-major
+    /// scratch (flash-attention reads it as the query).
+    ///
+    /// Default returns Unsupported. Backends without the fused kernel
+    /// can keep using `split_qkv_norm_rope` + `kv_cache_append_head_major`.
+    #[allow(clippy::too_many_arguments)]
+    fn split_qkv_norm_rope_into_cache(
+        _ctx: &mut Self::Context,
+        _qkv: &Self::Buffer,
+        _q_norm_w: &Self::Buffer,
+        _k_norm_w: &Self::Buffer,
+        _cos: &Self::Buffer,
+        _sin: &Self::Buffer,
+        _q_out: &mut Self::Buffer,
+        _cache_k: &mut Self::Buffer,
+        _cache_v: &mut Self::Buffer,
+        _tokens: usize,
+        _q_heads: usize,
+        _kv_heads: usize,
+        _head_dim: usize,
+        _pos_offset: usize,
+        _eps: f32,
+        _qk_mode: i32,
+        _cache_len: usize,
+        _cache_capacity: usize,
+    ) -> Result<()> {
+        Err(FerrumError::unsupported(
+            "split_qkv_norm_rope_into_cache not implemented for this backend",
+        ))
+    }
+
     /// Append new K/V into a pre-allocated head-major cache buffer.
     ///
     /// `cache_k` / `cache_v`: `[nkv, capacity, hd]` (head-major, pre-allocated)

--- a/crates/ferrum-models/src/models/llama_family.rs
+++ b/crates/ferrum-models/src/models/llama_family.rs
@@ -637,156 +637,157 @@ impl<B: Backend> LlamaFamilyModel<B> {
             MATMUL_CALLS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         }
 
-        // 3. Split fused QKV → token-major Q/K/V
-        let _t0 = if std::env::var("FERRUM_DECODE_OP_PROFILE").is_ok() {
-            B::sync(ctx);
-            Some(std::time::Instant::now())
-        } else {
-            None
-        };
-        B::split_qkv(
-            ctx,
-            &self.scratch.qkv_out,
-            &mut self.scratch.q_buf,
-            &mut self.scratch.k_buf,
-            &mut self.scratch.v_buf,
-            tokens,
-            q_dim,
-            kv_dim,
-        );
-        if let Some(t0) = _t0 {
-            B::sync(ctx);
-            OTHER_TIME_US.fetch_add(
-                t0.elapsed().as_micros() as u64,
-                std::sync::atomic::Ordering::Relaxed,
-            );
-            OTHER_CALLS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        }
-
-        // 4. Fused QK-norm + RoPE + transpose to head-major
-        //    Qwen3: mode=1 (norm + rope). Non-QK-norm variants: mode=2 (rope only).
-        //    V always uses mode=0 (transpose only).
+        // 3-5. Fused split-QKV + QK-norm + RoPE + cache-write.
+        //
+        // Single Metal dispatch replaces the (split_qkv → 3× qk_norm_rope
+        // → kv_cache_append_head_major) five-launch chain on the decode
+        // hot path. Reads qkv_out once, writes Q to head-major scratch
+        // and K/V straight into the pre-allocated KV cache slot at
+        // `cache_len + tok`. Saves 4 dispatches per layer when the
+        // backend implements the fused kernel; CPU and other backends
+        // keep using the unfused chain via the Unsupported fallbacks.
+        //
+        // qk_mode: 1 = norm + RoPE (Qwen3); 2 = RoPE only (Llama).
+        // V always passes apply_norm=0.
         let qk_mode: i32 = if cfg.has_qk_norm { 1 } else { 2 };
         let dummy = &layer.input_ln_w;
         let q_norm_w = layer.q_norm_w.as_ref().unwrap_or(dummy);
         let k_norm_w = layer.k_norm_w.as_ref().unwrap_or(dummy);
 
-        let _t0 = if std::env::var("FERRUM_DECODE_OP_PROFILE").is_ok() {
-            B::sync(ctx);
-            Some(std::time::Instant::now())
-        } else {
-            None
-        };
-        B::qk_norm_rope(
-            ctx,
-            &self.scratch.q_buf,
-            q_norm_w,
-            &self.rope.cos,
-            &self.rope.sin,
-            &mut self.scratch.q_head_major,
-            tokens,
-            nh,
-            hd,
-            pos_offset,
-            eps,
-            qk_mode,
-        );
-        if let Some(t0) = _t0 {
-            B::sync(ctx);
-            QKR_TIME_US.fetch_add(
-                t0.elapsed().as_micros() as u64,
-                std::sync::atomic::Ordering::Relaxed,
-            );
-            QKR_CALLS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        }
-        let _t0 = if std::env::var("FERRUM_DECODE_OP_PROFILE").is_ok() {
-            B::sync(ctx);
-            Some(std::time::Instant::now())
-        } else {
-            None
-        };
-        B::qk_norm_rope(
-            ctx,
-            &self.scratch.k_buf,
-            k_norm_w,
-            &self.rope.cos,
-            &self.rope.sin,
-            &mut self.scratch.k_head_major,
-            tokens,
-            nkv,
-            hd,
-            pos_offset,
-            eps,
-            qk_mode,
-        );
-        if let Some(t0) = _t0 {
-            B::sync(ctx);
-            QKR_TIME_US.fetch_add(
-                t0.elapsed().as_micros() as u64,
-                std::sync::atomic::Ordering::Relaxed,
-            );
-            QKR_CALLS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        }
-        let _t0 = if std::env::var("FERRUM_DECODE_OP_PROFILE").is_ok() {
-            B::sync(ctx);
-            Some(std::time::Instant::now())
-        } else {
-            None
-        };
-        B::qk_norm_rope(
-            ctx,
-            &self.scratch.v_buf,
-            dummy, // unused in mode 0
-            &self.rope.cos,
-            &self.rope.sin,
-            &mut self.scratch.v_head_major,
-            tokens,
-            nkv,
-            hd,
-            pos_offset,
-            eps,
-            0, // transpose only
-        );
-        if let Some(t0) = _t0 {
-            B::sync(ctx);
-            QKR_TIME_US.fetch_add(
-                t0.elapsed().as_micros() as u64,
-                std::sync::atomic::Ordering::Relaxed,
-            );
-            QKR_CALLS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        }
-
-        // 5. Append K/V to pre-allocated head-major cache
+        // Grab the per-layer KV cache up front so the deepest fusion can
+        // write K/V straight into it.
         let caches = self
             .kv_caches
             .get_mut(cache_id)
             .expect("ensure_kv must be called before forward_layer");
         let cache = &mut caches[li];
+        let cache_len_before = cache.len;
+        let cache_capacity = cache.capacity;
+
         let _t0 = if std::env::var("FERRUM_DECODE_OP_PROFILE").is_ok() {
             B::sync(ctx);
             Some(std::time::Instant::now())
         } else {
             None
         };
-        B::kv_cache_append_head_major(
+        let used_qkv_into_cache = B::split_qkv_norm_rope_into_cache(
             ctx,
+            &self.scratch.qkv_out,
+            q_norm_w,
+            k_norm_w,
+            &self.rope.cos,
+            &self.rope.sin,
+            &mut self.scratch.q_head_major,
             &mut cache.k,
             &mut cache.v,
-            cache.len,
-            cache.capacity,
-            &self.scratch.k_head_major,
-            &self.scratch.v_head_major,
             tokens,
+            nh,
             nkv,
             hd,
-        );
+            pos_offset,
+            eps,
+            qk_mode,
+            cache_len_before,
+            cache_capacity,
+        )
+        .is_ok();
+        if !used_qkv_into_cache {
+            // Fallback 1: fused split-QKV-norm-rope to head-major scratch
+            // (PR #47 path).
+            let used_fused_qkv = B::split_qkv_norm_rope(
+                ctx,
+                &self.scratch.qkv_out,
+                q_norm_w,
+                k_norm_w,
+                &self.rope.cos,
+                &self.rope.sin,
+                &mut self.scratch.q_head_major,
+                &mut self.scratch.k_head_major,
+                &mut self.scratch.v_head_major,
+                tokens,
+                nh,
+                nkv,
+                hd,
+                pos_offset,
+                eps,
+                qk_mode,
+            )
+            .is_ok();
+            if !used_fused_qkv {
+                // Fallback 2: original four-launch chain.
+                B::split_qkv(
+                    ctx,
+                    &self.scratch.qkv_out,
+                    &mut self.scratch.q_buf,
+                    &mut self.scratch.k_buf,
+                    &mut self.scratch.v_buf,
+                    tokens,
+                    q_dim,
+                    kv_dim,
+                );
+                B::qk_norm_rope(
+                    ctx,
+                    &self.scratch.q_buf,
+                    q_norm_w,
+                    &self.rope.cos,
+                    &self.rope.sin,
+                    &mut self.scratch.q_head_major,
+                    tokens,
+                    nh,
+                    hd,
+                    pos_offset,
+                    eps,
+                    qk_mode,
+                );
+                B::qk_norm_rope(
+                    ctx,
+                    &self.scratch.k_buf,
+                    k_norm_w,
+                    &self.rope.cos,
+                    &self.rope.sin,
+                    &mut self.scratch.k_head_major,
+                    tokens,
+                    nkv,
+                    hd,
+                    pos_offset,
+                    eps,
+                    qk_mode,
+                );
+                B::qk_norm_rope(
+                    ctx,
+                    &self.scratch.v_buf,
+                    dummy,
+                    &self.rope.cos,
+                    &self.rope.sin,
+                    &mut self.scratch.v_head_major,
+                    tokens,
+                    nkv,
+                    hd,
+                    pos_offset,
+                    eps,
+                    0,
+                );
+            }
+            B::kv_cache_append_head_major(
+                ctx,
+                &mut cache.k,
+                &mut cache.v,
+                cache.len,
+                cache.capacity,
+                &self.scratch.k_head_major,
+                &self.scratch.v_head_major,
+                tokens,
+                nkv,
+                hd,
+            );
+        }
         if let Some(t0) = _t0 {
             B::sync(ctx);
-            OTHER_TIME_US.fetch_add(
+            QKR_TIME_US.fetch_add(
                 t0.elapsed().as_micros() as u64,
                 std::sync::atomic::Ordering::Relaxed,
             );
-            OTHER_CALLS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            QKR_CALLS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         }
         cache.len += tokens;
         let kv_len = cache.len;

--- a/crates/ferrum-models/src/models/qwen3_moe.rs
+++ b/crates/ferrum-models/src/models/qwen3_moe.rs
@@ -440,7 +440,23 @@ impl<B: Backend> Qwen3MoeModel<B> {
         let dummy = &attn_layer.input_ln_w;
         let q_norm_w = attn_layer.q_norm_w.as_ref().unwrap_or(dummy);
         let k_norm_w = attn_layer.k_norm_w.as_ref().unwrap_or(dummy);
-        let used_fused_qkv = B::split_qkv_norm_rope(
+
+        // 5. Grab the per-layer KV cache up front — the deepest fused
+        //    variant writes K/V straight into it, avoiding a trailing
+        //    `kv_cache_append_head_major` dispatch.
+        let caches = self
+            .kv_caches
+            .get_mut(cache_id)
+            .expect("ensure_kv must be called before forward_layer");
+        let cache = &mut caches[li];
+        let cache_len_before = cache.len;
+        let cache_capacity = cache.capacity;
+
+        // Try the deepest fusion: fused split-QKV-norm-rope that writes
+        // K/V directly into the cache slot. Skips both the head-major
+        // K/V scratch buffers and the `kv_cache_append_head_major`
+        // dispatch on the decode hot path.
+        let used_qkv_into_cache = B::split_qkv_norm_rope_into_cache(
             ctx,
             &self.scratch.qkv_out,
             q_norm_w,
@@ -448,8 +464,8 @@ impl<B: Backend> Qwen3MoeModel<B> {
             &self.rope.cos,
             &self.rope.sin,
             &mut self.scratch.q_head_major,
-            &mut self.scratch.k_head_major,
-            &mut self.scratch.v_head_major,
+            &mut cache.k,
+            &mut cache.v,
             tokens,
             nh,
             nkv,
@@ -457,81 +473,100 @@ impl<B: Backend> Qwen3MoeModel<B> {
             pos_offset,
             eps,
             qk_mode,
+            cache_len_before,
+            cache_capacity,
         )
         .is_ok();
-        if !used_fused_qkv {
-            B::split_qkv(
+        if !used_qkv_into_cache {
+            // Fallback 1: fused split-QKV-norm-rope to head-major scratch
+            // (Metal pre-decode-fusion path), then explicit cache append.
+            let used_fused_qkv = B::split_qkv_norm_rope(
                 ctx,
                 &self.scratch.qkv_out,
-                &mut self.scratch.q_buf,
-                &mut self.scratch.k_buf,
-                &mut self.scratch.v_buf,
-                tokens,
-                q_dim,
-                kv_dim,
-            );
-            B::qk_norm_rope(
-                ctx,
-                &self.scratch.q_buf,
                 q_norm_w,
-                &self.rope.cos,
-                &self.rope.sin,
-                &mut self.scratch.q_head_major,
-                tokens,
-                nh,
-                hd,
-                pos_offset,
-                eps,
-                qk_mode,
-            );
-            B::qk_norm_rope(
-                ctx,
-                &self.scratch.k_buf,
                 k_norm_w,
                 &self.rope.cos,
                 &self.rope.sin,
+                &mut self.scratch.q_head_major,
                 &mut self.scratch.k_head_major,
+                &mut self.scratch.v_head_major,
                 tokens,
+                nh,
                 nkv,
                 hd,
                 pos_offset,
                 eps,
                 qk_mode,
-            );
-            B::qk_norm_rope(
+            )
+            .is_ok();
+            if !used_fused_qkv {
+                // Fallback 2: original four-launch chain.
+                B::split_qkv(
+                    ctx,
+                    &self.scratch.qkv_out,
+                    &mut self.scratch.q_buf,
+                    &mut self.scratch.k_buf,
+                    &mut self.scratch.v_buf,
+                    tokens,
+                    q_dim,
+                    kv_dim,
+                );
+                B::qk_norm_rope(
+                    ctx,
+                    &self.scratch.q_buf,
+                    q_norm_w,
+                    &self.rope.cos,
+                    &self.rope.sin,
+                    &mut self.scratch.q_head_major,
+                    tokens,
+                    nh,
+                    hd,
+                    pos_offset,
+                    eps,
+                    qk_mode,
+                );
+                B::qk_norm_rope(
+                    ctx,
+                    &self.scratch.k_buf,
+                    k_norm_w,
+                    &self.rope.cos,
+                    &self.rope.sin,
+                    &mut self.scratch.k_head_major,
+                    tokens,
+                    nkv,
+                    hd,
+                    pos_offset,
+                    eps,
+                    qk_mode,
+                );
+                B::qk_norm_rope(
+                    ctx,
+                    &self.scratch.v_buf,
+                    dummy,
+                    &self.rope.cos,
+                    &self.rope.sin,
+                    &mut self.scratch.v_head_major,
+                    tokens,
+                    nkv,
+                    hd,
+                    pos_offset,
+                    eps,
+                    0,
+                );
+            }
+            B::kv_cache_append_head_major(
                 ctx,
-                &self.scratch.v_buf,
-                dummy,
-                &self.rope.cos,
-                &self.rope.sin,
-                &mut self.scratch.v_head_major,
+                &mut cache.k,
+                &mut cache.v,
+                cache.len,
+                cache.capacity,
+                &self.scratch.k_head_major,
+                &self.scratch.v_head_major,
                 tokens,
                 nkv,
                 hd,
-                pos_offset,
-                eps,
-                0,
             );
         }
-
-        // 5. KV append + 6. flash attention.
-        let caches = self
-            .kv_caches
-            .get_mut(cache_id)
-            .expect("ensure_kv must be called before forward_layer");
-        let cache = &mut caches[li];
-        B::kv_cache_append_head_major(
-            ctx,
-            &mut cache.k,
-            &mut cache.v,
-            cache.len,
-            cache.capacity,
-            &self.scratch.k_head_major,
-            &self.scratch.v_head_major,
-            tokens,
-            nkv,
-            hd,
-        );
         cache.len += tokens;
         let kv_len = cache.len;
         let kv_stride = cache.capacity;


### PR DESCRIPTION
## Summary

Stacks on PR #47. Two changes that share one new Metal kernel:

1. **`split_qkv_norm_rope_kvc_f32`** — variant of PR #47's fused kernel that writes K and V **directly into the pre-allocated KV cache** at slot `cache_len + tok`, skipping per-token K/V scratch and the trailing `kv_cache_append_head_major` dispatch.
2. **Wired in both `Qwen3MoeModel::forward_layer` and `LlamaFamilyModel::forward_layer`** — the single-stream and prefill paths of both families now use the deepest fusion. Each forward path falls back through PR #47's variant and finally the original four-launch chain on backends without the new kernel.

On both Qwen3-MoE (48 layers) and Llama-family models, the decode prelude per layer is now:

  `rms_norm` → `qkv_proj` → ONE fused (split + norm + RoPE + cache-write) → `flash_attention`

down from eight ops in trunk-before-#46.

## Why this matters

Each Metal dispatch costs ~50 µs of CPU/GPU sync. The cache-append was a pure memcpy of the freshly-RoPE'd K/V into a contiguous cache slot — exactly the kind of trailing op that's nearly free per element but expensive per launch. Adding an output binding to the kernel that already wrote K/V (just at a different offset) costs nothing at the kernel level.

On Qwen3-30B-A3B (48 layers): **48 fewer dispatches per decode token** vs PR #47.

## Test plan

- [x] `cargo check --workspace --all-targets`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test --workspace --features metal --lib` — all green
- [x] Coherence (Qwen3-30B-A3B, greedy, 16 tokens, prompt "The capital of France is"):
      → "Paris. The capital of Italy is Rome. The capital of Spain is Madrid." — same as the unfused path.
- [ ] Re-bench `tg128` on memory-clean machine (deferred — dev box is RAM-tight under the 17 GB GGUF mmap, in-session bench numbers are swap-poisoned).

🤖 Generated with [Claude Code](https://claude.com/claude-code)