### PR TITLE
fix(kv): default capacity 32768→4096 + overflow guard for chat REPL

### DIFF
--- a/crates/ferrum-cli/src/commands/run_gguf.rs
+++ b/crates/ferrum-cli/src/commands/run_gguf.rs
@@ -447,6 +447,33 @@ fn run_repl<M: DecoderOnlyLLM>(
             .map_err(|e| FerrumError::model(format!("encode user: {e}")))?
             .get_ids()
             .to_vec();
+
+        // Pre-check KV capacity. Worst case for this turn = ingesting
+        // the full user prompt + generating `max_tokens` decode steps.
+        // If that would push past the per-cache budget, refuse cleanly
+        // here — the alternative is silent buffer overflow inside the
+        // attention kernel (garbage tokens, walking off the K/V tile,
+        // and a hard panic from `forward_layer`'s defensive check).
+        let max_new = cmd.max_tokens as usize;
+        let kv_capacity = model.kv_capacity();
+        let needed = cache_len + user_ids.len() + max_new;
+        if needed > kv_capacity {
+            eprintln!(
+                "{} context full: this turn would need {} tokens (current cache {} + prompt {} + max_tokens {}), but the KV budget is {}.",
+                "✗".red().bold(),
+                needed,
+                cache_len,
+                user_ids.len(),
+                max_new,
+                kv_capacity,
+            );
+            eprintln!(
+                "  Either run `/clear` to reset the conversation or restart with `FERRUM_KV_CAPACITY={}` (or larger).",
+                (needed.next_power_of_two()).max(8192),
+            );
+            continue;
+        }
+
         // We can't call `prefill` again on the same cache_id without
         // resetting — but we can use `decode` per-token to extend.
         // Cleaner: split the user turn into prefill semantics by feeding
@@ -466,7 +493,6 @@ fn run_repl<M: DecoderOnlyLLM>(
         io::stdout().flush().ok();
 
         let decode_start = Instant::now();
-        let max_new = cmd.max_tokens as usize;
         let mut produced: Vec<u32> = Vec::new();
         let mut next = sample_logits(&logits, &recent, &sampling, &mut rng)?;
         for step in 0..max_new {

--- a/crates/ferrum-models/src/common/llm.rs
+++ b/crates/ferrum-models/src/common/llm.rs
@@ -38,6 +38,23 @@ pub trait DecoderOnlyLLM: Send + Sync {
     /// Runtime-facing configuration.
     fn config(&self) -> &LlmRuntimeConfig;
 
+    /// Per-cache KV capacity in tokens — the maximum sequence length any
+    /// single `cache_id` can grow to before `prefill` / `decode` would
+    /// overflow the pre-allocated K/V buffers.
+    ///
+    /// Honours `FERRUM_KV_CAPACITY` and clamps to the model's declared
+    /// `max_seq_len`. Callers (REPL, HTTP server, schedulers) should
+    /// pre-check this before extending a sequence; the model panics on
+    /// append-side overflow rather than silently corrupt the cache.
+    ///
+    /// Default returns `config().max_seq_len`. Models that allocate a
+    /// smaller window (most do, capped by `FERRUM_KV_CAPACITY` or the
+    /// 4096 default in `ensure_kv`) override this to surface the real
+    /// budget.
+    fn kv_capacity(&self) -> usize {
+        self.config().max_seq_len
+    }
+
     /// Prefill the model with a prompt. Returns `[vocab_size]` logits for
     /// the last prompt token.
     fn prefill(&mut self, cache_id: &str, tokens: &[u32]) -> Vec<f32>;

--- a/crates/ferrum-models/src/models/llama_family.rs
+++ b/crates/ferrum-models/src/models/llama_family.rs
@@ -529,18 +529,19 @@ impl<B: Backend> LlamaFamilyModel<B> {
         }
         let nkv = self.cfg.num_kv_heads;
         let hd = self.cfg.head_dim;
-        // KV capacity defaults to the model's full context length (often
-        // 32k-128k) which can dominate the working set on a 32 GB Mac.
-        // Cap at FERRUM_KV_CAPACITY when the env var is set; otherwise
-        // honour the model's declared max so long-context use cases still
-        // work out-of-the-box. Typical decode workloads should set this
-        // to something like 4096 to free 10+ GB of GPU memory.
+        // KV capacity defaults to a chat-friendly 4096 to keep the working
+        // set sane on a 32 GB Mac (a 48-layer / 4-kv-head / 128-head_dim
+        // model spends ~786 MB on 4096 KV slots, vs ~6 GB on the model's
+        // declared 32K which would push the 17 GB Qwen3-30B-A3B model into
+        // swap). `FERRUM_KV_CAPACITY=N` overrides; clamp to the model's
+        // declared max so we never lie to the model about its window.
         let model_max = self.cfg.max_seq_len;
+        const DEFAULT_KV_CAPACITY: usize = 4096;
         let max = std::env::var("FERRUM_KV_CAPACITY")
             .ok()
             .and_then(|s| s.parse::<usize>().ok())
             .map(|cap| cap.min(model_max))
-            .unwrap_or(model_max);
+            .unwrap_or_else(|| model_max.min(DEFAULT_KV_CAPACITY));
 
         // Try pool first — reused buffers have stable device pointers,
         // so a captured decode graph can be replayed for this request too.
@@ -663,6 +664,18 @@ impl<B: Backend> LlamaFamilyModel<B> {
         let cache = &mut caches[li];
         let cache_len_before = cache.len;
         let cache_capacity = cache.capacity;
+
+        // Defense in depth: refuse to write past the KV buffer. The
+        // graceful path is the caller pre-checking via `kv_capacity()`
+        // and either compacting or refusing the request; this panic only
+        // fires when that contract is broken (and silent overflow would
+        // otherwise corrupt the cache + adjacent allocations).
+        if cache_len_before + tokens > cache_capacity {
+            panic!(
+                "KV cache overflow on layer {li}: would write tokens [{cache_len_before}..{}) but capacity is {cache_capacity} (cache_id={cache_id:?}). Increase FERRUM_KV_CAPACITY or call /clear in the REPL.",
+                cache_len_before + tokens
+            );
+        }
 
         let _t0 = if std::env::var("FERRUM_DECODE_OP_PROFILE").is_ok() {
             B::sync(ctx);
@@ -1921,6 +1934,17 @@ impl<B: Backend> LlamaFamilyModel<B> {
 impl<B: Backend> DecoderOnlyLLM for LlamaFamilyModel<B> {
     fn config(&self) -> &LlmRuntimeConfig {
         &self.runtime_cfg
+    }
+
+    fn kv_capacity(&self) -> usize {
+        // Mirror the bound `ensure_kv` will use when allocating the cache.
+        let model_max = self.cfg.max_seq_len;
+        const DEFAULT_KV_CAPACITY: usize = 4096;
+        std::env::var("FERRUM_KV_CAPACITY")
+            .ok()
+            .and_then(|s| s.parse::<usize>().ok())
+            .map(|cap| cap.min(model_max))
+            .unwrap_or_else(|| model_max.min(DEFAULT_KV_CAPACITY))
     }
 
     fn prefill(&mut self, cache_id: &str, tokens: &[u32]) -> Vec<f32> {

--- a/crates/ferrum-models/src/models/qwen3_moe.rs
+++ b/crates/ferrum-models/src/models/qwen3_moe.rs
@@ -387,12 +387,15 @@ impl<B: Backend> Qwen3MoeModel<B> {
         }
         let nkv = self.cfg.base.num_kv_heads;
         let hd = self.cfg.base.head_dim;
+        // See `LlamaFamilyModel::ensure_kv` for the rationale on the 4096
+        // chat-friendly default and how `FERRUM_KV_CAPACITY` overrides it.
         let model_max = self.cfg.base.max_seq_len;
+        const DEFAULT_KV_CAPACITY: usize = 4096;
         let max = std::env::var("FERRUM_KV_CAPACITY")
             .ok()
             .and_then(|s| s.parse::<usize>().ok())
             .map(|cap| cap.min(model_max))
-            .unwrap_or(model_max);
+            .unwrap_or_else(|| model_max.min(DEFAULT_KV_CAPACITY));
 
         let mut caches = self.kv_free_pool.pop().unwrap_or_else(|| {
             (0..self.cfg.base.num_layers)
@@ -497,6 +500,19 @@ impl<B: Backend> Qwen3MoeModel<B> {
         let cache = &mut caches[li];
         let cache_len_before = cache.len;
         let cache_capacity = cache.capacity;
+
+        // Defense in depth: refuse to write past the KV buffer. Silent
+        // overflow has visible failure modes (garbage output, stale token
+        // attention, slowdowns from reading uninitialised memory). The
+        // graceful path is the caller pre-checking via `kv_capacity()` and
+        // either compacting or refusing the request; this panic only
+        // fires when that contract is broken.
+        if cache_len_before + tokens > cache_capacity {
+            panic!(
+                "KV cache overflow on layer {li}: would write tokens [{cache_len_before}..{}) but capacity is {cache_capacity} (cache_id={cache_id:?}). Increase FERRUM_KV_CAPACITY or call /clear in the REPL.",
+                cache_len_before + tokens
+            );
+        }
 
         // Try the deepest fusion: fused split-QKV-norm-rope that writes
         // K/V directly into the cache slot. Skips both the head-major
@@ -1107,6 +1123,17 @@ impl<B: Backend> Qwen3MoeModel<B> {
 impl<B: Backend> DecoderOnlyLLM for Qwen3MoeModel<B> {
     fn config(&self) -> &LlmRuntimeConfig {
         &self.runtime_cfg
+    }
+
+    fn kv_capacity(&self) -> usize {
+        // Mirror the bound `ensure_kv` will use when allocating the cache.
+        let model_max = self.cfg.base.max_seq_len;
+        const DEFAULT_KV_CAPACITY: usize = 4096;
+        std::env::var("FERRUM_KV_CAPACITY")
+            .ok()
+            .and_then(|s| s.parse::<usize>().ok())
+            .map(|cap| cap.min(model_max))
+            .unwrap_or_else(|| model_max.min(DEFAULT_KV_CAPACITY))
     }
 
     fn prefill(&mut self, cache_id: &str, tokens: &[u32]) -> Vec<f32> {

--- a/docs/m1-max-qwen3-moe-perf-plan.md
+++ b/docs/m1-max-qwen3-moe-perf-plan.md
@@ -54,7 +54,7 @@
 
 | 变量 | 必须 | 作用 |
 |---|---|---|
-| `FERRUM_KV_CAPACITY=512` | **是** | 限 KV cache 容量。不设默认走 `max_seq_len=32K`，会分配 ~6 GB KV cache 把 32 GB Mac 推到 swap，bench 数字直接归零。**每次都要设。** |
+| `FERRUM_KV_CAPACITY=512` | bench 时 | 限 KV cache 容量。**默认值 = `min(model_max, 4096)`**（对 30B-A3B = 4096，约 786 MB GPU 内存），chat 直接能用。bench pp512 想剥离 KV 影响时设 512；REPL 跑长上下文设 8192-16384；超过此值 `forward_layer` 会 panic 而不是越界写脏数据（PR #57）。 |
 | `MTL_CAPTURE_ENABLED=1` | 仅 capture | 启用 Metal 抓帧。系统层面的 gate。 |
 | `FERRUM_METAL_CAPTURE=path/out.gputrace` | 仅 capture | 让 prefill 写一个 `.gputrace` 文件。 |
 | `FERRUM_DECODE_OP_PROFILE=1` | 仅 profile | 每个 stage（attn/moe/host/gate/up/silu/down/wsum）打印分解时间。**注意会插 `B::sync(ctx)` 拖慢 1.5-2×**——不要用它的绝对数字，只用相对占比。 |


### PR DESCRIPTION
## Summary

Multi-turn chat in the REPL silently corrupted the KV cache when the conversation grew past the env-var-set window — the kernel wrote past the buffer, the model emitted garbage tokens, and decode speed degraded with cache size. Two reinforcing causes:

1. **Default `FERRUM_KV_CAPACITY` was the model's declared `max_seq_len`** (32k–128k). On a 32 GB Mac running Qwen3-30B-A3B Q4_K_M (17 GB resident), that allocated ~6 GB of K/V on top, pushed the machine into swap, and the doc told users to override with `FERRUM_KV_CAPACITY=512`. 512 is correct for the `pp512` bench, but **far too small for chat** — the cache fills in 2–3 turns and the kernel happily writes past the buffer.

2. **No bounds check** anywhere on the append path. `cache.len + tokens > cache.capacity` produced silent buffer overflow → garbage output + slowdown. Live repro before this PR (REPL with `FERRUM_KV_CAPACITY=512`):

   | Turn | tok/s | cache | within 512? | output |
   |---|---:|---:|---|---|
   | 你好 | 23.8 | 161 | ✓ | coherent |
   | 你是谁 | 15.5 | 368 | ✓ | coherent |
   | 你会什么? | 9.2 | **891** | ✗ +379 | half-cogent then `WindowState_TH vanished哨…` |
   | rust 是什么 | 6.3 | **1414** | ✗ +902 | `혀 ALLEL` |
   | ? | 4.7 | **1935** | ✗ +1423 | full gibberish |

## Changes

- **Default `min(model_max, 4096)`** in both `LlamaFamilyModel::ensure_kv` and `Qwen3MoeModel::ensure_kv`. ~786 MB on the 30B-A3B layout — affordable, fits normal chat. `FERRUM_KV_CAPACITY=N` still overrides (clamped to `model_max`).
- **`DecoderOnlyLLM::kv_capacity()` trait method** so callers can pre-check before extending a sequence. Default returns `config().max_seq_len`; both real models override to mirror their `ensure_kv` bound.
- **Defense-in-depth panic** at the `kv_cache_append_head_major` site when `cache.len + tokens > cache.capacity`. Loud failure (layer index, cache id, suggested fix) — strictly better than silent corruption.
- **REPL pre-check** before each user turn refuses cleanly with a suggested next-power-of-2 `FERRUM_KV_CAPACITY=` if the worst-case `cache_len + prompt + max_tokens` would overflow. The panic in the previous bullet only fires when other callers (HTTP server, schedulers, tests) bypass this check.
- **Doc §3.1** updated to clarify that `FERRUM_KV_CAPACITY=512` is bench-only and the new default is 4096.

## Test plan

- [x] `cargo test -p ferrum-models -p ferrum-attention -p ferrum-kernels --features metal --release` — all green
- [x] Single-prompt run with NO env var (default 4096): Paris/Rome/Madrid output verbatim, decode 33 t/s
- [x] Single-prompt run with `FERRUM_KV_CAPACITY=64` and `--max-tokens 100`: panics with the new clear message after 52 generated tokens (vs. corrupting the cache silently)
- [x] `cargo fmt --all -- --check` clean
- [ ] CI: CPU + Metal green

## Notes

This is the immediate-unblock fix from the conversation around https://github.com/sizzlecar/ferrum-infer-rs/pull/54 — multi-turn chat is now usable. The actual speed gap (decode 30 t/s vs llama.cpp's 55 t/s, ~1.85×) is the next attack and lives in `docs/m1-max-qwen3-moe-perf-plan.md` §5.4 (forthcoming).

🤖 Generated with [Claude Code](https://claude.com/claude-code)