### PR TITLE
perf(metal): paged-KV multi-seq shared pool foundation (Phase 4a/5)

### DIFF
--- a/crates/ferrum-kernels/src/backend/traits.rs
+++ b/crates/ferrum-kernels/src/backend/traits.rs
@@ -174,6 +174,10 @@ pub struct KvCache<B: Backend> {
     pub block_table: Option<B::Buffer>,
     /// Paged: `[1]` u32 — current context length for the kernel to read.
     pub context_lens: Option<B::Buffer>,
+    /// Paged: host-side mirror of the physical block indices owned by
+    /// this cache. Lets the model's release path return blocks to the
+    /// shared allocator without reading them back from device.
+    pub paged_block_indices: Vec<u32>,
 }
 
 /// The core abstraction over CUDA / Metal / CPU.

--- a/crates/ferrum-models/src/common/mod.rs
+++ b/crates/ferrum-models/src/common/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod families;
 pub mod llm;
+pub mod paged_pool;
 
 pub use families::{
     AudioBuffer, AudioTokens, EmbeddingModel, EncoderDecoderLM, EncoderState, ImageBuffer,

--- a/crates/ferrum-models/src/common/paged_pool.rs
+++ b/crates/ferrum-models/src/common/paged_pool.rs
@@ -1,0 +1,249 @@
+//! Multi-sequence paged-KV pool — Phase 4 of Metal paged attention.
+//!
+//! Replaces the per-cache_id `KvCache` allocation model with a
+//! shared-pool architecture matching vLLM / mistral.rs:
+//!
+//! - **One pool per layer** holds K and V for *all* concurrent sequences.
+//!   Sized to `MAX_TOTAL_BLOCKS × num_kv_heads × block_size × head_dim`.
+//! - **Per-cache_id state** ([`PagedSeqState`]) carries that sequence's
+//!   logical → physical block mapping (`block_table`) plus its current
+//!   length (`len`). Multiple cache_ids can index into the same pool
+//!   without colliding because their block_tables point at disjoint
+//!   physical blocks (or shared ones, if prefix-caching is enabled
+//!   later).
+//! - **[`BlockAllocator`]** is a free-list owning physical block indices.
+//!   `allocate` pops, `free` pushes back. Out-of-memory surfaces as
+//!   `Result::Err` so the scheduler can refuse the request rather than
+//!   panicking deep in the model forward.
+//!
+//! What's *not* here yet (deferred to Phase 4c / 5):
+//! - Prefix sharing: today a fresh `PagedSeqState` always allocates new
+//!   blocks even if its prompt overlaps another live sequence's.
+//! - Eviction / preemption: when blocks run out we just `Err`. A real
+//!   scheduler would either refuse-and-queue or evict the least-recently-used.
+//! - Cross-process or cross-model pooling.
+
+use ferrum_kernels::backend::Backend;
+use ferrum_types::{FerrumError, Result};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+/// LIFO free-list block allocator. `O(1)` allocate / free, no fragmentation
+/// (all blocks are uniform size).
+///
+/// `capacity` is the total physical block count baked into the pool at
+/// load time. The allocator is independent per-model (block index space
+/// is not portable across models).
+pub struct BlockAllocator {
+    free_list: Vec<u32>,
+    capacity: u32,
+    /// Watermark: how many blocks have been live at peak, useful for
+    /// pool-sizing diagnostics in the bench harness.
+    peak_in_use: AtomicUsize,
+}
+
+impl BlockAllocator {
+    /// Create a fresh allocator. All `num_blocks` blocks start free.
+    /// Free-list is built so `allocate()` returns block 0 first, then 1,
+    /// etc. — predictable for tests and ensures the lower physical
+    /// blocks see the most reuse (better cache locality on M1's SLC).
+    pub fn new(num_blocks: u32) -> Self {
+        let mut free_list: Vec<u32> = (0..num_blocks).collect();
+        free_list.reverse(); // pop() yields 0 first
+        Self {
+            free_list,
+            capacity: num_blocks,
+            peak_in_use: AtomicUsize::new(0),
+        }
+    }
+
+    /// Allocate a single physical block. Returns `Err` when the pool is
+    /// exhausted — caller is expected to refuse the request and queue
+    /// it (or evict another seq, when that's wired up).
+    pub fn allocate(&mut self) -> Result<u32> {
+        match self.free_list.pop() {
+            Some(b) => {
+                let in_use = self.capacity as usize - self.free_list.len();
+                self.peak_in_use.fetch_max(in_use, Ordering::Relaxed);
+                Ok(b)
+            }
+            None => Err(FerrumError::resource_exhausted(format!(
+                "paged KV pool exhausted (capacity={} blocks, all in use)",
+                self.capacity
+            ))),
+        }
+    }
+
+    /// Bulk allocate. Atomic: either all `n` succeed or none are taken.
+    pub fn allocate_n(&mut self, n: usize) -> Result<Vec<u32>> {
+        if self.free_list.len() < n {
+            return Err(FerrumError::resource_exhausted(format!(
+                "paged KV pool exhausted: need {n} blocks but only {} free",
+                self.free_list.len()
+            )));
+        }
+        let mut out = Vec::with_capacity(n);
+        for _ in 0..n {
+            out.push(self.free_list.pop().unwrap());
+        }
+        let in_use = self.capacity as usize - self.free_list.len();
+        self.peak_in_use.fetch_max(in_use, Ordering::Relaxed);
+        Ok(out)
+    }
+
+    /// Return blocks to the free list. Caller is responsible for
+    /// ensuring no live sequence still references them; freeing a block
+    /// while it's still in a `PagedSeqState::blocks` will silently
+    /// corrupt the next allocation that gets it.
+    pub fn free(&mut self, blocks: &[u32]) {
+        self.free_list.extend_from_slice(blocks);
+    }
+
+    pub fn free_count(&self) -> usize {
+        self.free_list.len()
+    }
+
+    pub fn capacity(&self) -> u32 {
+        self.capacity
+    }
+
+    pub fn peak_in_use(&self) -> usize {
+        self.peak_in_use.load(Ordering::Relaxed)
+    }
+}
+
+/// Per-sequence paged-KV state.
+///
+/// Holds the logical→physical block mapping for ONE sequence (one
+/// `cache_id`) plus its current token count. The mapping is stored as
+/// both:
+/// - `blocks: Vec<u32>` — the host-side source of truth, used by the
+///   block allocator + grow logic.
+/// - `block_table_buf: B::Buffer` — a device-side u32 buffer that mirrors
+///   `blocks` and is read directly by the paged Metal kernels (PR #68 /
+///   #69). Kept in sync via [`Self::ensure_capacity`].
+///
+/// `context_lens_buf` is a 1-element u32 device buffer holding `len`.
+/// The kernel reads it each forward; we update it via `B::write_u32`.
+pub struct PagedSeqState<B: Backend> {
+    pub blocks: Vec<u32>,
+    pub block_table_buf: B::Buffer,
+    pub context_lens_buf: B::Buffer,
+    pub len: usize,
+    pub block_size: usize,
+    pub max_blocks_per_seq: usize,
+}
+
+impl<B: Backend> PagedSeqState<B> {
+    /// Allocate buffers for a sequence that hasn't yet allocated any
+    /// blocks. The allocator isn't touched here — the first call to
+    /// [`Self::ensure_capacity`] does the real work.
+    pub fn new(block_size: usize, max_blocks_per_seq: usize) -> Self {
+        let block_table_buf = B::alloc_u32(max_blocks_per_seq);
+        let context_lens_buf = B::alloc_u32(1);
+        // Initialise context_lens to 0 so a forward dispatched before
+        // any token has been written sees an empty context.
+        let mut ctx = B::new_context();
+        let mut cl = context_lens_buf;
+        B::write_u32(&mut ctx, &mut cl, &[0u32]);
+        B::sync(&mut ctx);
+        Self {
+            blocks: Vec::with_capacity(max_blocks_per_seq),
+            block_table_buf,
+            context_lens_buf: cl,
+            len: 0,
+            block_size,
+            max_blocks_per_seq,
+        }
+    }
+
+    /// Ensure the seq has enough blocks to hold `target_len` tokens.
+    /// Allocates additional blocks from the pool if needed and re-syncs
+    /// `block_table_buf` to the device. Idempotent if already big enough.
+    pub fn ensure_capacity(
+        &mut self,
+        ctx: &mut B::Context,
+        alloc: &mut BlockAllocator,
+        target_len: usize,
+    ) -> Result<()> {
+        let needed = target_len.div_ceil(self.block_size);
+        if needed > self.max_blocks_per_seq {
+            return Err(FerrumError::model(format!(
+                "paged KV: target_len={target_len} would need {needed} blocks, exceeds max_blocks_per_seq={}",
+                self.max_blocks_per_seq
+            )));
+        }
+        while self.blocks.len() < needed {
+            let block = alloc.allocate()?;
+            self.blocks.push(block);
+        }
+        // Mirror the host-side blocks list into the device buffer. We
+        // write the FULL `max_blocks_per_seq` entries — unused slots
+        // beyond `needed` are never read by the kernel (it only walks
+        // `[0, ceil(context_len / block_size))`), but writing them
+        // keeps the buffer's content predictable.
+        let mut padded = self.blocks.clone();
+        padded.resize(self.max_blocks_per_seq, 0);
+        B::write_u32(ctx, &mut self.block_table_buf, &padded);
+        Ok(())
+    }
+
+    /// Update the on-device `context_lens_buf` to the current `self.len`.
+    /// Call this after [`Self::ensure_capacity`] but before dispatching
+    /// the paged attention kernel for this seq.
+    pub fn sync_context_len(&mut self, ctx: &mut B::Context) {
+        B::write_u32(ctx, &mut self.context_lens_buf, &[self.len as u32]);
+    }
+
+    /// Release all blocks back to the allocator. Buffers are kept (cheap
+    /// to reuse for a future cache_id), but blocks become available for
+    /// other sequences. Sets `len` back to 0.
+    pub fn release(&mut self, alloc: &mut BlockAllocator) {
+        alloc.free(&self.blocks);
+        self.blocks.clear();
+        self.len = 0;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn allocator_basic() {
+        let mut a = BlockAllocator::new(4);
+        assert_eq!(a.free_count(), 4);
+        assert_eq!(a.allocate().unwrap(), 0);
+        assert_eq!(a.allocate().unwrap(), 1);
+        assert_eq!(a.allocate().unwrap(), 2);
+        assert_eq!(a.allocate().unwrap(), 3);
+        assert!(a.allocate().is_err());
+        assert_eq!(a.free_count(), 0);
+
+        a.free(&[1, 3]);
+        assert_eq!(a.free_count(), 2);
+        // LIFO: most recently freed comes back first.
+        assert_eq!(a.allocate().unwrap(), 3);
+        assert_eq!(a.allocate().unwrap(), 1);
+    }
+
+    #[test]
+    fn allocator_atomic_n_failure() {
+        let mut a = BlockAllocator::new(3);
+        let _ = a.allocate().unwrap(); // 1 left in free_list... wait, 2 left
+        let _ = a.allocate().unwrap();
+        // 1 free, asking for 2 should fail without consuming the 1.
+        assert!(a.allocate_n(2).is_err());
+        assert_eq!(a.free_count(), 1);
+    }
+
+    #[test]
+    fn allocator_peak_tracking() {
+        let mut a = BlockAllocator::new(8);
+        let blocks = a.allocate_n(5).unwrap();
+        assert_eq!(a.peak_in_use(), 5);
+        a.free(&blocks);
+        assert_eq!(a.peak_in_use(), 5); // peak doesn't decrease
+        let _ = a.allocate_n(3).unwrap();
+        assert_eq!(a.peak_in_use(), 5);
+    }
+}

--- a/crates/ferrum-models/src/models/llama_family.rs
+++ b/crates/ferrum-models/src/models/llama_family.rs
@@ -309,12 +309,36 @@ pub struct LlamaFamilyModel<B: Backend> {
     pub scratch: LlamaFamilyScratch<B>,
 
     /// Per-sequence KV caches, one `Vec<KvCache<B>>` of length `num_layers`.
+    ///
+    /// Two layouts overlay this same map:
+    /// - **Contiguous mode** (default): each cache holds its own
+    ///   `[num_kv_heads, capacity, head_dim]` k/v buffers.
+    /// - **Paged mode** (`FERRUM_METAL_PAGED_KV=1`): k/v are unused
+    ///   placeholders; the real K/V live in [`Self::paged_pools`] and
+    ///   the cache's `block_table` + `context_lens` index into them.
     pub kv_caches: HashMap<String, Vec<KvCache<B>>>,
     /// Free pool of pre-allocated KV cache slots. Released caches return
     /// here instead of being dropped, so their device pointers stay valid
     /// across requests — critical for graph capture (pointers baked into
     /// the captured graph would otherwise dangle).
     kv_free_pool: Vec<Vec<KvCache<B>>>,
+
+    // ── Paged-KV multi-seq state (Phase 4) ─────────────────────────────
+    //
+    // Only populated when `FERRUM_METAL_PAGED_KV=1`. When set, every
+    // `kv_caches` entry becomes a "view" into the shared pool: its
+    // `k` / `v` buffers are placeholders; reads / writes go through
+    // `paged_pools[layer].k` / `.v` indexed via the cache's
+    // `block_table`. Multiple cache_ids share the same pool, with
+    // disjoint physical block sets owned by `paged_block_alloc`.
+    //
+    /// Shared K/V pools, one per layer. Sized at model load time for the
+    /// configured `MAX_RUNNING_REQUESTS × max_blocks_per_seq` blocks.
+    pub paged_pools: Option<Vec<(B::Buffer, B::Buffer)>>,
+    /// Block allocator hands out physical block indices from the pool.
+    /// `Mutex` because the engine can call `ensure_kv` / `release_kv`
+    /// from multiple threads in concurrent serving.
+    pub paged_block_alloc: Option<std::sync::Mutex<crate::common::paged_pool::BlockAllocator>>,
 
     // ── Graph capture state (CUDA only; harmless no-op on other backends) ──
     /// Count of eager decode steps run so far. After `GRAPH_WARMUP`, the
@@ -424,6 +448,8 @@ impl<B: Backend> LlamaFamilyModel<B> {
             scratch,
             kv_caches: HashMap::new(),
             kv_free_pool: Vec::new(),
+            paged_pools: None,
+            paged_block_alloc: None,
             graph_warmup: 0,
             graph_capture_failed: false,
         })
@@ -498,6 +524,8 @@ impl<B: Backend> LlamaFamilyModel<B> {
             scratch,
             kv_caches: HashMap::new(),
             kv_free_pool: Vec::new(),
+            paged_pools: None,
+            paged_block_alloc: None,
             graph_warmup: 0,
             graph_capture_failed: false,
         })
@@ -558,35 +586,60 @@ impl<B: Backend> LlamaFamilyModel<B> {
             .unwrap_or(false);
         const PAGED_BLOCK_SIZE: usize = 16;
 
+        // Phase 4 shared-pool sizing. The pool sees ALL concurrent
+        // sequences; per-cache_id state just owns indices into it.
+        let max_seqs = std::env::var("FERRUM_PAGED_MAX_SEQS")
+            .ok()
+            .and_then(|s| s.parse::<usize>().ok())
+            .unwrap_or(16);
+        let max_blocks_per_seq = max.div_ceil(PAGED_BLOCK_SIZE);
+        let total_pool_blocks = max_seqs * max_blocks_per_seq;
+
+        // Lazy-allocate the shared paged pools on the FIRST paged
+        // ensure_kv call. Pools are big — for Llama-8B (8 kv_heads,
+        // head_dim=128) at 16 seqs × 256 blocks × 16 slots = 65536 KV
+        // slots: 65536 * 8 * 128 * 4 = 256 MB per layer × 32 layers
+        // = 8 GB total. Sized this large only because `max_seqs=16`
+        // is the default; lower it via env to shrink.
+        if paged && self.paged_pools.is_none() {
+            let mut pools = Vec::with_capacity(self.cfg.num_layers);
+            for _ in 0..self.cfg.num_layers {
+                let pool_floats = total_pool_blocks * nkv * PAGED_BLOCK_SIZE * hd;
+                pools.push((B::alloc(pool_floats), B::alloc(pool_floats)));
+            }
+            self.paged_pools = Some(pools);
+            self.paged_block_alloc = Some(std::sync::Mutex::new(
+                crate::common::paged_pool::BlockAllocator::new(total_pool_blocks as u32),
+            ));
+        }
+
         // Try pool first — reused buffers have stable device pointers,
         // so a captured decode graph can be replayed for this request too.
         let mut caches = self.kv_free_pool.pop().unwrap_or_else(|| {
             (0..self.cfg.num_layers)
                 .map(|_| {
                     if paged {
-                        let num_blocks = max.div_ceil(PAGED_BLOCK_SIZE);
-                        // Pool: [num_blocks, nkv, block_size, hd] f32.
-                        let pool_floats = num_blocks * nkv * PAGED_BLOCK_SIZE * hd;
-                        // Identity block table: logical i → physical i.
-                        let block_table_init: Vec<u32> = (0..num_blocks as u32).collect();
-                        let mut block_table = B::alloc_u32(num_blocks);
-                        let mut bt_ctx = B::new_context();
-                        B::write_u32(&mut bt_ctx, &mut block_table, &block_table_init);
-                        // context_lens starts at [0]; updated each
-                        // forward via write_u32.
+                        // Paged mode: cache holds metadata only. K/V
+                        // are 1-element placeholders (allocated cheaply
+                        // since Backend::alloc requires a non-zero
+                        // size on most backends). The real data lives
+                        // in `self.paged_pools[li].{k,v}`.
+                        let mut block_table = B::alloc_u32(max_blocks_per_seq);
                         let mut context_lens = B::alloc_u32(1);
+                        let mut bt_ctx = B::new_context();
                         B::write_u32(&mut bt_ctx, &mut context_lens, &[0u32]);
                         B::sync(&mut bt_ctx);
                         KvCache {
-                            k: B::alloc(pool_floats),
-                            v: B::alloc(pool_floats),
+                            k: B::alloc(1),
+                            v: B::alloc(1),
                             len: 0,
-                            capacity: num_blocks * PAGED_BLOCK_SIZE,
+                            capacity: max_blocks_per_seq * PAGED_BLOCK_SIZE,
                             num_kv_heads: nkv,
                             head_dim: hd,
                             block_size: PAGED_BLOCK_SIZE,
                             block_table: Some(block_table),
                             context_lens: Some(context_lens),
+                            paged_block_indices: Vec::new(),
                         }
                     } else {
                         KvCache {
@@ -599,17 +652,52 @@ impl<B: Backend> LlamaFamilyModel<B> {
                             block_size: 0,
                             block_table: None,
                             context_lens: None,
+                            paged_block_indices: Vec::new(),
                         }
                     }
                 })
                 .collect()
         });
+
+        // Allocate physical blocks for THIS cache_id from the shared
+        // pool. We allocate all `max_blocks_per_seq` upfront for
+        // simplicity (matches contig's "pre-alloc to capacity"
+        // semantics); a smarter Phase 4b can grow on demand to save
+        // pool occupancy.
+        if paged {
+            let alloc_arc = self
+                .paged_block_alloc
+                .as_ref()
+                .expect("paged_block_alloc must be initialised when paged=true");
+            let mut alloc = alloc_arc.lock().expect("block alloc poisoned");
+            let block_indices = alloc.allocate_n(max_blocks_per_seq).unwrap_or_else(|e| {
+                panic!(
+                    "paged KV pool exhausted on ensure_kv for cache_id={cache_id:?}: {e}. \
+                     Increase FERRUM_PAGED_MAX_SEQS (currently {max_seqs}) or release \
+                     other cache_ids first.",
+                )
+            });
+            // Write the block table to each layer's cache. All layers
+            // share the same logical→physical mapping for this seq.
+            // Also stash the host-side index list so release_kv can
+            // return them to the allocator without a device readback.
+            let mut padded = block_indices.clone();
+            padded.resize(max_blocks_per_seq, 0);
+            let mut ctx_tmp = B::new_context();
+            for c in caches.iter_mut() {
+                if let Some(bt) = c.block_table.as_mut() {
+                    B::write_u32(&mut ctx_tmp, bt, &padded);
+                }
+                c.paged_block_indices = block_indices.clone();
+            }
+            B::sync(&mut ctx_tmp);
+        }
+
         // Reset logical length; buffers stay. No need to zero the memory —
         // the kv_cache_append writes new K/V in place, and attention only
         // reads up to `cache_len`.
         for c in caches.iter_mut() {
             c.len = 0;
-            // Paged: reset the per-cache context_lens to 0 (live buffer).
             if let Some(cl) = c.context_lens.as_mut() {
                 let mut ctx_tmp = B::new_context();
                 B::write_u32(&mut ctx_tmp, cl, &[0u32]);
@@ -710,6 +798,21 @@ impl<B: Backend> LlamaFamilyModel<B> {
 
         // Grab the per-layer KV cache up front so the deepest fusion can
         // write K/V straight into it.
+        //
+        // Paged mode: also need this layer's shared pool buffers
+        // (self.paged_pools[li]). The pool is a separate field from
+        // kv_caches, so we take a raw pointer to its (k, v) here while
+        // we still hold &mut self, then deref via unsafe inside the
+        // paged dispatch below. Safety: paged_pools is allocated once
+        // and never resized; we don't touch self.paged_pools while the
+        // pointer is in use.
+        let paged_pool_ptr: Option<(*mut B::Buffer, *mut B::Buffer)> =
+            if let Some(pools) = self.paged_pools.as_mut() {
+                let pool = &mut pools[li];
+                Some((&mut pool.0 as *mut _, &mut pool.1 as *mut _))
+            } else {
+                None
+            };
         let caches = self
             .kv_caches
             .get_mut(cache_id)
@@ -746,6 +849,13 @@ impl<B: Backend> LlamaFamilyModel<B> {
                 .as_ref()
                 .expect("paged cache missing block_table");
             let num_blocks_per_seq = cache.capacity / cache.block_size;
+            // Paged mode: K/V live in the shared pool, not cache.k/.v.
+            let (pool_k_ptr, pool_v_ptr) =
+                paged_pool_ptr.expect("paged_pools must be allocated when block_size > 0");
+            // SAFETY: paged_pools is allocated once and never resized;
+            // we do not touch self.paged_pools concurrently.
+            let pool_k = unsafe { &mut *pool_k_ptr };
+            let pool_v = unsafe { &mut *pool_v_ptr };
             B::split_qkv_norm_rope_into_paged_cache(
                 ctx,
                 &self.scratch.qkv_out,
@@ -754,8 +864,8 @@ impl<B: Backend> LlamaFamilyModel<B> {
                 &self.rope.cos,
                 &self.rope.sin,
                 &mut self.scratch.q_head_major,
-                &mut cache.k,
-                &mut cache.v,
+                pool_k,
+                pool_v,
                 bt,
                 tokens,
                 nh,
@@ -916,23 +1026,29 @@ impl<B: Backend> LlamaFamilyModel<B> {
                 .as_mut()
                 .expect("paged cache missing context_lens");
             let num_blocks_per_seq = cache.capacity / cache.block_size;
+            // Paged mode: K/V come from the shared pool.
+            let (pool_k_ptr, pool_v_ptr) =
+                paged_pool_ptr.expect("paged_pools must be allocated when block_size > 0");
+            // SAFETY: same as the write-side above; pool buffers are
+            // allocated-once and never moved while we hold the pointer.
+            let pool_k = unsafe { &*pool_k_ptr };
+            let pool_v = unsafe { &*pool_v_ptr };
             // Single dispatch handles both decode (q_len=1) and causal
             // prefill (q_len>1). The kernel computes per-token causal
             // limit as `context_lens[seq] - (q_len - 1 - q_token_idx)`,
             // so we set context_lens to the FINAL kv_len after this
-            // batch's writes (= cache_len_before + tokens, which is
-            // the new `cache.len` value already updated above).
+            // batch's writes.
             let final_kv_len = cache.len as u32;
             B::write_u32(ctx, cl_buf, &[final_kv_len]);
             B::paged_decode_attention(
                 ctx,
                 &self.scratch.q_head_major,
-                &cache.k,
-                &cache.v,
+                pool_k,
+                pool_v,
                 &mut self.scratch.attn_head_major_out,
                 bt,
                 cl_buf,
-                1, // num_seqs
+                1, // num_seqs (single-seq dispatch; multi-seq is fan-in via forward_layer_batched, Phase 4b)
                 nh,
                 nkv,
                 hd,
@@ -1761,6 +1877,19 @@ impl<B: Backend> LlamaFamilyModel<B> {
             return vec![self.decode_internal(cid, *tok, *pos)];
         }
 
+        // Phase 4a: paged mode falls back to per-item decode_internal
+        // for multi-batch. Phase 4b will add a true batched-paged
+        // dispatch (num_seqs > 1 in one paged_decode_attention call).
+        // The shared pool storage already works correctly under
+        // serialized per-item calls — they just don't share the
+        // GEMM batching benefit yet.
+        if self.paged_pools.is_some() {
+            return batch
+                .iter()
+                .map(|(cid, tok, pos)| self.decode_internal(cid, *tok, *pos))
+                .collect();
+        }
+
         // Ensure all caches exist and scratch is sized for M tokens.
         for (cid, _, _) in batch {
             self.ensure_kv(cid);
@@ -2074,7 +2203,21 @@ impl<B: Backend> DecoderOnlyLLM for LlamaFamilyModel<B> {
 
         const WARMUP_CACHE: &str = "__ferrum_warmup__";
         let _ = self.prefill_internal(WARMUP_CACHE, &[0u32]);
-        if let Some(caches) = self.kv_caches.remove(WARMUP_CACHE) {
+        // Release via the same path as `release` so paged blocks
+        // return to the shared allocator. Otherwise warmup leaks
+        // 256 blocks (the full per-seq quota) into the pool.
+        if let Some(mut caches) = self.kv_caches.remove(WARMUP_CACHE) {
+            if let Some(alloc_arc) = self.paged_block_alloc.as_ref() {
+                let mut alloc = alloc_arc.lock().expect("block alloc poisoned");
+                if let Some(c0) = caches.first() {
+                    if !c0.paged_block_indices.is_empty() {
+                        alloc.free(&c0.paged_block_indices);
+                    }
+                }
+                for c in caches.iter_mut() {
+                    c.paged_block_indices.clear();
+                }
+            }
             self.kv_free_pool.push(caches);
         }
     }
@@ -2137,7 +2280,25 @@ impl<B: Backend> DecoderOnlyLLM for LlamaFamilyModel<B> {
 
         // Return the cache's buffers to the free pool instead of dropping.
         // Pointers stay stable for the next request's captured graph.
-        if let Some(caches) = self.kv_caches.remove(cache_id) {
+        // Paged mode: also free the cache's blocks back to the shared
+        // allocator so other sequences can reuse them.
+        if let Some(mut caches) = self.kv_caches.remove(cache_id) {
+            if let Some(alloc_arc) = self.paged_block_alloc.as_ref() {
+                let mut alloc = alloc_arc.lock().expect("block alloc poisoned");
+                // All caches share the same block_indices set (one per
+                // cache_id), so freeing once via the first layer's cache
+                // is enough.
+                if let Some(c0) = caches.first() {
+                    if !c0.paged_block_indices.is_empty() {
+                        alloc.free(&c0.paged_block_indices);
+                    }
+                }
+                // Clear the host-side mirror on every layer so a
+                // free-pool reuse re-allocates fresh blocks.
+                for c in caches.iter_mut() {
+                    c.paged_block_indices.clear();
+                }
+            }
             self.kv_free_pool.push(caches);
         }
     }

--- a/crates/ferrum-models/src/models/qwen3_moe.rs
+++ b/crates/ferrum-models/src/models/qwen3_moe.rs
@@ -428,6 +428,7 @@ impl<B: Backend> Qwen3MoeModel<B> {
                     block_size: 0,
                     block_table: None,
                     context_lens: None,
+                    paged_block_indices: Vec::new(),
                 })
                 .collect()
         });


### PR DESCRIPTION
## Summary

Replaces PR #70's per-cache_id paged-KV allocation with a shared-pool architecture. Each request's \`KvCache\` becomes metadata-only (block_table + context_lens); actual K/V live in a per-layer shared pool, with physical blocks handed out by a model-wide \`BlockAllocator\`. This is the foundation for true multi-sequence concurrency (Phase 4b lands the batched dispatch).

## What changes

- New module \`ferrum-models::common::paged_pool\` with \`BlockAllocator\` (LIFO free-list, peak tracking, 3 unit tests).
- \`KvCache\` gains \`paged_block_indices: Vec<u32>\` — host-side mirror so release frees blocks without device readback.
- \`LlamaFamilyModel\` gains \`paged_pools\` (per-layer shared K/V) + \`paged_block_alloc\` (single allocator).
- \`ensure_kv\` lazy-allocates the pools, pulls blocks per request, mirrors into block_table buffer.
- \`forward_layer\` reads K/V from shared pool via raw-pointer split-borrow.
- Release path returns blocks to allocator (warmup cache too — otherwise it leaks max_blocks_per_seq per model load).
- \`decode_batch_internal\` paged path falls back to per-item \`decode_internal\` (Phase 4b unlocks batched).

## Correctness

Byte-identical decode parity vs contig:

\`\`\`
prompt: "Once upon a time" (4 tokens), greedy, 24 tokens
contig:        ...in a small village, there was a wise old man who lived in a house with a garden. The garden was
paged shared:  ...same...
\`\`\`

tg128 throughput parity (~31 t/s vs ~32 t/s contig, within noise — single-seq paged is no faster on its own).

Two sequential paged runs (separate processes) succeed at 31.4 / 31.3 t/s — proves warmup-allocate-release cycle works.

## Pool sizing

\`FERRUM_PAGED_MAX_SEQS\` (default 16) × \`ceil(FERRUM_KV_CAPACITY / 16)\` blocks per layer.

For Llama-8B + max_seqs=16 + capacity=4096: 8 GB total. Lower \`max_seqs\` if memory-constrained.

## What's NOT in this PR

- **Multi-seq batched dispatch** (num_seqs > 1 in one paged_decode_attention call). Kernel from PR #68 already supports this; Phase 4b fans in multiple cache_ids in Rust.
- ContinuousBatchScheduler integration.
- 16-concurrent throughput bench (Group B).

## Test plan

- [x] cargo build --workspace --features metal passes
- [x] cargo test --workspace --features metal --release: all pass + 3 new BlockAllocator tests
- [x] Qwen3-8B paged shared pool generates byte-identical text vs contig
- [x] Two sequential paged runs succeed (alloc → free → re-alloc cycle)

Stacks on PR #70 (now in main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)