### PR TITLE
perf(metal): widen weighted_sum_residual_norm_stacked from 32 → 256 threads (tg128 28 → 38 t/s)

### DIFF
--- a/crates/ferrum-kernels/src/moe_post_ops.metal
+++ b/crates/ferrum-kernels/src/moe_post_ops.metal
@@ -127,9 +127,20 @@ kernel void weighted_sum_stacked_f32(
 // must skip its own rms_norm when this path was taken (signalled by a
 // caller-side flag); the fused output IS its norm_out input.
 //
-// Threadgroup: 32 threads (1 simdgroup). One simdgroup per token row.
-// Each thread covers `hidden / 32` floats during the partial sum_sq
-// reduce and the final normed write.
+// Threadgroup: WSUM_NORM_THREADS=256 threads = 8 simdgroups, all in
+// one threadgroup (the rms-norm sumsq reduce needs a single fan-in
+// point so multi-TG would need a global atomic — not worth it for the
+// hidden=2048 working set). Cross-simdgroup reduce for sum_sq goes
+// through threadgroup memory: each simdgroup leader writes its partial
+// to `sg_sum_sq[sgitg]`, thread 0 of simdgroup 0 totals them.
+//
+// Going from 32 → 256 threads gives Apple GPU 8× the parallel ALU
+// occupancy on the per-element work in phase 1 (weighted-sum + sumsq)
+// and phase 3 (normed write), which dominate the kernel runtime —
+// the cross-simdgroup reduce is a few cycles either way.
+
+constant int WSUM_NORM_THREADS = 256;
+constant int WSUM_NORM_NSG     = 8;   // = WSUM_NORM_THREADS / 32
 
 struct WSumResNormParams {
     int hidden;
@@ -145,14 +156,17 @@ kernel void weighted_sum_residual_norm_stacked_f32(
     device       float* normed_out  [[buffer(4)]],   // [hidden]
     constant WSumResNormParams& p   [[buffer(5)]],
     uint3 tgpig [[threadgroup_position_in_grid]],
-    uint  tiisg [[thread_index_in_simdgroup]])
+    uint3 tpitg [[thread_position_in_threadgroup]],
+    uint  tiisg [[thread_index_in_simdgroup]],
+    uint  sgitg [[simdgroup_index_in_threadgroup]])
 {
     const int hidden  = p.hidden;
     const int n_slots = p.n_slots;
+    const int tid     = int(tpitg.x);
 
     // Phase 1: residual += weighted_sum, accumulate Σ residual^2.
     float local_sum_sq = 0.0f;
-    for (int i = tiisg; i < hidden; i += 32) {
+    for (int i = tid; i < hidden; i += WSUM_NORM_THREADS) {
         float sum = 0.0f;
         for (int s = 0; s < n_slots; s++) {
             sum += weights[s] * slots[s * hidden + i];
@@ -162,12 +176,27 @@ kernel void weighted_sum_residual_norm_stacked_f32(
         local_sum_sq += new_val * new_val;
     }
 
-    // Phase 2: cross-simdgroup reduce.
-    const float total_sq = simd_sum(local_sum_sq);
-    const float scale    = 1.0f / sqrt(total_sq / float(hidden) + p.eps);
+    // Phase 2: cross-simdgroup reduce for sumsq. Each simdgroup leader
+    // contributes its simd_sum partial; thread 0 totals + broadcasts.
+    const float sg_part = simd_sum(local_sum_sq);
+    threadgroup float sg_sum_sq[WSUM_NORM_NSG];
+    if (tiisg == 0) {
+        sg_sum_sq[sgitg] = sg_part;
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    threadgroup float scale_slot[1];
+    if (tid == 0) {
+        float total_sq = 0.0f;
+        for (int s = 0; s < WSUM_NORM_NSG; ++s) {
+            total_sq += sg_sum_sq[s];
+        }
+        scale_slot[0] = 1.0f / sqrt(total_sq / float(hidden) + p.eps);
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    const float scale = scale_slot[0];
 
     // Phase 3: write normed_out using next layer's norm weight.
-    for (int i = tiisg; i < hidden; i += 32) {
+    for (int i = tid; i < hidden; i += WSUM_NORM_THREADS) {
         normed_out[i] = residual[i] * scale * next_norm_w[i];
     }
 }

--- a/crates/ferrum-kernels/src/moe_post_ops.rs
+++ b/crates/ferrum-kernels/src/moe_post_ops.rs
@@ -237,8 +237,12 @@ pub fn dispatch_weighted_sum_residual_norm_stacked(
         &params as *const _ as *const c_void,
     );
 
-    // One simdgroup per token (q_len=1 in decode). 32 threads cover hidden.
+    // 256 threads = 8 simdgroups in a single threadgroup. The rms-norm
+    // sumsq reduce needs a single fan-in point so multi-TG would force
+    // a global atomic — for hidden ≤ ~16K we win more from the 8× ALU
+    // parallelism of 256 vs 32 threads than we'd lose to threadgroup
+    // memory traffic for the cross-simdgroup reduce.
     let grid = MTLSize::new(1, 1, 1);
-    let tg = MTLSize::new(32, 1, 1);
+    let tg = MTLSize::new(256, 1, 1);
     enc.dispatch_thread_groups(grid, tg);
 }


### PR DESCRIPTION
## Summary

Reshape the cross-layer-fused MoE tail kernel from 1 simdgroup (32 threads) per dispatch to 8 simdgroups (256 threads). On Qwen3-30B-A3B Q4_K_M / M1 Max:

  **tg128: 28 → 38 t/s (+36%) · 51% → 70% of llama.cpp's 54.6 t/s**

## Diagnosis

The fine-grained decode profile from PR #57 showed `weighted_sum_residual_norm_stacked` (the cross-layer-fused MoE tail with the next layer's rms-norm folded in) taking **~20% of decode time** in profile mode — substantially more than the gate / up / down q4_K GEMVs that do orders of magnitude more arithmetic.

Inspecting the dispatch revealed it was launching **a single threadgroup of 32 threads** to do all of `hidden=2048` elements:
- The rms-norm sumsq reduce was implemented as a simdgroup-only `simd_sum`, so the kernel couldn't exploit more than one simdgroup of GPU parallelism.
- M1 Max has many compute units but they were all idle except one — phases 1 and 3 (which dominate the kernel runtime) were doing 64 elements per thread serially when they could trivially split across 8× the threads.

## Change

```c
- // Threadgroup: 32 threads (1 simdgroup).
- let grid = MTLSize::new(1, 1, 1);
- let tg = MTLSize::new(32, 1, 1);
+ // Threadgroup: 256 threads (8 simdgroups).
+ let grid = MTLSize::new(1, 1, 1);
+ let tg = MTLSize::new(256, 1, 1);
```

The kernel's three phases now look like:

1. **Residual update + sumsq accumulate**: 256 threads cooperate; each thread now does `hidden / 256` elements (vs 64 before). 8× ALU occupancy.
2. **Cross-simdgroup reduce**: each simdgroup leader contributes its `simd_sum` partial through threadgroup memory (`sg_sum_sq[8]`); thread 0 totals + computes scale + broadcasts via a 1-slot threadgroup scratch.
3. **Normed write**: 256 threads write 8× faster than 32.

Multi-TG is left out on purpose — would force a global atomic for the sumsq fan-in, more complex for the same hidden-2048 working set.

## Results on Qwen3-30B-A3B Q4_K_M / M1 Max

| | before | after | Δ |
|---|---:|---:|---:|
| tg128 throughput | 28.0 | **38.0 t/s** | **+36%** |
| vs llama.cpp 54.6 | 51% | **70%** | +19 pp |
| profile total | 181 | 100 ms | -45% |
| profile wsum stage | 36 | 11 ms | **-69%** |
| Qwen3-8B tg128 | 28 | 27 t/s | flat (8B doesn't use this path) |

After the change, the per-stage profile (still in profile mode with per-stage syncs) is nearly uniform across MoE sub-stages — wsum is no longer the standout cost:

```
[decode-prof] total=98 ms | attn=13 (13%) | moe=69 (70%)
              [route=11 gate=12 up=12 silu=8 down=12 wsum=10]
              | embed=0 fnorm=0 lmhead=1 other=15 (16%)
```

## Test plan

- [x] Paris / Rome / Madrid output verbatim
- [x] `cargo test -p ferrum-kernels --features metal --release` — 11/11 pass
- [x] Qwen3-8B unchanged (dense, doesn't hit this kernel)
- [x] `cargo fmt --all -- --check` clean
- [ ] CI: CPU + Metal green

## Next

Remaining decode gap: gate / up / down q4_K MoE-id GEMVs (~50% of decode, equally distributed between them). Same kernel inner loop as llama.cpp, so the win there will come from how dispatches are fed — separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)