### PR TITLE
perf(decode): fuse next-layer rms_norm into MoE tail (saves ~47 dispatches/token)

### DIFF
--- a/crates/ferrum-kernels/src/backend/metal.rs
+++ b/crates/ferrum-kernels/src/backend/metal.rs
@@ -889,6 +889,38 @@ impl Backend for MetalBackend {
         Ok(())
     }
 
+    fn weighted_sum_residual_norm_stacked(
+        ctx: &mut Self::Context,
+        slots: &Self::Buffer,
+        weights: &Self::Buffer,
+        residual: &mut Self::Buffer,
+        next_norm_w: &Self::Buffer,
+        normed_out: &mut Self::Buffer,
+        n_slots: usize,
+        hidden: usize,
+        eps: f32,
+    ) -> Result<()> {
+        let slots_buf = slots.expect_f32("weighted_sum_residual_norm_stacked slots");
+        let weights_buf = weights.expect_f32("weighted_sum_residual_norm_stacked weights");
+        let residual_buf = residual.expect_f32_mut("weighted_sum_residual_norm_stacked residual");
+        let nw_buf = next_norm_w.expect_f32("weighted_sum_residual_norm_stacked next_norm_w");
+        let normed_buf = normed_out.expect_f32_mut("weighted_sum_residual_norm_stacked normed_out");
+        let enc = ctx.compute_encoder();
+        crate::moe_post_ops::dispatch_weighted_sum_residual_norm_stacked(
+            &st().pipes.device,
+            enc,
+            slots_buf,
+            weights_buf,
+            residual_buf,
+            nw_buf,
+            normed_buf,
+            n_slots,
+            hidden,
+            eps,
+        );
+        Ok(())
+    }
+
     fn weighted_sum_batched(
         ctx: &mut Self::Context,
         slots: &Self::Buffer,

--- a/crates/ferrum-kernels/src/backend/traits.rs
+++ b/crates/ferrum-kernels/src/backend/traits.rs
@@ -474,6 +474,34 @@ pub trait Backend: Send + Sync + Sized + 'static {
         ))
     }
 
+    /// Fused weighted-sum-residual + RMSNorm: combines this layer's
+    /// `weighted_sum_residual_stacked` with the next layer's leading
+    /// `rms_norm` into a single dispatch.
+    ///
+    /// Computes
+    ///   `residual[i] += Σ_s w[s] · slots[s, i]`
+    ///   `normed_out[i] = residual[i] · (1 / sqrt(Σ residual² / hidden + eps)) · next_norm_w[i]`
+    ///
+    /// Caller is responsible for skipping the next layer's standalone
+    /// `rms_norm` — `normed_out` IS that layer's `norm_out` input.
+    /// Default returns Unsupported.
+    #[allow(clippy::too_many_arguments)]
+    fn weighted_sum_residual_norm_stacked(
+        _ctx: &mut Self::Context,
+        _slots: &Self::Buffer,
+        _weights: &Self::Buffer,
+        _residual: &mut Self::Buffer,
+        _next_norm_w: &Self::Buffer,
+        _normed_out: &mut Self::Buffer,
+        _n_slots: usize,
+        _hidden: usize,
+        _eps: f32,
+    ) -> Result<()> {
+        Err(FerrumError::unsupported(
+            "weighted_sum_residual_norm_stacked not implemented for this backend",
+        ))
+    }
+
     /// Per-batch weighted sum: `out[b, h] = Σ_k weights[b, k] · slots[b, k, h]`.
     /// Single dispatch covers the whole batch (prefill version of
     /// `weighted_sum_stacked` which only handled one token).

--- a/crates/ferrum-kernels/src/moe_post_ops.metal
+++ b/crates/ferrum-kernels/src/moe_post_ops.metal
@@ -114,3 +114,60 @@ kernel void weighted_sum_stacked_f32(
     }
     out[i] = sum;
 }
+
+// ── Fused weighted-sum-residual + RMSNorm (cross-layer tail) ─────────
+// Folds the trailing `weighted_sum_residual_stacked` of layer L AND
+// the leading `rms_norm` of layer L+1 into one Metal dispatch:
+//   residual[i] += Σ_s w[s] · slots[s, i]
+//   normed[i]   = residual[i] · (1 / sqrt(Σ residual^2 / hidden + eps))
+//                · next_norm_w[i]
+//
+// Saves one dispatch per layer transition on the decode hot path
+// (-47 dispatches / token at 48 layers). The next forward_layer call
+// must skip its own rms_norm when this path was taken (signalled by a
+// caller-side flag); the fused output IS its norm_out input.
+//
+// Threadgroup: 32 threads (1 simdgroup). One simdgroup per token row.
+// Each thread covers `hidden / 32` floats during the partial sum_sq
+// reduce and the final normed write.
+
+struct WSumResNormParams {
+    int hidden;
+    int n_slots;
+    float eps;
+};
+
+kernel void weighted_sum_residual_norm_stacked_f32(
+    device const float* slots       [[buffer(0)]],
+    device const float* weights     [[buffer(1)]],
+    device       float* residual    [[buffer(2)]],   // updated in place
+    device const float* next_norm_w [[buffer(3)]],   // [hidden]
+    device       float* normed_out  [[buffer(4)]],   // [hidden]
+    constant WSumResNormParams& p   [[buffer(5)]],
+    uint3 tgpig [[threadgroup_position_in_grid]],
+    uint  tiisg [[thread_index_in_simdgroup]])
+{
+    const int hidden  = p.hidden;
+    const int n_slots = p.n_slots;
+
+    // Phase 1: residual += weighted_sum, accumulate Σ residual^2.
+    float local_sum_sq = 0.0f;
+    for (int i = tiisg; i < hidden; i += 32) {
+        float sum = 0.0f;
+        for (int s = 0; s < n_slots; s++) {
+            sum += weights[s] * slots[s * hidden + i];
+        }
+        const float new_val = residual[i] + sum;
+        residual[i] = new_val;
+        local_sum_sq += new_val * new_val;
+    }
+
+    // Phase 2: cross-simdgroup reduce.
+    const float total_sq = simd_sum(local_sum_sq);
+    const float scale    = 1.0f / sqrt(total_sq / float(hidden) + p.eps);
+
+    // Phase 3: write normed_out using next layer's norm weight.
+    for (int i = tiisg; i < hidden; i += 32) {
+        normed_out[i] = residual[i] * scale * next_norm_w[i];
+    }
+}

--- a/crates/ferrum-kernels/src/moe_post_ops.rs
+++ b/crates/ferrum-kernels/src/moe_post_ops.rs
@@ -15,6 +15,7 @@ const SHADER_SRC: &str = include_str!("moe_post_ops.metal");
 static SILU_PIPELINE: OnceLock<ComputePipelineState> = OnceLock::new();
 static WSUM_PIPELINE: OnceLock<ComputePipelineState> = OnceLock::new();
 static WSUM_RES_PIPELINE: OnceLock<ComputePipelineState> = OnceLock::new();
+static WSUM_RES_NORM_PIPELINE: OnceLock<ComputePipelineState> = OnceLock::new();
 
 fn silu_pipeline(device: &Device) -> &'static ComputePipelineState {
     SILU_PIPELINE.get_or_init(|| {
@@ -55,6 +56,20 @@ fn wsum_res_pipeline(device: &Device) -> &'static ComputePipelineState {
         device
             .new_compute_pipeline_state_with_function(&function)
             .expect("build weighted_sum_residual_stacked_f32 pipeline")
+    })
+}
+
+fn wsum_res_norm_pipeline(device: &Device) -> &'static ComputePipelineState {
+    WSUM_RES_NORM_PIPELINE.get_or_init(|| {
+        let lib = device
+            .new_library_with_source(SHADER_SRC, &CompileOptions::new())
+            .expect("compile moe_post_ops.metal");
+        let function = lib
+            .get_function("weighted_sum_residual_norm_stacked_f32", None)
+            .expect("find weighted_sum_residual_norm_stacked_f32");
+        device
+            .new_compute_pipeline_state_with_function(&function)
+            .expect("build weighted_sum_residual_norm_stacked_f32 pipeline")
     })
 }
 
@@ -174,5 +189,56 @@ pub fn dispatch_weighted_sum_residual_stacked(
     let grid_x = (hidden as u64).div_ceil(256);
     let grid = MTLSize::new(grid_x, 1, 1);
     let tg = MTLSize::new(256, 1, 1);
+    enc.dispatch_thread_groups(grid, tg);
+}
+
+/// Fused weighted-sum-residual + RMSNorm: residual update AND next layer's
+/// rms_norm in one dispatch. The kernel writes `residual[i] += Σ_s w[s] ·
+/// slots[s, i]` AND `normed_out[i] = residual[i] * scale * next_norm_w[i]`,
+/// where `scale = 1 / sqrt(Σ residual² / hidden + eps)`.
+///
+/// Caller must skip the next layer's standalone `rms_norm` — `normed_out`
+/// IS that layer's `norm_out` input.
+#[allow(clippy::too_many_arguments)]
+pub fn dispatch_weighted_sum_residual_norm_stacked(
+    device: &Device,
+    enc: &ComputeCommandEncoderRef,
+    slots: &Buffer,
+    weights: &Buffer,
+    residual: &Buffer,
+    next_norm_w: &Buffer,
+    normed_out: &Buffer,
+    n_slots: usize,
+    hidden: usize,
+    eps: f32,
+) {
+    #[repr(C)]
+    struct P {
+        hidden: i32,
+        n_slots: i32,
+        eps: f32,
+    }
+    let params = P {
+        hidden: hidden as i32,
+        n_slots: n_slots as i32,
+        eps,
+    };
+
+    let pipe = wsum_res_norm_pipeline(device);
+    enc.set_compute_pipeline_state(pipe);
+    enc.set_buffer(0, Some(slots), 0);
+    enc.set_buffer(1, Some(weights), 0);
+    enc.set_buffer(2, Some(residual), 0);
+    enc.set_buffer(3, Some(next_norm_w), 0);
+    enc.set_buffer(4, Some(normed_out), 0);
+    enc.set_bytes(
+        5,
+        std::mem::size_of::<P>() as u64,
+        &params as *const _ as *const c_void,
+    );
+
+    // One simdgroup per token (q_len=1 in decode). 32 threads cover hidden.
+    let grid = MTLSize::new(1, 1, 1);
+    let tg = MTLSize::new(32, 1, 1);
     enc.dispatch_thread_groups(grid, tg);
 }

--- a/crates/ferrum-models/src/models/qwen3_moe.rs
+++ b/crates/ferrum-models/src/models/qwen3_moe.rs
@@ -386,7 +386,15 @@ impl<B: Backend> Qwen3MoeModel<B> {
         residual: &mut B::Buffer,
         pos_offset: usize,
         tokens: usize,
-    ) -> Result<()> {
+        // If `Some(idx)` and we land on the decode fast path, fold the
+        // next layer's leading rms_norm into this layer's MoE tail
+        // (cross-layer norm fusion). The next layer's caller must pass
+        // `prev_did_norm_fusion = true` so it skips its own rms_norm.
+        next_layer_idx: Option<usize>,
+        // If `true`, skip step 1's input rms_norm — the previous
+        // layer's tail already populated `scratch.norm_out`.
+        prev_did_norm_fusion: bool,
+    ) -> Result<bool> {
         let cfg_base = &self.cfg.base;
         let h = cfg_base.hidden_size;
         let nh = cfg_base.num_heads;
@@ -405,16 +413,19 @@ impl<B: Backend> Qwen3MoeModel<B> {
             None
         };
 
-        // 1. Input RMSNorm
-        B::rms_norm(
-            ctx,
-            residual,
-            &attn_layer.input_ln_w,
-            eps,
-            &mut self.scratch.norm_out,
-            tokens,
-            h,
-        );
+        // 1. Input RMSNorm — skipped when the previous layer's MoE tail
+        //    fused this norm via `weighted_sum_residual_norm_stacked`.
+        if !prev_did_norm_fusion {
+            B::rms_norm(
+                ctx,
+                residual,
+                &attn_layer.input_ln_w,
+                eps,
+                &mut self.scratch.norm_out,
+                tokens,
+                h,
+            );
+        }
 
         // 2. Fused QKV
         attn_layer.qkv_proj.forward(
@@ -680,6 +691,12 @@ impl<B: Backend> Qwen3MoeModel<B> {
         // Prefill (m>1) and the per-expert fallback still go through
         // moe_out + add_inplace.
         let decode_fast_path = stacked_path_available && tokens == 1;
+        // Cross-layer fusion: when on the decode fast path AND there is
+        // a next layer, fold its leading rms_norm into this layer's
+        // tail (`weighted_sum_residual_norm_stacked`). Returns whether
+        // the fusion ran so the caller can signal the next layer to
+        // skip its standalone rms_norm.
+        let did_norm_fusion = decode_fast_path && next_layer_idx.is_some();
 
         if stacked_path_available {
             if tokens > 1 {
@@ -688,8 +705,9 @@ impl<B: Backend> Qwen3MoeModel<B> {
                 self.moe_forward_batched_prefill(ctx, li, tokens)?;
             } else {
                 // Decode m=1: dedicated per-token path that fuses
-                // residual-add into the final weighted-sum.
-                self.moe_forward_stacked(ctx, li, tokens, residual)?;
+                // residual-add into the final weighted-sum, and
+                // optionally folds the next layer's rms_norm in too.
+                self.moe_forward_stacked(ctx, li, tokens, residual, next_layer_idx)?;
             }
         } else {
             moe_forward::<B>(
@@ -728,7 +746,7 @@ impl<B: Backend> Qwen3MoeModel<B> {
             MOE_CALLS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         }
 
-        Ok(())
+        Ok(did_norm_fusion)
     }
 
     fn moe_forward_stacked(
@@ -737,8 +755,23 @@ impl<B: Backend> Qwen3MoeModel<B> {
         li: usize,
         tokens: usize,
         residual: &mut B::Buffer,
+        next_layer_idx: Option<usize>,
     ) -> Result<()> {
         let cfg = &self.cfg;
+        // `next_norm_w` is the next layer's `attn_layer.input_ln_w`.
+        // We can't borrow `self.attn_layers[idx]` and pass &mut
+        // self.scratch to the impl simultaneously, so collect the raw
+        // pointer here. Safety: forward_layer holds &mut self for the
+        // call; the borrow scopes are fully sequential.
+        let next_norm_w_ptr: Option<*const B::Buffer> =
+            next_layer_idx.map(|idx| &self.attn_layers[idx].input_ln_w as *const _);
+        // SAFETY: pointer dereference is valid because:
+        //   * The buffer lives in `self.attn_layers[idx]` which we
+        //     borrowed immutably to take the pointer. We do not mutate
+        //     `self.attn_layers` while `next_norm_w_ptr` is in use.
+        //   * `&mut self.scratch` and `&self.moe_layers[li]` are disjoint
+        //     fields from `self.attn_layers` so this is safe.
+        let next_norm_w: Option<&B::Buffer> = next_norm_w_ptr.map(|p| unsafe { &*p });
         moe_forward_stacked_decode_impl::<B>(
             ctx,
             &self.moe_layers[li],
@@ -750,6 +783,8 @@ impl<B: Backend> Qwen3MoeModel<B> {
             cfg.norm_topk_prob,
             tokens,
             residual,
+            next_norm_w,
+            cfg.base.rms_norm_eps,
         )
     }
 
@@ -798,8 +833,29 @@ impl<B: Backend> Qwen3MoeModel<B> {
             .expect("scratch residual missing (previous call didn't restore)");
         B::embedding_lookup(&mut ctx, &self.embed, tokens, &mut residual, h);
 
-        for li in 0..self.cfg.base.num_layers {
-            self.forward_layer(&mut ctx, li, cache_id, &mut residual, pos_offset, seq_len)
+        // For prefill (seq_len > 1) the cross-layer norm fusion does
+        // not apply (it lives on the decode fast path). We still pass
+        // `next_layer_idx = None` so forward_layer emits the regular
+        // tail.
+        let mut prev_did_norm_fusion = false;
+        let num_layers = self.cfg.base.num_layers;
+        for li in 0..num_layers {
+            let next_layer_idx = if li + 1 < num_layers {
+                Some(li + 1)
+            } else {
+                None
+            };
+            prev_did_norm_fusion = self
+                .forward_layer(
+                    &mut ctx,
+                    li,
+                    cache_id,
+                    &mut residual,
+                    pos_offset,
+                    seq_len,
+                    next_layer_idx,
+                    prev_did_norm_fusion,
+                )
                 .expect("forward_layer");
         }
 
@@ -855,8 +911,28 @@ impl<B: Backend> Qwen3MoeModel<B> {
             .expect("scratch residual missing (previous call didn't restore)");
         B::embedding_lookup(&mut ctx, &self.embed, &[token], &mut residual, h);
 
-        for li in 0..self.cfg.base.num_layers {
-            self.forward_layer(&mut ctx, li, cache_id, &mut residual, pos as usize, 1)
+        // Cross-layer rms_norm fusion: layer L's MoE tail folds the
+        // next layer's leading rms_norm into its weighted-sum-residual
+        // when the decode fast path applies. The flag carries forward.
+        let mut prev_did_norm_fusion = false;
+        let num_layers = self.cfg.base.num_layers;
+        for li in 0..num_layers {
+            let next_layer_idx = if li + 1 < num_layers {
+                Some(li + 1)
+            } else {
+                None
+            };
+            prev_did_norm_fusion = self
+                .forward_layer(
+                    &mut ctx,
+                    li,
+                    cache_id,
+                    &mut residual,
+                    pos as usize,
+                    1,
+                    next_layer_idx,
+                    prev_did_norm_fusion,
+                )
                 .expect("forward_layer");
         }
 
@@ -976,6 +1052,10 @@ fn moe_forward_stacked_decode_impl<B: Backend>(
     norm_topk_prob: bool,
     tokens: usize,
     residual: &mut B::Buffer,
+    // If `Some`, fold the NEXT layer's leading rms_norm into the
+    // weighted-sum-residual tail using `weighted_sum_residual_norm_stacked`.
+    next_norm_w: Option<&B::Buffer>,
+    eps: f32,
 ) -> Result<()> {
     // GPU-side routing: one Metal launch reads router_logits and writes
     // selected ids + combine weights directly into device-side scratch
@@ -1061,20 +1141,37 @@ fn moe_forward_stacked_decode_impl<B: Backend>(
             inter,
         )?;
 
-        // 5. Fused weighted-sum + residual-add:
-        //    residual[i] += Σ_k w[k] · down[k, i]. Writes directly into
-        //    the residual stream, skipping the moe_out scratch and the
-        //    trailing `add_inplace` the caller used to do. Saves 1
-        //    dispatch per layer (×48 = 48 dispatches per decode token)
-        //    plus the moe_out → residual memory traffic.
-        B::weighted_sum_residual_stacked(
-            ctx,
-            &scratch.down_out_stacked,
-            &scratch.weights_buf,
-            residual,
-            top_k,
-            h,
-        )?;
+        // 5. Fused weighted-sum + residual-add (+ optional next-layer
+        //    rms_norm). Two paths:
+        //
+        //    * `next_norm_w = Some(_)` (cross-layer fusion): one kernel
+        //      computes residual[i] += Σ_k w[k] · down[k, i] AND
+        //      norm_out[i] = residual[i] · scale · next_norm_w[i].
+        //      The next layer's leading rms_norm is skipped. Saves an
+        //      additional dispatch per layer transition.
+        //    * `next_norm_w = None` (last layer): just residual-add.
+        if let Some(nnw) = next_norm_w {
+            B::weighted_sum_residual_norm_stacked(
+                ctx,
+                &scratch.down_out_stacked,
+                &scratch.weights_buf,
+                residual,
+                nnw,
+                &mut scratch.norm_out,
+                top_k,
+                h,
+                eps,
+            )?;
+        } else {
+            B::weighted_sum_residual_stacked(
+                ctx,
+                &scratch.down_out_stacked,
+                &scratch.weights_buf,
+                residual,
+                top_k,
+                h,
+            )?;
+        }
     }
 
     Ok(())


### PR DESCRIPTION
## Summary

Cross-layer fusion: combine layer L's `weighted_sum_residual_stacked` with layer L+1's leading `rms_norm` into one Metal kernel. On Qwen3-30B-A3B that removes **47 dispatches per decode token** (one per layer transition; the last layer keeps its un-fused tail).

## What

The decode hot path used to do, per layer:

```
... MoE ... → weighted_sum_residual_stacked: residual += Σ_k w[k] · down[k]
                       │
                       ▼  (next layer)
rms_norm: norm_out = residual · scale · input_ln_w
```

Two back-to-back dispatches over the same `residual` buffer. Stacked the residual update and the RMS norm into a single kernel:

```metal
weighted_sum_residual_norm_stacked_f32(
    slots, weights, residual, next_norm_w, normed_out, ...
) {
    // Phase 1: residual += weighted_sum + accumulate sum_sq
    // Phase 2: simd_sum reduce → scale = 1 / sqrt(sum_sq / hidden + eps)
    // Phase 3: normed_out = residual · scale · next_norm_w
}
```

One simdgroup per token row; each thread covers `hidden / 32` floats.

## Wiring

`forward_layer` now takes:
- `next_layer_idx: Option<usize>` — when `Some` AND decode fast path applies, fuse the next layer's rms_norm.
- `prev_did_norm_fusion: bool` — when `true`, the previous layer already produced `norm_out`, so this layer skips its leading `rms_norm`.

Returns whether fusion ran so the loop can carry the flag forward. The last layer (no next) keeps the un-fused tail; the post-loop `final_norm` and `lm_head` are unchanged.

## Stacked savings

After this PR (Qwen3-30B-A3B, 48 layers, decode hot path):
- Layer 0: leading rms_norm + ... + fused (wsum_res + next_norm) = 11 dispatches
- Layer 1..N-2: ... + fused (wsum_res + next_norm) = 10 dispatches (skip own rms_norm)
- Layer N-1: skips own rms_norm + ... + un-fused tail (no next) = 11 dispatches

Down from 12 dispatches/layer flat (post-#48). 

Cumulative this session (#46 → this PR): ~330+ dispatches/token saved on Qwen3-30B-A3B decode.

## Test plan
- [x] `cargo check --workspace --all-targets`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test --workspace --features metal --lib` — all green
- [x] Coherence (Qwen3-30B-A3B, greedy, 16 tokens, prompt "The capital of France is"):
      → "Paris. The capital of Italy is Rome. The capital of Spain is Madrid." — same as the unfused path.
- [ ] Re-bench `tg128` on memory-clean machine (deferred — dev box swap-thrashing under the 17 GB GGUF mmap; in-session bench numbers were swap-poisoned across all of #46–#49).

🤖 Generated with [Claude Code](https://claude.com/claude-code)