### PR TITLE
perf(metal): vectorize dense GEMM + flash_attn QK loads (consistency)

### DIFF
--- a/crates/ferrum-attention/src/metal/shaders/flash_attn.metal
+++ b/crates/ferrum-attention/src/metal/shaders/flash_attn.metal
@@ -86,18 +86,30 @@ kernel void flash_attn_f32(
             device const float* k_row = k_base + ki * d;
             device const float* v_row = v_base + ki * d;
 
-            // Compute dot product Q[qi] · K[ki] using simd reduction
-            float dot = 0.0f;
-            for (int j = tiisg; j < d; j += 32) {
-                dot += q_row[j] * k_row[j];
+            // Compute dot product Q[qi] · K[ki] using simd reduction.
+            // Vectorized: each thread loads 4 floats per iter (float4
+            // load = 16-byte coalesced access vs 4× 4-byte scalar loads).
+            // For d=128, head_dim divisible by 4: each thread does d/(32*4)
+            // = 1 float4 load and 1 metal::dot. For odd head_dims fall
+            // back to scalar tail.
+            float dot_acc = 0.0f;
+            const int d4 = d & ~3; // round down to multiple of 4
+            for (int j = tiisg * 4; j < d4; j += 32 * 4) {
+                float4 q_v = *((device const float4 *)(q_row + j));
+                float4 k_v = *((device const float4 *)(k_row + j));
+                dot_acc += metal::dot(q_v, k_v);
             }
-            dot = simd_sum(dot) * p.scale;
+            // Tail (head_dim not multiple of 4) — rare, kept for safety.
+            for (int j = d4 + tiisg; j < d; j += 32) {
+                dot_acc += q_row[j] * k_row[j];
+            }
+            float dot_v = simd_sum(dot_acc) * p.scale;
 
             // Online softmax update
             float old_M = M;
-            M = max(M, dot);
+            M = max(M, dot_v);
             float exp_diff = exp(old_M - M);
-            float exp_val = exp(dot - M);
+            float exp_val = exp(dot_v - M);
 
             // Rescale existing accumulator and sum
             S = S * exp_diff + exp_val;

--- a/crates/ferrum-kernels/src/q4_k_gemm.metal
+++ b/crates/ferrum-kernels/src/q4_k_gemm.metal
@@ -152,25 +152,18 @@ kernel void gemm_q4kw_f32a_f32o(
         }
 
         // === Load B (activations) tile into shared memory ===
+        // Vector store of 8 halves at once — same change as
+        // `q4_k_moe_id_gemm.metal` (PR #52). Replaces 8 scalar half
+        // writes with one half2x4 store. Critical for the inner-K
+        // shmem bandwidth.
         {
             const short sx = short(tiitg) % NL1;
             const short sy = (short(tiitg) / NL1) / 8;
             const short ly = (short(tiitg) / NL1) % 8;
             const short ib = 4 * sx + sy;
 
-            // 8 floats from device memory → half2x4 in shared
-            float4 v0 = float4(*((device const float4 *)(y + 0)));
-            float4 v1 = float4(*((device const float4 *)(y + 4)));
-
-            threadgroup half * dst8 = sb + 64 * ib + 8 * ly;
-            dst8[0] = half(v0[0]);
-            dst8[1] = half(v0[1]);
-            dst8[2] = half(v0[2]);
-            dst8[3] = half(v0[3]);
-            dst8[4] = half(v1[0]);
-            dst8[5] = half(v1[1]);
-            dst8[6] = half(v1[2]);
-            dst8[7] = half(v1[3]);
+            *(threadgroup half2x4 *)(sb + 64 * ib + 8 * ly) =
+                half2x4(*((device const float2x4 *) y));
         }
 
         // Advance weight pointer for next K tile

--- a/crates/ferrum-kernels/src/q6_k_gemm.metal
+++ b/crates/ferrum-kernels/src/q6_k_gemm.metal
@@ -142,25 +142,15 @@ kernel void gemm_q6kw_f32a_f32o(
             }
         }
 
-        // Load B tile (8 floats → 8 halves per thread)
+        // Load B tile — vector store (see q4_k_moe_id_gemm for rationale)
         {
             const short sx = short(tiitg) % NL1_Q6;
             const short sy = (short(tiitg) / NL1_Q6) / 8;
             const short ly = (short(tiitg) / NL1_Q6) % 8;
             const short ib = 4 * sx + sy;
 
-            float4 v0 = float4(*((device const float4 *)(y + 0)));
-            float4 v1 = float4(*((device const float4 *)(y + 4)));
-
-            threadgroup half * dst8 = sb + 64 * ib + 8 * ly;
-            dst8[0] = half(v0[0]);
-            dst8[1] = half(v0[1]);
-            dst8[2] = half(v0[2]);
-            dst8[3] = half(v0[3]);
-            dst8[4] = half(v1[0]);
-            dst8[5] = half(v1[1]);
-            dst8[6] = half(v1[2]);
-            dst8[7] = half(v1[3]);
+            *(threadgroup half2x4 *)(sb + 64 * ib + 8 * ly) =
+                half2x4(*((device const float2x4 *) y));
         }
 
         il = (il + 2 < NL_BLOCK_Q6_K) ? il + 2 : il % 2;


### PR DESCRIPTION
## Summary

Follow-up to PR #52 — apply the same vector-store pattern to the dense Q4_K / Q6_K GEMM kernels and to flash_attn's Q·K dot product. **No measurable perf change on Qwen3-30B-A3B Q4_K_M** (these kernels aren't the prefill bottleneck), but lands for consistency and to keep the load path tidy ahead of the upcoming flash_attn rewrite.

## Changes

1. **`q4_k_gemm.metal`** (dense, used for qkv_proj / o_proj / lm_head / embedding) — same vector half2x4 store as PR #52
2. **`q6_k_gemm.metal`** — same
3. **`flash_attn.metal`** — replace scalar Q·K dot loop with float4 vectorized `metal::dot` + scalar tail for non-multiple-of-4 head_dims

## Measurements (M1 Max, 5× pp512 median)

| metric | post #52 | this PR |
|---|---:|---:|
| pp512 | 283 t/s | 282 t/s |

Flat — these kernels aren't the bottleneck on Qwen3-30B-A3B. Dense GEMMs are ~5% of prefill; flash_attn is currently ~33% but its real bottleneck is architecture, not single-thread dot-product memory throughput.

## Why land it anyway

- **Consistency**: keeps all `mul_mm`-style kernels using the same vector-store pattern. PR #52 left dense GEMMs as the odd ones out.
- **Setting up the next step**: the next major prefill optimization is rewriting `flash_attn.metal` to Q-batched simdgroup_matmul (matching llama.cpp's `kernel_flash_attn_ext`). That's a multi-day effort — this PR is the small prep piece.

## Where the prefill perf gap actually is

After this PR, ferrum prefill on Qwen3-30B-A3B = 282 t/s vs llama.cpp 618 t/s = **46%**. To close the rest:

| stage | ferrum t (capture) | llama.cpp est. | gap |
|---|---:|---:|---:|
| MoE GEMM (gate/up/down) | 1.4 s | ~0.5 s | 2.8× |
| flash_attn | 0.9 s | ~0.15 s | 6× ← **biggest gap** |
| other | 0.5 s | ~0.18 s | 2.8× |

Closing the flash_attn gap (Q-batched simdgroup_matmul) is the next milestone. ETA: separate PR.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo check --workspace --all-targets`
- [x] `cargo check --workspace --features metal --all-targets`
- [x] `cargo test -p ferrum-kernels --features metal --lib` — 10 passed
- [x] Correctness: Qwen3-30B-A3B outputs Paris/Rome/Madrid

🤖 Generated with [Claude Code](https://claude.com/claude-code)