### PR TITLE
perf(metal): paged-KV decode attention kernel + tests (Phase 1/5)

### DIFF
--- a/crates/ferrum-attention/src/metal/pipelines.rs
+++ b/crates/ferrum-attention/src/metal/pipelines.rs
@@ -50,6 +50,7 @@ impl MetalPipelines {
                     "flash_attn_f32",
                     "flash_attn_q_tiled_f32",
                     "flash_attn_decode_f32",
+                    "flash_attn_decode_paged_f32",
                 ][..],
             ),
             (
@@ -1187,4 +1188,106 @@ impl MetalPipelines {
         let tg = MTLSize::new(256, 1, 1);
         enc.dispatch_thread_groups(grid, tg);
     }
+
+    /// Run paged-KV decode attention on the caller's existing compute
+    /// encoder. Mirrors the API of [`Self::flash_attn_v2_on_encoder`]
+    /// but takes a paged KV cache + per-sequence block tables instead
+    /// of contiguous K/V buffers.
+    ///
+    /// Layout:
+    ///   q              : `[num_seqs, num_heads, head_dim]`
+    ///   k_cache, v_cache : `[num_blocks, num_kv_heads, block_size, head_dim]`
+    ///   o              : `[num_seqs, num_heads, head_dim]`
+    ///   block_tables   : `[num_seqs, max_num_blocks_per_seq]` u32
+    ///   context_lens   : `[num_seqs]` u32
+    ///
+    /// All buffers are f32 except `block_tables` and `context_lens` which
+    /// are u32. Caller is responsible for opening / closing the encoder.
+    ///
+    /// Restrictions matching the existing `flash_attn_decode_f32`:
+    /// `head_dim == 128`. Block size is configurable via
+    /// `PagedAttnDispatchParams::block_size` (typical: 16).
+    #[allow(clippy::too_many_arguments)]
+    pub fn paged_decode_attention_on_encoder(
+        &self,
+        enc: &metal::ComputeCommandEncoderRef,
+        q: &Buffer,
+        k_cache: &Buffer,
+        v_cache: &Buffer,
+        o: &Buffer,
+        block_tables: &Buffer,
+        context_lens: &Buffer,
+        params: &PagedAttnDispatchParams,
+    ) {
+        debug_assert_eq!(
+            params.head_dim, 128,
+            "paged_decode_attention currently only supports head_dim=128"
+        );
+        debug_assert!(
+            params.num_heads % params.num_kv_heads == 0,
+            "GQA: num_heads must be divisible by num_kv_heads"
+        );
+
+        // The kernel-side struct must match the layout in flash_attn.metal
+        // (PagedAttnParams). Keep these in sync — there's no static check.
+        #[repr(C)]
+        struct P {
+            num_heads: i32,
+            num_kv_heads: i32,
+            head_dim: i32,
+            scale: f32,
+            block_size: i32,
+            max_num_blocks_per_seq: i32,
+            kv_block_stride: i32,
+            kv_head_stride: i32,
+            causal: i32,
+        }
+        let kv_head_stride = (params.block_size * params.head_dim) as i32;
+        let kv_block_stride = (params.num_kv_heads as i32) * kv_head_stride;
+        let p = P {
+            num_heads: params.num_heads as i32,
+            num_kv_heads: params.num_kv_heads as i32,
+            head_dim: params.head_dim as i32,
+            scale: 1.0 / (params.head_dim as f32).sqrt(),
+            block_size: params.block_size as i32,
+            max_num_blocks_per_seq: params.max_num_blocks_per_seq as i32,
+            kv_block_stride,
+            kv_head_stride,
+            causal: 1,
+        };
+
+        enc.set_compute_pipeline_state(self.pipeline("flash_attn_decode_paged_f32"));
+        enc.set_buffer(0, Some(q), 0);
+        enc.set_buffer(1, Some(k_cache), 0);
+        enc.set_buffer(2, Some(v_cache), 0);
+        enc.set_buffer(3, Some(o), 0);
+        enc.set_buffer(4, Some(block_tables), 0);
+        enc.set_buffer(5, Some(context_lens), 0);
+        enc.set_bytes(
+            6,
+            std::mem::size_of::<P>() as u64,
+            &p as *const _ as *const c_void as *const _,
+        );
+
+        // One TG per (head, sequence). TG = 32 simdgroups × 32 threads
+        // (matches the contiguous-KV decode kernel's geometry).
+        let grid = MTLSize::new(1, params.num_heads as u64, params.num_seqs as u64);
+        let tg = MTLSize::new(32, 32, 1);
+        enc.dispatch_thread_groups(grid, tg);
+    }
+}
+
+/// Caller-side parameters for [`MetalPipelines::paged_decode_attention_on_encoder`].
+///
+/// Layout / stride conventions match the comments on the dispatch
+/// helper. `kv_block_stride` and `kv_head_stride` are computed inside
+/// the dispatch so callers don't have to.
+#[derive(Clone, Copy, Debug)]
+pub struct PagedAttnDispatchParams {
+    pub num_seqs: usize,
+    pub num_heads: usize,
+    pub num_kv_heads: usize,
+    pub head_dim: usize,
+    pub block_size: usize,
+    pub max_num_blocks_per_seq: usize,
 }

--- a/crates/ferrum-attention/src/metal/shaders/flash_attn.metal
+++ b/crates/ferrum-attention/src/metal/shaders/flash_attn.metal
@@ -538,3 +538,168 @@ kernel void flash_attn_decode_f32(
         }
     }
 }
+
+// ── Paged-KV variant of flash_attn_decode_f32 ────────────────────────
+//
+// Same online-softmax + cross-simdgroup combine as the contiguous-KV
+// variant above; the only change is HOW each simdgroup addresses K/V.
+//
+// Memory model (vLLM-style, simplified for f32-only):
+//   k_cache, v_cache : [num_blocks, num_kv_heads, BLOCK_SIZE, head_dim]
+//                      one shared pool; both cache buffers share the
+//                      block_size grid.
+//   block_tables     : [max_num_seqs, max_num_blocks_per_seq] u32
+//                      block_tables[seq][i] = physical block index for
+//                      the i-th logical block of sequence `seq`.
+//   context_lens     : [max_num_seqs] u32 — true sequence length;
+//                      simdgroups skip past it.
+//
+// The kernel takes two structs:
+//   FlashAttnParams (already defined for contiguous variant) covers
+//                   num_heads / num_kv_heads / head_dim / scale.
+//   PagedAttnParams covers block_size / max_num_blocks_per_seq /
+//                   kv_block_stride / kv_head_stride.
+//
+// `bi` (= tgpig.z) indexes into context_lens / block_tables directly
+// — one TG per (head, sequence) just like the contiguous variant.
+// pos_offset / kv_len from FlashAttnParams are NOT used here; the
+// per-sequence context_len comes from the buffer.
+//
+// Why a separate kernel rather than runtime branching: the inner KV
+// loop is the hot path (32 SGs × N positions). Apple's Metal compiler
+// generates measurably tighter code when the block-table indirection
+// is statically present rather than gated by a runtime flag. Cost:
+// ~80 extra MSL lines, no extra dispatch overhead — both variants can
+// live behind one `B::flash_attention` API.
+
+struct PagedAttnParams {
+    int num_heads;
+    int num_kv_heads;
+    int head_dim;
+    float scale;
+    int block_size;              // KV positions per physical block (16 typical)
+    int max_num_blocks_per_seq;  // block_tables row stride
+    int kv_block_stride;         // floats between consecutive blocks (= num_kv_heads * block_size * head_dim)
+    int kv_head_stride;          // floats between consecutive kv heads within a block (= block_size * head_dim)
+    int causal;                  // unused for q_len=1 (context_len already encodes causal mask)
+};
+
+kernel void flash_attn_decode_paged_f32(
+    device const float*    Q              [[buffer(0)]],   // [num_seqs, num_heads, head_dim]
+    device const float*    K_cache        [[buffer(1)]],   // [num_blocks, num_kv_heads, block_size, head_dim]
+    device const float*    V_cache        [[buffer(2)]],   // same layout as K_cache
+    device       float*    O              [[buffer(3)]],   // [num_seqs, num_heads, head_dim]
+    device const uint32_t* block_tables   [[buffer(4)]],
+    device const uint32_t* context_lens   [[buffer(5)]],
+    constant PagedAttnParams& p           [[buffer(6)]],
+    uint3  tgpig [[threadgroup_position_in_grid]],   // (1, head, seq)
+    uint   sgitg [[simdgroup_index_in_threadgroup]], // 0..31 — which KV-stripe
+    uint   tiisg [[thread_index_in_simdgroup]])      // 0..31 — which D slice
+{
+    const int hi    = int(tgpig.y);
+    const int bi    = int(tgpig.z);
+    const int kv_hi = hi / (p.num_heads / p.num_kv_heads);
+    const int d     = p.head_dim;
+    const int bs    = p.block_size;
+    const int context_len = int(context_lens[bi]);
+
+    // Pointers (Q / O are still token-major, same as contiguous variant).
+    device const float* q_row = Q + (bi * p.num_heads + hi) * d + tiisg * SDPA_EPT;
+    device       float* o_row = O + (bi * p.num_heads + hi) * d;
+    device const uint32_t* my_block_table = block_tables + bi * p.max_num_blocks_per_seq;
+
+    // Per-thread Q (pre-scaled), running output, scratch K/V slice.
+    float q[SDPA_EPT];
+    float o_acc[SDPA_EPT];
+    for (int i = 0; i < SDPA_EPT; ++i) {
+        q[i]     = p.scale * q_row[i];
+        o_acc[i] = 0.0f;
+    }
+
+    float max_score = -INFINITY;
+    float sum_exp   = 0.0f;
+
+    // KV loop — each simdgroup walks KV positions { sgitg, sgitg+BN, ... }.
+    // For each position: resolve logical → physical block via block_tables.
+    for (int ki = int(sgitg); ki < context_len; ki += SDPA_BN) {
+        const int logical_block = ki / bs;
+        const int slot_in_block = ki % bs;
+        const uint32_t physical_block = my_block_table[logical_block];
+
+        // Pointer to this position's K/V slice. The cache layout is
+        //   cache[physical_block][kv_hi][slot_in_block][d]
+        // = base + physical_block*kv_block_stride
+        //        + kv_hi*kv_head_stride
+        //        + slot_in_block*d
+        //        + tiisg*SDPA_EPT
+        const int slice_off = int(physical_block) * p.kv_block_stride
+                             + kv_hi * p.kv_head_stride
+                             + slot_in_block * d
+                             + int(tiisg) * SDPA_EPT;
+        device const float* k_row = K_cache + slice_off;
+        device const float* v_row = V_cache + slice_off;
+
+        // Same dot + online softmax body as flash_attn_decode_f32.
+        float dot_acc = 0.0f;
+        float k_v[SDPA_EPT];
+        for (int j = 0; j < SDPA_EPT; ++j) {
+            k_v[j]   = k_row[j];
+            dot_acc += q[j] * k_v[j];
+        }
+        const float score = simd_sum(dot_acc);
+
+        const float new_max = max(max_score, score);
+        const float factor  = exp(max_score - new_max);
+        const float exp_sc  = exp(score      - new_max);
+
+        max_score = new_max;
+        sum_exp   = sum_exp * factor + exp_sc;
+
+        for (int j = 0; j < SDPA_EPT; ++j) {
+            o_acc[j] = o_acc[j] * factor + exp_sc * v_row[j];
+        }
+    }
+
+    // Cross-simdgroup combine — identical structure to the contiguous
+    // variant. Could be factored, but the 60 lines below are the
+    // hotpath tail and we deliberately don't introduce a function-call
+    // boundary on M1 Max where it can prevent register coalescing.
+    threadgroup float outputs[SDPA_BN * SDPA_D];
+    threadgroup float max_scores[SDPA_BN];
+    threadgroup float sum_exp_scores[SDPA_BN];
+
+    threadgroup float* my_out = outputs + sgitg * SDPA_D + tiisg * SDPA_EPT;
+    for (int j = 0; j < SDPA_EPT; ++j) {
+        my_out[j] = o_acc[j];
+    }
+    if (tiisg == 0) {
+        max_scores[sgitg]     = max_score;
+        sum_exp_scores[sgitg] = sum_exp;
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    if (sgitg == 0) {
+        const float local_max = max_scores[tiisg];
+        const float global_max = simd_max(local_max);
+        const float local_factor = exp(local_max - global_max);
+        const float local_sum_scaled = sum_exp_scores[tiisg] * local_factor;
+        const float global_sum = simd_sum(local_sum_scaled);
+
+        max_scores[tiisg]     = local_factor;
+        sum_exp_scores[tiisg] = global_sum;
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    if (sgitg == 0) {
+        const float gs = sum_exp_scores[0];
+        const float inv_S = (gs > 0.0f) ? (1.0f / gs) : 0.0f;
+        for (int j = 0; j < SDPA_EPT; ++j) {
+            const int col = tiisg * SDPA_EPT + j;
+            float total = 0.0f;
+            for (int s = 0; s < SDPA_BN; ++s) {
+                total += outputs[s * SDPA_D + col] * max_scores[s];
+            }
+            o_row[col] = total * inv_S;
+        }
+    }
+}

--- a/crates/ferrum-attention/tests/paged_attention_test.rs
+++ b/crates/ferrum-attention/tests/paged_attention_test.rs
@@ -1,0 +1,412 @@
+//! Correctness tests for the paged-KV decode attention kernel.
+//!
+//! Approach: build a contiguous KV with known data, run the existing
+//! `flash_attn_decode_f32` kernel as the reference, then re-arrange the
+//! same data into a paged cache and run `flash_attn_decode_paged_f32`,
+//! and assert the outputs match within tolerance. This isolates the
+//! block-table indirection — the math (online softmax, cross-simdgroup
+//! combine) is identical between the two kernels.
+
+#![cfg(all(target_os = "macos", feature = "metal"))]
+
+use ferrum_attention::metal::pipelines::{MetalPipelines, PagedAttnDispatchParams};
+use metal::{Device, MTLResourceOptions};
+use std::ffi::c_void;
+
+fn assert_close(a: &[f32], b: &[f32], atol: f32, label: &str) {
+    assert_eq!(a.len(), b.len(), "{label}: length mismatch");
+    let mut max_diff = 0.0f32;
+    let mut max_idx = 0;
+    for (i, (x, y)) in a.iter().zip(b.iter()).enumerate() {
+        let d = (x - y).abs();
+        if d > max_diff {
+            max_diff = d;
+            max_idx = i;
+        }
+    }
+    assert!(
+        max_diff < atol,
+        "{label}: max diff {max_diff} at idx {max_idx} (a={}, b={}), atol={atol}",
+        a[max_idx],
+        b[max_idx]
+    );
+}
+
+fn make_buffer(device: &Device, data_bytes: &[u8]) -> metal::Buffer {
+    device.new_buffer_with_data(
+        data_bytes.as_ptr() as *const c_void,
+        data_bytes.len() as u64,
+        MTLResourceOptions::StorageModeShared,
+    )
+}
+
+fn buffer_from_f32(device: &Device, data: &[f32]) -> metal::Buffer {
+    let bytes = unsafe {
+        std::slice::from_raw_parts(data.as_ptr() as *const u8, data.len() * 4)
+    };
+    make_buffer(device, bytes)
+}
+
+fn buffer_from_u32(device: &Device, data: &[u32]) -> metal::Buffer {
+    let bytes = unsafe {
+        std::slice::from_raw_parts(data.as_ptr() as *const u8, data.len() * 4)
+    };
+    make_buffer(device, bytes)
+}
+
+fn read_f32(buf: &metal::Buffer, len: usize) -> Vec<f32> {
+    unsafe { std::slice::from_raw_parts(buf.contents() as *const f32, len).to_vec() }
+}
+
+/// Reference: run the contiguous-KV decode kernel and read its output.
+fn run_contiguous(
+    pipes: &MetalPipelines,
+    q: &[f32],
+    k_contig: &[f32],
+    v_contig: &[f32],
+    num_heads: usize,
+    num_kv_heads: usize,
+    head_dim: usize,
+    kv_len: usize,
+) -> Vec<f32> {
+    let device = &pipes.device;
+    let q_buf = buffer_from_f32(device, q);
+    let k_buf = buffer_from_f32(device, k_contig);
+    let v_buf = buffer_from_f32(device, v_contig);
+    let o_buf = device.new_buffer((q.len() * 4) as u64, MTLResourceOptions::StorageModeShared);
+
+    let cmd = pipes.queue.new_command_buffer();
+    let enc = cmd.new_compute_command_encoder();
+
+    // Match the FlashAttnParams layout in flash_attn.metal verbatim.
+    #[repr(C)]
+    struct P {
+        batch: i32,
+        num_heads: i32,
+        num_kv_heads: i32,
+        q_len: i32,
+        kv_len: i32,
+        head_dim: i32,
+        scale: f32,
+        causal: i32,
+        pos_offset: i32,
+        kv_seq_stride: i32,
+        sliding_window: i32,
+    }
+    let params = P {
+        batch: 1,
+        num_heads: num_heads as i32,
+        num_kv_heads: num_kv_heads as i32,
+        q_len: 1,
+        kv_len: kv_len as i32,
+        head_dim: head_dim as i32,
+        scale: 1.0 / (head_dim as f32).sqrt(),
+        causal: 1,
+        pos_offset: kv_len as i32 - 1,
+        kv_seq_stride: 0,
+        sliding_window: 0,
+    };
+
+    enc.set_compute_pipeline_state(pipes.pipeline("flash_attn_decode_f32"));
+    enc.set_buffer(0, Some(&q_buf), 0);
+    enc.set_buffer(1, Some(&k_buf), 0);
+    enc.set_buffer(2, Some(&v_buf), 0);
+    enc.set_buffer(3, Some(&o_buf), 0);
+    enc.set_bytes(
+        4,
+        std::mem::size_of::<P>() as u64,
+        &params as *const _ as *const c_void,
+    );
+    let grid = metal::MTLSize::new(1, num_heads as u64, 1);
+    let tg = metal::MTLSize::new(32, 32, 1);
+    enc.dispatch_thread_groups(grid, tg);
+    enc.end_encoding();
+    cmd.commit();
+    cmd.wait_until_completed();
+
+    read_f32(&o_buf, q.len())
+}
+
+/// Build a paged KV cache from a contiguous one.
+///
+/// Contiguous layout: `[num_kv_heads, kv_len, head_dim]`
+/// Paged layout: `[num_blocks, num_kv_heads, block_size, head_dim]`
+///
+/// Returns (paged_buf, block_table) where block_table[i] = physical
+/// index of the i-th logical block. We assign blocks in-order for the
+/// test; a real allocator would interleave.
+fn pack_into_paged(
+    contig: &[f32],
+    num_kv_heads: usize,
+    kv_len: usize,
+    head_dim: usize,
+    block_size: usize,
+) -> (Vec<f32>, Vec<u32>) {
+    let num_blocks = kv_len.div_ceil(block_size);
+    let mut paged = vec![0.0f32; num_blocks * num_kv_heads * block_size * head_dim];
+    let mut table = Vec::with_capacity(num_blocks);
+    for logical_block in 0..num_blocks {
+        let physical_block = logical_block; // identity assignment for the test
+        table.push(physical_block as u32);
+        for slot in 0..block_size {
+            let token_idx = logical_block * block_size + slot;
+            if token_idx >= kv_len {
+                break;
+            }
+            for kvh in 0..num_kv_heads {
+                let src_off = kvh * kv_len * head_dim + token_idx * head_dim;
+                let dst_off = physical_block * num_kv_heads * block_size * head_dim
+                    + kvh * block_size * head_dim
+                    + slot * head_dim;
+                paged[dst_off..dst_off + head_dim]
+                    .copy_from_slice(&contig[src_off..src_off + head_dim]);
+            }
+        }
+    }
+    (paged, table)
+}
+
+fn run_paged(
+    pipes: &MetalPipelines,
+    q: &[f32],
+    k_paged: &[f32],
+    v_paged: &[f32],
+    block_table: &[u32],
+    context_len: u32,
+    num_heads: usize,
+    num_kv_heads: usize,
+    head_dim: usize,
+    block_size: usize,
+) -> Vec<f32> {
+    let device = &pipes.device;
+    let q_buf = buffer_from_f32(device, q);
+    let k_buf = buffer_from_f32(device, k_paged);
+    let v_buf = buffer_from_f32(device, v_paged);
+    let o_buf = device.new_buffer((q.len() * 4) as u64, MTLResourceOptions::StorageModeShared);
+    let bt_buf = buffer_from_u32(device, block_table);
+    let cl_buf = buffer_from_u32(device, &[context_len]);
+
+    let cmd = pipes.queue.new_command_buffer();
+    let enc = cmd.new_compute_command_encoder();
+    pipes.paged_decode_attention_on_encoder(
+        enc,
+        &q_buf,
+        &k_buf,
+        &v_buf,
+        &o_buf,
+        &bt_buf,
+        &cl_buf,
+        &PagedAttnDispatchParams {
+            num_seqs: 1,
+            num_heads,
+            num_kv_heads,
+            head_dim,
+            block_size,
+            max_num_blocks_per_seq: block_table.len(),
+        },
+    );
+    enc.end_encoding();
+    cmd.commit();
+    cmd.wait_until_completed();
+
+    read_f32(&o_buf, q.len())
+}
+
+#[test]
+fn paged_decode_matches_contiguous_small() {
+    // 8 query heads / 2 kv heads (GQA factor 4), 50 KV positions,
+    // block_size=16 → 4 blocks (the last is partial).
+    let num_heads = 8;
+    let num_kv_heads = 2;
+    let head_dim = 128;
+    let kv_len = 50;
+    let block_size = 16;
+
+    let q: Vec<f32> = (0..num_heads * head_dim)
+        .map(|i| (i as f32 * 0.013).sin() * 0.2)
+        .collect();
+    let k: Vec<f32> = (0..num_kv_heads * kv_len * head_dim)
+        .map(|i| (i as f32 * 0.0091).cos() * 0.25)
+        .collect();
+    let v: Vec<f32> = (0..num_kv_heads * kv_len * head_dim)
+        .map(|i| (i as f32 * 0.0117 + 1.7).sin() * 0.25)
+        .collect();
+
+    let device = Device::system_default().expect("no Metal device");
+    let pipes = MetalPipelines::new(&device);
+
+    let out_contig = run_contiguous(
+        &pipes,
+        &q,
+        &k,
+        &v,
+        num_heads,
+        num_kv_heads,
+        head_dim,
+        kv_len,
+    );
+
+    let (k_paged, table) = pack_into_paged(&k, num_kv_heads, kv_len, head_dim, block_size);
+    let (v_paged, _) = pack_into_paged(&v, num_kv_heads, kv_len, head_dim, block_size);
+    let out_paged = run_paged(
+        &pipes,
+        &q,
+        &k_paged,
+        &v_paged,
+        &table,
+        kv_len as u32,
+        num_heads,
+        num_kv_heads,
+        head_dim,
+        block_size,
+    );
+
+    // Both kernels do f32 online softmax with the same loop schedule
+    // (same SDPA_BN=32 simdgroup distribution); only the K/V address
+    // computation differs. Numerical results should match to high
+    // precision.
+    assert_close(&out_contig, &out_paged, 1e-4, "paged vs contiguous (small)");
+}
+
+#[test]
+fn paged_decode_matches_contiguous_long_context() {
+    // Long-context regime: kv_len=2049 > 32 (SDPA_BN), each simdgroup
+    // walks ~64 KV positions. Block size 16 → 129 blocks, last partial.
+    let num_heads = 32;
+    let num_kv_heads = 8;
+    let head_dim = 128;
+    let kv_len = 2049;
+    let block_size = 16;
+
+    let q: Vec<f32> = (0..num_heads * head_dim)
+        .map(|i| (i as f32 * 0.005 + 0.3).sin() * 0.15)
+        .collect();
+    let k: Vec<f32> = (0..num_kv_heads * kv_len * head_dim)
+        .map(|i| (i as f32 * 0.00071).cos() * 0.18)
+        .collect();
+    let v: Vec<f32> = (0..num_kv_heads * kv_len * head_dim)
+        .map(|i| (i as f32 * 0.00097 + 2.1).sin() * 0.18)
+        .collect();
+
+    let device = Device::system_default().expect("no Metal device");
+    let pipes = MetalPipelines::new(&device);
+
+    let out_contig = run_contiguous(
+        &pipes,
+        &q,
+        &k,
+        &v,
+        num_heads,
+        num_kv_heads,
+        head_dim,
+        kv_len,
+    );
+
+    let (k_paged, table) = pack_into_paged(&k, num_kv_heads, kv_len, head_dim, block_size);
+    let (v_paged, _) = pack_into_paged(&v, num_kv_heads, kv_len, head_dim, block_size);
+    let out_paged = run_paged(
+        &pipes,
+        &q,
+        &k_paged,
+        &v_paged,
+        &table,
+        kv_len as u32,
+        num_heads,
+        num_kv_heads,
+        head_dim,
+        block_size,
+    );
+
+    // Slightly looser tolerance for long context: f32 sumexp
+    // accumulation accumulates more rounding error.
+    assert_close(
+        &out_contig,
+        &out_paged,
+        5e-4,
+        "paged vs contiguous (long ctx)",
+    );
+}
+
+#[test]
+fn paged_decode_handles_shuffled_block_table() {
+    // The block_table doesn't have to be identity; that's the whole
+    // point of paged caching. Build a contiguous KV, scatter into a
+    // larger paged pool with NON-identity block assignment, run paged
+    // attention, compare.
+    let num_heads: usize = 8;
+    let num_kv_heads: usize = 2;
+    let head_dim: usize = 128;
+    let kv_len: usize = 50;
+    let block_size: usize = 16;
+    let num_logical_blocks = kv_len.div_ceil(block_size); // 4
+    // Allocate a bigger physical pool so we can shuffle assignments.
+    let num_physical_blocks = 8;
+    // Permutation: logical 0->5, 1->2, 2->7, 3->1.
+    let permutation = [5u32, 2, 7, 1];
+    assert_eq!(permutation.len(), num_logical_blocks);
+
+    let q: Vec<f32> = (0..num_heads * head_dim)
+        .map(|i| (i as f32 * 0.029).sin() * 0.2)
+        .collect();
+    let k: Vec<f32> = (0..num_kv_heads * kv_len * head_dim)
+        .map(|i| (i as f32 * 0.011).cos() * 0.2)
+        .collect();
+    let v: Vec<f32> = (0..num_kv_heads * kv_len * head_dim)
+        .map(|i| (i as f32 * 0.013 + 0.5).sin() * 0.2)
+        .collect();
+
+    // Build pool with the given permutation.
+    let mut k_pool = vec![0.0f32; num_physical_blocks * num_kv_heads * block_size * head_dim];
+    let mut v_pool = vec![0.0f32; num_physical_blocks * num_kv_heads * block_size * head_dim];
+    for (logical_block, &physical_block) in permutation.iter().enumerate() {
+        for slot in 0..block_size {
+            let token_idx = logical_block * block_size + slot;
+            if token_idx >= kv_len {
+                break;
+            }
+            for kvh in 0..num_kv_heads {
+                let src_off = kvh * kv_len * head_dim + token_idx * head_dim;
+                let dst_off = physical_block as usize * num_kv_heads * block_size * head_dim
+                    + kvh * block_size * head_dim
+                    + slot * head_dim;
+                k_pool[dst_off..dst_off + head_dim]
+                    .copy_from_slice(&k[src_off..src_off + head_dim]);
+                v_pool[dst_off..dst_off + head_dim]
+                    .copy_from_slice(&v[src_off..src_off + head_dim]);
+            }
+        }
+    }
+
+    let device = Device::system_default().expect("no Metal device");
+    let pipes = MetalPipelines::new(&device);
+
+    let out_contig = run_contiguous(
+        &pipes,
+        &q,
+        &k,
+        &v,
+        num_heads,
+        num_kv_heads,
+        head_dim,
+        kv_len,
+    );
+    let out_paged = run_paged(
+        &pipes,
+        &q,
+        &k_pool,
+        &v_pool,
+        &permutation,
+        kv_len as u32,
+        num_heads,
+        num_kv_heads,
+        head_dim,
+        block_size,
+    );
+
+    assert_close(
+        &out_contig,
+        &out_paged,
+        1e-4,
+        "paged vs contiguous (shuffled block table)",
+    );
+}

--- a/crates/ferrum-attention/tests/paged_attention_test.rs
+++ b/crates/ferrum-attention/tests/paged_attention_test.rs
@@ -41,16 +41,12 @@ fn make_buffer(device: &Device, data_bytes: &[u8]) -> metal::Buffer {
 }
 
 fn buffer_from_f32(device: &Device, data: &[f32]) -> metal::Buffer {
-    let bytes = unsafe {
-        std::slice::from_raw_parts(data.as_ptr() as *const u8, data.len() * 4)
-    };
+    let bytes = unsafe { std::slice::from_raw_parts(data.as_ptr() as *const u8, data.len() * 4) };
     make_buffer(device, bytes)
 }
 
 fn buffer_from_u32(device: &Device, data: &[u32]) -> metal::Buffer {
-    let bytes = unsafe {
-        std::slice::from_raw_parts(data.as_ptr() as *const u8, data.len() * 4)
-    };
+    let bytes = unsafe { std::slice::from_raw_parts(data.as_ptr() as *const u8, data.len() * 4) };
     make_buffer(device, bytes)
 }
 
@@ -339,7 +335,7 @@ fn paged_decode_handles_shuffled_block_table() {
     let kv_len: usize = 50;
     let block_size: usize = 16;
     let num_logical_blocks = kv_len.div_ceil(block_size); // 4
-    // Allocate a bigger physical pool so we can shuffle assignments.
+                                                          // Allocate a bigger physical pool so we can shuffle assignments.
     let num_physical_blocks = 8;
     // Permutation: logical 0->5, 1->2, 2->7, 3->1.
     let permutation = [5u32, 2, 7, 1];


### PR DESCRIPTION
## Summary

Phase 1 of Metal paged attention. This PR adds **only the GPU kernel + standalone correctness tests**. Subsequent PRs wire it into ferrum-kv block management, the LlamaFamily decode path, and the ContinuousBatchScheduler.

**Why a 165-line kernel addition, not a 1500-line port from mistral.rs**:

Reviewed mistral.rs's \`pagedattention.metal\` (1434 lines, MLX + vLLM port). It's templated across f32/f16/bf16 × f32/f16/bf16/uchar cache × 8 head dims × 3 block sizes + ALiBi + FP8 scales + sinks + v2 split-K reduction.

ferrum's situation: f32 throughout, head_dim=128, no ALiBi/sinks/FP8 yet, and we already have an MLX-style decode kernel from PR #66 (\`flash_attn_decode_f32\`). The bandwidth-bound math + cross-simdgroup combine logic in that kernel is byte-for-byte what we need; **only the K/V addressing changes** (block_table[seq][i] → physical block instead of contiguous offset). Net new code: 165 MSL lines.

## Correctness

3 tests in \`tests/paged_attention_test.rs\`, all pass:

| Test | Heads (q/kv) | kv_len | Block table |
|------|:---:|:---:|---|
| \`paged_decode_matches_contiguous_small\` | 8/2 | 50 | identity |
| \`paged_decode_matches_contiguous_long_context\` | 32/8 | 2049 | identity |
| \`paged_decode_handles_shuffled_block_table\` | 8/2 | 50 | 0→5, 1→2, 2→7, 3→1 |

Reference: same Q/K/V data run through \`flash_attn_decode_f32\` (contiguous KV). Tolerance: 1e-4 on identity / shuffled, 5e-4 on long-context (f32 sumexp accumulates more rounding error over 2k positions).

## What's NOT in this PR

- Block allocator / KV pool (Phase 2: hook into ferrum-kv's existing \`managers/paged.rs\`)
- LlamaFamily decode path uses the new kernel (Phase 3)
- ContinuousBatchScheduler emits paged batches (Phase 4)
- 16-concurrent throughput bench (Phase 5)

## Test plan
- [x] Kernel compiles clean on Metal (verified via runtime \`MetalPipelines::new\`)
- [x] cargo build --release --features metal passes
- [x] cargo test -p ferrum-attention --features metal --release: all pre-existing 9 tests still pass + 3 new paged tests pass
- [x] Contiguous parity verified at 3 KV scales

🤖 Generated with [Claude Code](https://claude.com/claude-code)