### PR TITLE
perf(metal): paged-KV split_qkv_norm_rope_into_cache (Phase 2/5)

### DIFF
--- a/crates/ferrum-attention/src/metal/pipelines.rs
+++ b/crates/ferrum-attention/src/metal/pipelines.rs
@@ -83,6 +83,7 @@ impl MetalPipelines {
                     "kv_cache_append_f32",
                     "split_qkv_norm_rope_f32",
                     "split_qkv_norm_rope_kvc_f32",
+                    "split_qkv_norm_rope_paged_kvc_f32",
                 ][..],
             ),
             (
@@ -697,6 +698,90 @@ impl MetalPipelines {
         enc.set_buffer(7, Some(cache_v), 0);
         enc.set_bytes(
             8,
+            std::mem::size_of::<P>() as u64,
+            &params as *const _ as *const c_void as *const _,
+        );
+        let grid = MTLSize::new(tokens as u64, (q_heads + 2 * kv_heads) as u64, 1);
+        let tg = MTLSize::new(32, 1, 1);
+        enc.dispatch_thread_groups(grid, tg);
+    }
+
+    /// Paged-KV variant of [`Self::split_qkv_norm_rope_into_cache`].
+    ///
+    /// Same fused split + qk-norm + RoPE + cache-write, but K/V are
+    /// written into a paged pool `[num_blocks, kv_heads, block_size,
+    /// head_dim]` indexed via `block_table[logical_block]` →
+    /// physical_block. Q still goes to head-major scratch.
+    ///
+    /// `block_table` is the per-sequence logical→physical map for the
+    /// caller's single sequence; multi-seq dispatch threads `tgpig.z`
+    /// into a `[num_seqs, max_blocks_per_seq]` table — that's a future
+    /// PR. For now this signature handles single-seq decode + prefill
+    /// (the only call sites we're integrating in Phase 3).
+    #[allow(clippy::too_many_arguments)]
+    pub fn split_qkv_norm_rope_into_paged_cache(
+        &self,
+        enc: &ComputeCommandEncoderRef,
+        qkv: &Buffer,
+        q_norm_w: &Buffer,
+        k_norm_w: &Buffer,
+        cos: &Buffer,
+        sin: &Buffer,
+        q_out: &Buffer,
+        cache_k: &Buffer,
+        cache_v: &Buffer,
+        block_table: &Buffer,
+        tokens: usize,
+        q_heads: usize,
+        kv_heads: usize,
+        head_dim: usize,
+        pos_offset: usize,
+        eps: f32,
+        qk_mode: i32,
+        cache_len: usize,
+        block_size: usize,
+        max_num_blocks_per_seq: usize,
+    ) {
+        // Layout matches `SplitQkvNormRopePagedKvcParams` in norm_rope.metal.
+        #[repr(C)]
+        struct P {
+            tokens: i32,
+            q_heads: i32,
+            kv_heads: i32,
+            head_dim: i32,
+            half_dim: i32,
+            pos_offset: i32,
+            eps: f32,
+            qk_mode: i32,
+            cache_len: i32,
+            block_size: i32,
+            max_num_blocks_per_seq: i32,
+        }
+        let params = P {
+            tokens: tokens as i32,
+            q_heads: q_heads as i32,
+            kv_heads: kv_heads as i32,
+            head_dim: head_dim as i32,
+            half_dim: (head_dim / 2) as i32,
+            pos_offset: pos_offset as i32,
+            eps,
+            qk_mode,
+            cache_len: cache_len as i32,
+            block_size: block_size as i32,
+            max_num_blocks_per_seq: max_num_blocks_per_seq as i32,
+        };
+        enc.set_compute_pipeline_state(self.pipeline("split_qkv_norm_rope_paged_kvc_f32"));
+        enc.set_buffer(0, Some(qkv), 0);
+        enc.set_buffer(1, Some(q_norm_w), 0);
+        enc.set_buffer(2, Some(k_norm_w), 0);
+        enc.set_buffer(3, Some(cos), 0);
+        enc.set_buffer(4, Some(sin), 0);
+        enc.set_buffer(5, Some(q_out), 0);
+        enc.set_buffer(6, Some(cache_k), 0);
+        enc.set_buffer(7, Some(cache_v), 0);
+        enc.set_buffer(8, Some(block_table), 0);
+        enc.set_bytes(
+            9,
             std::mem::size_of::<P>() as u64,
             &params as *const _ as *const c_void as *const _,
         );

--- a/crates/ferrum-attention/src/metal/shaders/norm_rope.metal
+++ b/crates/ferrum-attention/src/metal/shaders/norm_rope.metal
@@ -385,3 +385,132 @@ kernel void split_qkv_norm_rope_kvc_f32(
         dst[i + half_d] = x1 * c + x0 * s;
     }
 }
+
+// ── Paged-KV variant of split_qkv_norm_rope_kvc_f32 ──────────────────
+//
+// Same fused split + qk-norm + RoPE + cache-write as the contiguous
+// variant above. The only change is K/V's `dst` computation: instead
+// of writing into `cache_{k,v}[kv_head][cache_len + tok][hd]`, we
+// resolve the destination via the block-table:
+//
+//   global_slot     = cache_len + tok
+//   logical_block   = global_slot / block_size
+//   slot_in_block   = global_slot % block_size
+//   physical_block  = block_table[logical_block]
+//   dst             = cache_{k,v}[physical_block][kv_head][slot_in_block][hd]
+//
+// Cache layout: [num_blocks, kv_heads, block_size, head_dim] (matches
+// flash_attn_decode_paged_f32 from the sibling PR). Q stays head-major
+// — only K/V live in the paged pool.
+
+struct SplitQkvNormRopePagedKvcParams {
+    int tokens;
+    int q_heads;
+    int kv_heads;
+    int head_dim;
+    int half_dim;
+    int pos_offset;
+    float eps;
+    int qk_mode;
+    int cache_len;              // existing seq length in cache (slot of first new token)
+    int block_size;             // KV positions per physical block (16 typical)
+    int max_num_blocks_per_seq; // block_table row stride (single-seq case for now)
+};
+
+kernel void split_qkv_norm_rope_paged_kvc_f32(
+    device const float*    qkv          [[buffer(0)]],
+    device const float*    q_norm_w     [[buffer(1)]],
+    device const float*    k_norm_w     [[buffer(2)]],
+    device const float*    cos_tab      [[buffer(3)]],
+    device const float*    sin_tab      [[buffer(4)]],
+    device       float*    q_out        [[buffer(5)]],   // [q_heads, tokens, hd]
+    device       float*    cache_k      [[buffer(6)]],   // [num_blocks, kv_heads, block_size, hd]
+    device       float*    cache_v      [[buffer(7)]],   // [num_blocks, kv_heads, block_size, hd]
+    device const uint32_t* block_table  [[buffer(8)]],   // [max_blocks_per_seq] (single seq)
+    constant SplitQkvNormRopePagedKvcParams& p [[buffer(9)]],
+    uint2 tgpig [[threadgroup_position_in_grid]],
+    uint  tiisg [[thread_index_in_simdgroup]])
+{
+    const int tok = int(tgpig.x);
+    const int head_g = int(tgpig.y);
+    if (tok >= p.tokens) return;
+
+    const int hd = p.head_dim;
+    const int half_d = p.half_dim;
+    const int q_dim = p.q_heads * hd;
+    const int kv_dim = p.kv_heads * hd;
+    const int qkv_stride = q_dim + 2 * kv_dim;
+
+    int region;
+    int local_head;
+    int src_off;
+    if (head_g < p.q_heads) {
+        region = 0;
+        local_head = head_g;
+        src_off = tok * qkv_stride + local_head * hd;
+    } else if (head_g < p.q_heads + p.kv_heads) {
+        region = 1;
+        local_head = head_g - p.q_heads;
+        src_off = tok * qkv_stride + q_dim + local_head * hd;
+    } else {
+        region = 2;
+        local_head = head_g - p.q_heads - p.kv_heads;
+        src_off = tok * qkv_stride + q_dim + kv_dim + local_head * hd;
+    }
+
+    device const float* src = qkv + src_off;
+
+    // Compute dst pointer.
+    // Q (region 0): head-major scratch as before.
+    // K/V (region 1/2): paged layout — index via block_table.
+    device float* dst;
+    if (region == 0) {
+        dst = q_out + local_head * p.tokens * hd + tok * hd;
+    } else {
+        const int global_slot     = p.cache_len + tok;
+        const int logical_block   = global_slot / p.block_size;
+        const int slot_in_block   = global_slot % p.block_size;
+        const uint32_t physical_block = block_table[logical_block];
+        const int slot_offset = int(physical_block) * p.kv_heads * p.block_size * hd
+                              + local_head * p.block_size * hd
+                              + slot_in_block * hd;
+        dst = (region == 1 ? cache_k : cache_v) + slot_offset;
+    }
+
+    // V: pure copy.
+    if (region == 2) {
+        for (int i = int(tiisg); i < hd; i += 32) {
+            dst[i] = src[i];
+        }
+        return;
+    }
+
+    // Q / K: optional QK-norm, then RoPE.
+    const bool apply_norm = (p.qk_mode == 1);
+    float scale = 1.0f;
+    device const float* norm_w = (region == 0) ? q_norm_w : k_norm_w;
+    if (apply_norm) {
+        float sum_sq = 0.0f;
+        for (int i = int(tiisg); i < hd; i += 32) {
+            float v = src[i];
+            sum_sq += v * v;
+        }
+        sum_sq = simd_sum(sum_sq);
+        scale = 1.0f / sqrt(sum_sq / float(hd) + p.eps);
+    }
+
+    const int pos = p.pos_offset + tok;
+    device const float* cos_row = cos_tab + pos * half_d;
+    device const float* sin_row = sin_tab + pos * half_d;
+
+    for (int i = int(tiisg); i < half_d; i += 32) {
+        float w0 = apply_norm ? (scale * norm_w[i])          : 1.0f;
+        float w1 = apply_norm ? (scale * norm_w[i + half_d]) : 1.0f;
+        float x0 = src[i]          * w0;
+        float x1 = src[i + half_d] * w1;
+        float c = cos_row[i];
+        float s = sin_row[i];
+        dst[i]          = x0 * c - x1 * s;
+        dst[i + half_d] = x1 * c + x0 * s;
+    }
+}

--- a/crates/ferrum-attention/tests/paged_kv_append_test.rs
+++ b/crates/ferrum-attention/tests/paged_kv_append_test.rs
@@ -1,0 +1,420 @@
+//! Correctness tests for the paged-KV variant of split_qkv_norm_rope.
+//!
+//! Approach: build a fused QKV input + RoPE tables, run the EXISTING
+//! contiguous `split_qkv_norm_rope_into_cache` to populate a contiguous
+//! KV cache, then run the NEW paged variant with the same inputs to
+//! populate a paged pool. Walk the paged pool via the block_table and
+//! verify each (head, position) slice equals the contiguous cache's
+//! corresponding slice. This isolates the paged-dst computation from
+//! the math (norm + RoPE), which is identical between the two kernels.
+
+#![cfg(all(target_os = "macos", feature = "metal"))]
+
+use ferrum_attention::metal::pipelines::MetalPipelines;
+use metal::{Device, MTLResourceOptions};
+use std::ffi::c_void;
+
+fn buffer_from_f32(device: &Device, data: &[f32]) -> metal::Buffer {
+    let bytes =
+        unsafe { std::slice::from_raw_parts(data.as_ptr() as *const u8, data.len() * 4) };
+    device.new_buffer_with_data(
+        bytes.as_ptr() as *const c_void,
+        bytes.len() as u64,
+        MTLResourceOptions::StorageModeShared,
+    )
+}
+
+fn buffer_from_u32(device: &Device, data: &[u32]) -> metal::Buffer {
+    let bytes =
+        unsafe { std::slice::from_raw_parts(data.as_ptr() as *const u8, data.len() * 4) };
+    device.new_buffer_with_data(
+        bytes.as_ptr() as *const c_void,
+        bytes.len() as u64,
+        MTLResourceOptions::StorageModeShared,
+    )
+}
+
+fn empty_buffer(device: &Device, num_floats: usize) -> metal::Buffer {
+    device.new_buffer(
+        (num_floats * 4) as u64,
+        MTLResourceOptions::StorageModeShared,
+    )
+}
+
+fn read_f32(buf: &metal::Buffer, len: usize) -> Vec<f32> {
+    unsafe { std::slice::from_raw_parts(buf.contents() as *const f32, len).to_vec() }
+}
+
+#[derive(Clone, Copy)]
+struct Cfg {
+    tokens: usize,
+    q_heads: usize,
+    kv_heads: usize,
+    head_dim: usize,
+    cache_len: usize,
+    cache_capacity: usize,
+    block_size: usize,
+    max_seq_len: usize,
+    qk_mode: i32, // 0 = no qk-norm, 1 = qk-norm enabled
+    eps: f32,
+}
+
+fn make_input_data(c: &Cfg) -> (Vec<f32>, Vec<f32>, Vec<f32>, Vec<f32>, Vec<f32>) {
+    let qkv_dim = c.q_heads * c.head_dim + 2 * c.kv_heads * c.head_dim;
+    let qkv: Vec<f32> = (0..c.tokens * qkv_dim)
+        .map(|i| (i as f32 * 0.011 + 0.2).sin() * 0.3)
+        .collect();
+    let q_norm_w: Vec<f32> = (0..c.head_dim)
+        .map(|i| 1.0 + (i as f32 * 0.05).cos() * 0.1)
+        .collect();
+    let k_norm_w: Vec<f32> = (0..c.head_dim)
+        .map(|i| 1.0 + (i as f32 * 0.07).sin() * 0.1)
+        .collect();
+    // RoPE tables: cos/sin for each position up to cache_len + tokens.
+    let half_d = c.head_dim / 2;
+    let cos: Vec<f32> = (0..c.max_seq_len * half_d)
+        .map(|i| (i as f32 * 0.001).cos())
+        .collect();
+    let sin: Vec<f32> = (0..c.max_seq_len * half_d)
+        .map(|i| (i as f32 * 0.001).sin())
+        .collect();
+    (qkv, q_norm_w, k_norm_w, cos, sin)
+}
+
+/// Run the existing contiguous `split_qkv_norm_rope_into_cache` and
+/// return (q_head_major, cache_k, cache_v) buffers.
+#[allow(clippy::too_many_arguments)]
+fn run_contiguous(
+    pipes: &MetalPipelines,
+    c: &Cfg,
+    qkv: &[f32],
+    q_norm_w: &[f32],
+    k_norm_w: &[f32],
+    cos: &[f32],
+    sin: &[f32],
+) -> (Vec<f32>, Vec<f32>, Vec<f32>) {
+    let device = &pipes.device;
+    let qkv_buf = buffer_from_f32(device, qkv);
+    let q_norm_buf = buffer_from_f32(device, q_norm_w);
+    let k_norm_buf = buffer_from_f32(device, k_norm_w);
+    let cos_buf = buffer_from_f32(device, cos);
+    let sin_buf = buffer_from_f32(device, sin);
+    let q_out = empty_buffer(device, c.q_heads * c.tokens * c.head_dim);
+    let cache_k = empty_buffer(device, c.kv_heads * c.cache_capacity * c.head_dim);
+    let cache_v = empty_buffer(device, c.kv_heads * c.cache_capacity * c.head_dim);
+
+    let cmd = pipes.queue.new_command_buffer();
+    let enc = cmd.new_compute_command_encoder();
+    pipes.split_qkv_norm_rope_into_cache(
+        enc,
+        &qkv_buf,
+        &q_norm_buf,
+        &k_norm_buf,
+        &cos_buf,
+        &sin_buf,
+        &q_out,
+        &cache_k,
+        &cache_v,
+        c.tokens,
+        c.q_heads,
+        c.kv_heads,
+        c.head_dim,
+        c.cache_len, // pos_offset = cache_len
+        c.eps,
+        c.qk_mode,
+        c.cache_len,
+        c.cache_capacity,
+    );
+    enc.end_encoding();
+    cmd.commit();
+    cmd.wait_until_completed();
+
+    (
+        read_f32(&q_out, c.q_heads * c.tokens * c.head_dim),
+        read_f32(&cache_k, c.kv_heads * c.cache_capacity * c.head_dim),
+        read_f32(&cache_v, c.kv_heads * c.cache_capacity * c.head_dim),
+    )
+}
+
+/// Run the NEW paged `split_qkv_norm_rope_into_paged_cache` and return
+/// (q_head_major, k_pool, v_pool, block_table). The pool is sized for
+/// `num_blocks` physical blocks; we use a non-identity assignment to
+/// stress the indirection logic.
+#[allow(clippy::too_many_arguments)]
+fn run_paged(
+    pipes: &MetalPipelines,
+    c: &Cfg,
+    qkv: &[f32],
+    q_norm_w: &[f32],
+    k_norm_w: &[f32],
+    cos: &[f32],
+    sin: &[f32],
+    block_table: &[u32],
+    num_physical_blocks: usize,
+) -> (Vec<f32>, Vec<f32>, Vec<f32>) {
+    let device = &pipes.device;
+    let qkv_buf = buffer_from_f32(device, qkv);
+    let q_norm_buf = buffer_from_f32(device, q_norm_w);
+    let k_norm_buf = buffer_from_f32(device, k_norm_w);
+    let cos_buf = buffer_from_f32(device, cos);
+    let sin_buf = buffer_from_f32(device, sin);
+    let q_out = empty_buffer(device, c.q_heads * c.tokens * c.head_dim);
+    let pool_floats = num_physical_blocks * c.kv_heads * c.block_size * c.head_dim;
+    let cache_k = empty_buffer(device, pool_floats);
+    let cache_v = empty_buffer(device, pool_floats);
+    let bt_buf = buffer_from_u32(device, block_table);
+
+    let cmd = pipes.queue.new_command_buffer();
+    let enc = cmd.new_compute_command_encoder();
+    pipes.split_qkv_norm_rope_into_paged_cache(
+        enc,
+        &qkv_buf,
+        &q_norm_buf,
+        &k_norm_buf,
+        &cos_buf,
+        &sin_buf,
+        &q_out,
+        &cache_k,
+        &cache_v,
+        &bt_buf,
+        c.tokens,
+        c.q_heads,
+        c.kv_heads,
+        c.head_dim,
+        c.cache_len, // pos_offset = cache_len
+        c.eps,
+        c.qk_mode,
+        c.cache_len,
+        c.block_size,
+        block_table.len(),
+    );
+    enc.end_encoding();
+    cmd.commit();
+    cmd.wait_until_completed();
+
+    (
+        read_f32(&q_out, c.q_heads * c.tokens * c.head_dim),
+        read_f32(&cache_k, pool_floats),
+        read_f32(&cache_v, pool_floats),
+    )
+}
+
+/// Walk the contiguous and paged caches at the same logical positions
+/// and assert per-element equality. Returns the maximum absolute diff
+/// observed (for diagnostic).
+fn compare_caches(
+    c: &Cfg,
+    contig_k: &[f32],
+    contig_v: &[f32],
+    paged_k: &[f32],
+    paged_v: &[f32],
+    block_table: &[u32],
+    label: &str,
+) {
+    let mut max_diff = 0.0f32;
+    let mut max_loc = (0usize, 0usize, 0usize, 0usize);
+    for kvh in 0..c.kv_heads {
+        for tok in 0..c.tokens {
+            let global_slot = c.cache_len + tok;
+            let logical_block = global_slot / c.block_size;
+            let slot_in_block = global_slot % c.block_size;
+            let physical_block = block_table[logical_block] as usize;
+            for d in 0..c.head_dim {
+                let contig_off = kvh * c.cache_capacity * c.head_dim
+                    + global_slot * c.head_dim
+                    + d;
+                let paged_off = physical_block * c.kv_heads * c.block_size * c.head_dim
+                    + kvh * c.block_size * c.head_dim
+                    + slot_in_block * c.head_dim
+                    + d;
+                let dk = (contig_k[contig_off] - paged_k[paged_off]).abs();
+                let dv = (contig_v[contig_off] - paged_v[paged_off]).abs();
+                let dmax = dk.max(dv);
+                if dmax > max_diff {
+                    max_diff = dmax;
+                    max_loc = (kvh, tok, d, physical_block);
+                }
+            }
+        }
+    }
+    assert!(
+        max_diff < 1e-5,
+        "{label}: max diff {max_diff} at (kvh={}, tok={}, d={}, phys_block={}); paged write doesn't match contiguous reference",
+        max_loc.0,
+        max_loc.1,
+        max_loc.2,
+        max_loc.3,
+    );
+}
+
+#[test]
+fn paged_kv_append_matches_contiguous_qk_norm() {
+    // Qwen3-style: QK-norm enabled (qk_mode=1).
+    let c = Cfg {
+        tokens: 5,
+        q_heads: 8,
+        kv_heads: 2,
+        head_dim: 128,
+        cache_len: 11,
+        cache_capacity: 64,
+        block_size: 16,
+        max_seq_len: 128,
+        qk_mode: 1,
+        eps: 1e-6,
+    };
+
+    let (qkv, qn, kn, cos, sin) = make_input_data(&c);
+    let device = Device::system_default().expect("no Metal device");
+    let pipes = MetalPipelines::new(&device);
+
+    // Contiguous reference.
+    let (q_contig, k_contig, v_contig) = run_contiguous(&pipes, &c, &qkv, &qn, &kn, &cos, &sin);
+
+    // Paged variant with non-identity block table.
+    // cache_len=11, tokens=5 → writes to global slots [11..16). With
+    // block_size=16, that's logical block 0 (slots 11-15). So we only
+    // need block_table[0] populated, but allocate room for more.
+    let num_physical_blocks = 8;
+    let block_table: Vec<u32> = (0..4).map(|i| ((i + 3) % num_physical_blocks) as u32).collect();
+    let (q_paged, k_paged, v_paged) = run_paged(
+        &pipes,
+        &c,
+        &qkv,
+        &qn,
+        &kn,
+        &cos,
+        &sin,
+        &block_table,
+        num_physical_blocks,
+    );
+
+    // Q output should be byte-identical (same head-major scratch layout).
+    for (i, (a, b)) in q_contig.iter().zip(q_paged.iter()).enumerate() {
+        assert!(
+            (a - b).abs() < 1e-6,
+            "Q output mismatch at idx {i}: contig={a}, paged={b}",
+        );
+    }
+
+    // K/V should match per-position via block_table indirection.
+    compare_caches(
+        &c,
+        &k_contig,
+        &v_contig,
+        &k_paged,
+        &v_paged,
+        &block_table,
+        "paged kvc (qk_norm)",
+    );
+}
+
+#[test]
+fn paged_kv_append_matches_contiguous_no_qk_norm() {
+    // Llama-3.x-style: qk_mode=2 (RoPE only, no QK-norm).
+    let c = Cfg {
+        tokens: 7,
+        q_heads: 8,
+        kv_heads: 2,
+        head_dim: 128,
+        cache_len: 33,
+        cache_capacity: 64,
+        block_size: 16,
+        max_seq_len: 128,
+        qk_mode: 2,
+        eps: 1e-6,
+    };
+
+    let (qkv, qn, kn, cos, sin) = make_input_data(&c);
+    let device = Device::system_default().expect("no Metal device");
+    let pipes = MetalPipelines::new(&device);
+
+    let (q_contig, k_contig, v_contig) = run_contiguous(&pipes, &c, &qkv, &qn, &kn, &cos, &sin);
+
+    // tokens 33..40 span logical blocks 2 (slots 32-39) and possibly 3.
+    // 40 is exclusive. 33→ block 2 slot 1, 39 → block 2 slot 7. All in block 2.
+    let num_physical_blocks = 6;
+    let block_table: Vec<u32> = vec![5, 1, 4, 0, 2, 3]; // permutation
+    let (q_paged, k_paged, v_paged) = run_paged(
+        &pipes,
+        &c,
+        &qkv,
+        &qn,
+        &kn,
+        &cos,
+        &sin,
+        &block_table,
+        num_physical_blocks,
+    );
+
+    for (i, (a, b)) in q_contig.iter().zip(q_paged.iter()).enumerate() {
+        assert!(
+            (a - b).abs() < 1e-6,
+            "Q output mismatch at idx {i}: contig={a}, paged={b}",
+        );
+    }
+    compare_caches(
+        &c,
+        &k_contig,
+        &v_contig,
+        &k_paged,
+        &v_paged,
+        &block_table,
+        "paged kvc (no qk_norm)",
+    );
+}
+
+#[test]
+fn paged_kv_append_spans_block_boundary() {
+    // Stress: tokens span TWO logical blocks. cache_len=14, tokens=5
+    // writes to global slots [14..19). With block_size=16: block 0
+    // gets slots 14-15 (2 tokens), block 1 gets slots 16-18 (3 tokens).
+    let c = Cfg {
+        tokens: 5,
+        q_heads: 8,
+        kv_heads: 2,
+        head_dim: 128,
+        cache_len: 14,
+        cache_capacity: 64,
+        block_size: 16,
+        max_seq_len: 128,
+        qk_mode: 1,
+        eps: 1e-6,
+    };
+
+    let (qkv, qn, kn, cos, sin) = make_input_data(&c);
+    let device = Device::system_default().expect("no Metal device");
+    let pipes = MetalPipelines::new(&device);
+
+    let (q_contig, k_contig, v_contig) = run_contiguous(&pipes, &c, &qkv, &qn, &kn, &cos, &sin);
+
+    let num_physical_blocks = 8;
+    // Logical block 0 → physical 5; logical block 1 → physical 2.
+    let block_table: Vec<u32> = vec![5, 2, 7, 1];
+    let (q_paged, k_paged, v_paged) = run_paged(
+        &pipes,
+        &c,
+        &qkv,
+        &qn,
+        &kn,
+        &cos,
+        &sin,
+        &block_table,
+        num_physical_blocks,
+    );
+
+    for (i, (a, b)) in q_contig.iter().zip(q_paged.iter()).enumerate() {
+        assert!(
+            (a - b).abs() < 1e-6,
+            "Q output mismatch at idx {i}: contig={a}, paged={b}",
+        );
+    }
+    compare_caches(
+        &c,
+        &k_contig,
+        &v_contig,
+        &k_paged,
+        &v_paged,
+        &block_table,
+        "paged kvc (cross-block)",
+    );
+}

--- a/crates/ferrum-attention/tests/paged_kv_append_test.rs
+++ b/crates/ferrum-attention/tests/paged_kv_append_test.rs
@@ -15,8 +15,7 @@ use metal::{Device, MTLResourceOptions};
 use std::ffi::c_void;
 
 fn buffer_from_f32(device: &Device, data: &[f32]) -> metal::Buffer {
-    let bytes =
-        unsafe { std::slice::from_raw_parts(data.as_ptr() as *const u8, data.len() * 4) };
+    let bytes = unsafe { std::slice::from_raw_parts(data.as_ptr() as *const u8, data.len() * 4) };
     device.new_buffer_with_data(
         bytes.as_ptr() as *const c_void,
         bytes.len() as u64,
@@ -25,8 +24,7 @@ fn buffer_from_f32(device: &Device, data: &[f32]) -> metal::Buffer {
 }
 
 fn buffer_from_u32(device: &Device, data: &[u32]) -> metal::Buffer {
-    let bytes =
-        unsafe { std::slice::from_raw_parts(data.as_ptr() as *const u8, data.len() * 4) };
+    let bytes = unsafe { std::slice::from_raw_parts(data.as_ptr() as *const u8, data.len() * 4) };
     device.new_buffer_with_data(
         bytes.as_ptr() as *const c_void,
         bytes.len() as u64,
@@ -220,9 +218,7 @@ fn compare_caches(
             let slot_in_block = global_slot % c.block_size;
             let physical_block = block_table[logical_block] as usize;
             for d in 0..c.head_dim {
-                let contig_off = kvh * c.cache_capacity * c.head_dim
-                    + global_slot * c.head_dim
-                    + d;
+                let contig_off = kvh * c.cache_capacity * c.head_dim + global_slot * c.head_dim + d;
                 let paged_off = physical_block * c.kv_heads * c.block_size * c.head_dim
                     + kvh * c.block_size * c.head_dim
                     + slot_in_block * c.head_dim
@@ -275,7 +271,9 @@ fn paged_kv_append_matches_contiguous_qk_norm() {
     // block_size=16, that's logical block 0 (slots 11-15). So we only
     // need block_table[0] populated, but allocate room for more.
     let num_physical_blocks = 8;
-    let block_table: Vec<u32> = (0..4).map(|i| ((i + 3) % num_physical_blocks) as u32).collect();
+    let block_table: Vec<u32> = (0..4)
+        .map(|i| ((i + 3) % num_physical_blocks) as u32)
+        .collect();
     let (q_paged, k_paged, v_paged) = run_paged(
         &pipes,
         &c,


### PR DESCRIPTION
## Summary

Phase 2 of Metal paged attention. Adds the **write side** to complement PR #68's read side. Together they cover the kernel-level paged KV pipeline; Phase 3 wires them into the LlamaFamily decode path.

## What's new

\`split_qkv_norm_rope_paged_kvc_f32\` extends the existing contiguous \`split_qkv_norm_rope_kvc_f32\` with paged dst computation:

\`\`\`
global_slot     = cache_len + tok
logical_block   = global_slot / block_size
slot_in_block   = global_slot % block_size
physical_block  = block_table[logical_block]
dst             = cache_{k,v}[physical_block][kv_head][slot_in_block][hd]
\`\`\`

Math (norm + RoPE) is identical to the contiguous variant — only \`dst\` differs. Net: ~140 MSL lines, ~80 Rust lines.

## Correctness

3 tests, all pass:

| Test | Variant | Tokens | Cache_len | Block_table | Span |
|------|---------|:------:|:---------:|-------------|------|
| \`paged_kv_append_matches_contiguous_qk_norm\` | qk_mode=1 (Qwen3) | 5 | 11 | non-identity 4-perm | 1 logical block |
| \`paged_kv_append_matches_contiguous_no_qk_norm\` | qk_mode=2 (Llama) | 7 | 33 | full 6-perm | 1 logical block |
| \`paged_kv_append_spans_block_boundary\` | qk_mode=1 | 5 | 14 | identity-ish | **2 logical blocks** (slots 14-15 + 16-18) |

Reference: same Q/K/V data through \`split_qkv_norm_rope_into_cache\` (existing contiguous). Each test asserts:
- Q output (head-major scratch) is byte-identical (1e-6)
- For each (kv_head, position, dim): contig_cache[kvh][slot][d] == paged_cache[block_table[slot/bs]][kvh][slot%bs][d] within 1e-5

## Stacking

Stacks on PR #68 (paged read). Both together = full kernel pipeline. Phase 3 can now wire them into LlamaFamily.

## What's NOT in this PR

- LlamaFamily decode integration (Phase 3)
- ferrum-kv block allocator (Phase 3)
- Multi-sequence block tables (Phase 4)
- Scheduler + 16-concurrent bench (Phase 4-5)

## Test plan
- [x] cargo build --release --features metal passes
- [x] cargo test -p ferrum-attention --features metal --release: 13 tests, 0 failures (10 pre-existing + 3 new)
- [x] Single-block, cross-block-boundary, and permuted block_table all verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)