### PR TITLE
feat: GGUF model support in serve/bench/pull (Group A enabled)

### DIFF
--- a/crates/ferrum-cli/src/commands/bench.rs
+++ b/crates/ferrum-cli/src/commands/bench.rs
@@ -50,30 +50,48 @@ pub struct BenchCommand {
 }
 
 pub async fn execute(cmd: BenchCommand, config: CliConfig) -> Result<()> {
-    let model_id = super::run::resolve_model_alias(&cmd.model);
+    // GGUF short-circuit: skip alias resolution + HF cache lookup when the
+    // model arg is already a `.gguf` path. The engine's executor factory
+    // (registry.rs) detects `.gguf` and routes to GgufLoader. Tokenizer is
+    // auto-discovered next to the gguf file.
+    let (model_id, source) = if super::run::looks_like_gguf_path(&cmd.model) {
+        let gguf_path = std::path::PathBuf::from(&cmd.model);
+        let id = gguf_path
+            .file_stem()
+            .map(|s| s.to_string_lossy().to_string())
+            .unwrap_or_else(|| cmd.model.clone());
+        let src = ferrum_models::source::ResolvedModelSource {
+            original: cmd.model.clone(),
+            local_path: gguf_path,
+            format: ferrum_models::source::ModelFormat::Unknown,
+            from_cache: true,
+        };
+        (id, src)
+    } else {
+        let id = super::run::resolve_model_alias(&cmd.model);
+        let cache_dir = super::run::get_hf_cache_dir(&config);
+        let src = match super::run::find_cached_model(&cache_dir, &id) {
+            Some(source) => source,
+            None => {
+                eprintln!("Downloading model...");
+                let token = std::env::var("HF_TOKEN")
+                    .or_else(|_| std::env::var("HUGGING_FACE_HUB_TOKEN"))
+                    .ok();
+                let downloader = HfDownloader::new(cache_dir.clone(), token)?;
+                let snapshot_path = downloader.download(&id, None).await?;
+                let format = super::run::detect_format(&snapshot_path);
+                ferrum_models::source::ResolvedModelSource {
+                    original: id.clone(),
+                    local_path: snapshot_path,
+                    format,
+                    from_cache: false,
+                }
+            }
+        };
+        (id, src)
+    };
     eprintln!("{}", format!("Ferrum Benchmark - {}", model_id).bold());
     eprintln!("{}", "=".repeat(60).dimmed());
-
-    // Find or download model
-    let cache_dir = super::run::get_hf_cache_dir(&config);
-    let source = match super::run::find_cached_model(&cache_dir, &model_id) {
-        Some(source) => source,
-        None => {
-            eprintln!("Downloading model...");
-            let token = std::env::var("HF_TOKEN")
-                .or_else(|_| std::env::var("HUGGING_FACE_HUB_TOKEN"))
-                .ok();
-            let downloader = HfDownloader::new(cache_dir.clone(), token)?;
-            let snapshot_path = downloader.download(&model_id, None).await?;
-            let format = super::run::detect_format(&snapshot_path);
-            ferrum_models::source::ResolvedModelSource {
-                original: model_id.clone(),
-                local_path: snapshot_path,
-                format,
-                from_cache: false,
-            }
-        }
-    };
 
     unsafe {
         std::env::set_var(
@@ -129,7 +147,7 @@ pub async fn execute(cmd: BenchCommand, config: CliConfig) -> Result<()> {
     // DefaultInferenceEngine (Priority) has stream lifecycle issues with bench.
     let mut engine_config = ferrum_engine::simple_engine_config(model_id.clone(), device);
     engine_config.scheduler.policy = ferrum_types::SchedulingPolicy::ContinuousBatch;
-    let engine = ferrum_engine::create_mvp_engine(engine_config).await?;
+    let engine = ferrum_engine::create_default_engine(engine_config).await?;
 
     let prompt = if cmd.long_context {
         generate_long_prompt()

--- a/crates/ferrum-cli/src/commands/bench.rs
+++ b/crates/ferrum-cli/src/commands/bench.rs
@@ -15,6 +15,7 @@ use ferrum_models::HfDownloader;
 use ferrum_types::{InferenceRequest, Priority, RequestId, Result, SamplingParams};
 use futures::StreamExt;
 use std::collections::HashMap;
+use std::path::PathBuf;
 use std::time::Instant;
 use uuid::Uuid;
 
@@ -51,11 +52,28 @@ pub struct BenchCommand {
 
 pub async fn execute(cmd: BenchCommand, config: CliConfig) -> Result<()> {
     // GGUF short-circuit: skip alias resolution + HF cache lookup when the
-    // model arg is already a `.gguf` path. The engine's executor factory
+    // model arg is already a `.gguf` path OR a registered GGUF alias
+    // (e.g. `qwen3:8b-q4_k_m`). The engine's executor factory
     // (registry.rs) detects `.gguf` and routes to GgufLoader. Tokenizer is
     // auto-discovered next to the gguf file.
-    let (model_id, source) = if super::run::looks_like_gguf_path(&cmd.model) {
-        let gguf_path = std::path::PathBuf::from(&cmd.model);
+    let cache_dir_for_gguf = super::run::get_hf_cache_dir(&config);
+    let resolved_gguf_path: Option<PathBuf> = if super::run::looks_like_gguf_path(&cmd.model) {
+        Some(PathBuf::from(&cmd.model))
+    } else if let Some((repo, filename)) = super::run::resolve_gguf_alias(&cmd.model) {
+        match super::run::find_cached_gguf(&cache_dir_for_gguf, &repo, &filename) {
+            Some(p) => Some(p),
+            None => {
+                eprintln!(
+                    "GGUF alias '{}' not in cache. Run: ferrum pull {}",
+                    cmd.model, cmd.model
+                );
+                return Err(ferrum_types::FerrumError::model("GGUF model not found"));
+            }
+        }
+    } else {
+        None
+    };
+    let (model_id, source) = if let Some(gguf_path) = resolved_gguf_path {
         let id = gguf_path
             .file_stem()
             .map(|s| s.to_string_lossy().to_string())

--- a/crates/ferrum-cli/src/commands/pull.rs
+++ b/crates/ferrum-cli/src/commands/pull.rs
@@ -14,6 +14,102 @@ pub struct PullCommand {
 }
 
 pub async fn execute(cmd: PullCommand, config: CliConfig) -> Result<()> {
+    // GGUF alias path — pulls just the requested quantization plus the
+    // sidecar tokenizer.json so `serve` / `bench` can pick it up. Doing
+    // this BEFORE `resolve_model_alias` keeps GGUF aliases like
+    // `qwen3:8b-q4_k_m` from accidentally falling through to the
+    // safetensors HF repo (`Qwen/Qwen3-8B-Q4_K_M`, which doesn't exist).
+    if let Some((repo, filename)) = super::run::resolve_gguf_alias(&cmd.model) {
+        println!(
+            "{} {} (file: {})",
+            "Pulling GGUF".cyan().bold(),
+            repo,
+            filename
+        );
+        let cache_dir = get_hf_cache_dir(&config);
+        println!("{}", format!("Cache: {}", cache_dir.display()).dimmed());
+        let token = std::env::var("HF_TOKEN")
+            .or_else(|_| std::env::var("HUGGING_FACE_HUB_TOKEN"))
+            .ok();
+        let downloader = HfDownloader::new(cache_dir.clone(), token.clone())?;
+        let gguf_path = match downloader.download_gguf(&repo, None, &filename).await {
+            Ok(path) => path,
+            Err(e) => {
+                eprintln!();
+                eprintln!("{} Failed to pull GGUF: {}", "✗".red().bold(), e);
+                return Err(e);
+            }
+        };
+
+        // Some GGUF repos (e.g. Qwen/Qwen3-*-GGUF) don't host
+        // tokenizer.json. Pull it from the safetensors sibling repo
+        // (`<repo>` minus `-GGUF`) and drop it next to the gguf file so
+        // serve / bench's auto_discover_tokenizer_path picks it up.
+        let snapshot_dir = gguf_path
+            .parent()
+            .map(|p| p.to_path_buf())
+            .unwrap_or_else(|| cache_dir.clone());
+        if !snapshot_dir.join("tokenizer.json").is_file() {
+            if let Some(sibling) = super::run::tokenizer_sibling_repo(&repo) {
+                println!();
+                println!(
+                    "{} tokenizer.json missing in GGUF repo — fetching from {}",
+                    "→".cyan(),
+                    sibling.dimmed()
+                );
+                let dl2 = HfDownloader::new(cache_dir.clone(), token.clone())?;
+                match dl2.download(&sibling, None).await {
+                    Ok(sibling_dir) => {
+                        // Copy tokenizer.json + tokenizer_config.json into
+                        // the GGUF snapshot dir so they live next to the
+                        // gguf file.
+                        for tok_file in [
+                            "tokenizer.json",
+                            "tokenizer_config.json",
+                            "special_tokens_map.json",
+                            "chat_template.json",
+                        ] {
+                            let src = sibling_dir.join(tok_file);
+                            if src.is_file() {
+                                let dst = snapshot_dir.join(tok_file);
+                                if let Err(e) = std::fs::copy(&src, &dst) {
+                                    eprintln!(
+                                        "{} could not copy {}: {}",
+                                        "⚠".yellow(),
+                                        tok_file,
+                                        e
+                                    );
+                                }
+                            }
+                        }
+                        println!(
+                            "{} tokenizer placed at {}",
+                            "✓".green(),
+                            snapshot_dir.display().to_string().dimmed()
+                        );
+                    }
+                    Err(e) => {
+                        eprintln!(
+                            "{} sibling tokenizer pull failed: {} — \
+                             you'll need to provide tokenizer.json manually",
+                            "⚠".yellow().bold(),
+                            e
+                        );
+                    }
+                }
+            }
+        }
+
+        println!();
+        println!("{} Model ready at:", "✓".green().bold());
+        println!("  {}", gguf_path.display());
+        println!();
+        println!("{}", "Run with:".dimmed());
+        println!("  ferrum serve {}", cmd.model.cyan());
+        println!("  ferrum bench {} --concurrency 8", cmd.model.cyan());
+        return Ok(());
+    }
+
     let model_id = resolve_model_alias(&cmd.model);
 
     println!("{} {}", "Pulling".cyan().bold(), model_id);

--- a/crates/ferrum-cli/src/commands/run.rs
+++ b/crates/ferrum-cli/src/commands/run.rs
@@ -412,6 +412,104 @@ pub fn looks_like_gguf_path(model: &str) -> bool {
         && p.is_file()
 }
 
+/// Resolve a GGUF alias to a `(repo, filename)` pair if recognised. Returns
+/// `None` for non-GGUF aliases — callers fall through to
+/// [`resolve_model_alias`].
+///
+/// These map ergonomic aliases to the `<org>/<name>-GGUF` repos the
+/// community publishes Q4_K_M quantizations under. The filename component
+/// pins a specific quantization; users wanting other quants pass the path
+/// directly or extend this table.
+pub fn resolve_gguf_alias(name: &str) -> Option<(String, String)> {
+    // Aliases verified by probing the HF API on 2026-05-01. Quantization
+    // availability differs per repo — Qwen/Qwen3-{0.6B,1.7B}-GGUF only
+    // host Q8_0; 4B / 8B / 30B-A3B host Q4_K_M.
+    match name.to_lowercase().as_str() {
+        // Group A bench targets — same models the bench scripts use for
+        // single-request PP/TG comparison vs llama.cpp / mistral.rs.
+        "qwen3:8b-q4_k_m" => Some((
+            "Qwen/Qwen3-8B-GGUF".to_string(),
+            "Qwen3-8B-Q4_K_M.gguf".to_string(),
+        )),
+        "qwen3:4b-q4_k_m" => Some((
+            "Qwen/Qwen3-4B-GGUF".to_string(),
+            "Qwen3-4B-Q4_K_M.gguf".to_string(),
+        )),
+        "qwen3:1.7b" | "qwen3:1.7b-q8_0" => Some((
+            "Qwen/Qwen3-1.7B-GGUF".to_string(),
+            "Qwen3-1.7B-Q8_0.gguf".to_string(),
+        )),
+        "qwen3:0.6b-gguf" | "qwen3:0.6b-q8_0" => Some((
+            "Qwen/Qwen3-0.6B-GGUF".to_string(),
+            "Qwen3-0.6B-Q8_0.gguf".to_string(),
+        )),
+        "qwen3-moe:30b-a3b-q4_k_m" | "qwen3:30b-a3b-q4_k_m" => Some((
+            "Qwen/Qwen3-30B-A3B-GGUF".to_string(),
+            "Qwen3-30B-A3B-Q4_K_M.gguf".to_string(),
+        )),
+        "llama3.1:8b-q4_k_m" => Some((
+            "bartowski/Meta-Llama-3.1-8B-Instruct-GGUF".to_string(),
+            "Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf".to_string(),
+        )),
+        "llama3.2:3b-q4_k_m" => Some((
+            "bartowski/Llama-3.2-3B-Instruct-GGUF".to_string(),
+            "Llama-3.2-3B-Instruct-Q4_K_M.gguf".to_string(),
+        )),
+        "llama3.2:1b-q4_k_m" => Some((
+            "bartowski/Llama-3.2-1B-Instruct-GGUF".to_string(),
+            "Llama-3.2-1B-Instruct-Q4_K_M.gguf".to_string(),
+        )),
+        _ => None,
+    }
+}
+
+/// For GGUF aliases whose repo lacks a tokenizer.json, return the sibling
+/// safetensors repo where the tokenizer should be pulled from. Convention:
+/// strip a trailing `-GGUF` from the repo name. Returns `None` for repos
+/// that already host their own tokenizer (e.g. bartowski/*).
+pub fn tokenizer_sibling_repo(gguf_repo: &str) -> Option<String> {
+    if let Some(stripped) = gguf_repo.strip_suffix("-GGUF") {
+        Some(stripped.to_string())
+    } else {
+        None
+    }
+}
+
+/// Locate a previously-pulled GGUF file in the HF cache.
+///
+/// Mirrors `find_cached_model` but returns the path to the specific
+/// `.gguf` file (not a directory). Looks up `refs/main` to find the
+/// active snapshot, falls back to the first snapshot containing the
+/// requested file. Returns `None` if neither finds it.
+pub fn find_cached_gguf(cache_dir: &PathBuf, repo: &str, filename: &str) -> Option<PathBuf> {
+    let repo_dir = cache_dir
+        .join("hub")
+        .join(format!("models--{}", repo.replace('/', "--")));
+    let snapshots_dir = repo_dir.join("snapshots");
+
+    let ref_main = repo_dir.join("refs").join("main");
+    if let Ok(rev) = std::fs::read_to_string(&ref_main) {
+        let rev = rev.trim();
+        if !rev.is_empty() {
+            let candidate = snapshots_dir.join(rev).join(filename);
+            if candidate.is_file() {
+                return Some(candidate);
+            }
+        }
+    }
+
+    if let Ok(entries) = std::fs::read_dir(&snapshots_dir) {
+        for entry in entries.flatten() {
+            let candidate = entry.path().join(filename);
+            if candidate.is_file() {
+                return Some(candidate);
+            }
+        }
+    }
+
+    None
+}
+
 pub fn select_device(backend: &str) -> ferrum_types::Device {
     match backend.to_lowercase().as_str() {
         "cpu" => ferrum_types::Device::CPU,

--- a/crates/ferrum-cli/src/commands/run.rs
+++ b/crates/ferrum-cli/src/commands/run.rs
@@ -150,7 +150,7 @@ pub async fn execute(cmd: RunCommand, config: CliConfig) -> Result<()> {
 
     // Create engine
     let engine_config = ferrum_engine::simple_engine_config(model_id.clone(), device);
-    let engine = ferrum_engine::create_mvp_engine(engine_config).await?;
+    let engine = ferrum_engine::create_default_engine(engine_config).await?;
 
     // Print ready message
     eprintln!();

--- a/crates/ferrum-cli/src/commands/serve.rs
+++ b/crates/ferrum-cli/src/commands/serve.rs
@@ -70,27 +70,56 @@ pub async fn execute(cmd: ServeCommand, config: CliConfig) -> Result<()> {
         .or(config.models.default_model.clone())
         .unwrap_or_else(|| "TinyLlama/TinyLlama-1.1B-Chat-v1.0".to_string());
 
-    let model_id = resolve_model_alias(&model_name);
+    // GGUF short-circuit: if the user passed a `.gguf` file path directly,
+    // skip alias / HF cache resolution and ConfigManager::load_from_path
+    // (which expects an HF safetensors directory layout). The engine's
+    // CandleExecutorFactory + HuggingFaceTokenizerFactory both detect
+    // `.gguf` and route to GgufLoader + sibling-tokenizer auto-discovery.
+    let gguf_path: Option<PathBuf> = if super::run::looks_like_gguf_path(&model_name) {
+        Some(PathBuf::from(&model_name))
+    } else {
+        None
+    };
+
+    let model_id = if let Some(p) = gguf_path.as_ref() {
+        // Use the GGUF stem as the OpenAI model id — the user sees this
+        // back in /v1/models responses + chat completion `model` field.
+        p.file_stem()
+            .map(|s| s.to_string_lossy().to_string())
+            .unwrap_or_else(|| model_name.clone())
+    } else {
+        resolve_model_alias(&model_name)
+    };
     println!("{} {}", "Model:".dimmed(), model_id.cyan());
 
     let host = host.unwrap_or_else(|| config.server.host.clone());
     let port = port.unwrap_or(config.server.port);
 
-    // Find cached model
-    let cache_dir = get_hf_cache_dir(&config);
-    let source = match find_cached_model(&cache_dir, &model_id) {
-        Some(source) => {
-            println!("{} {}", "Path:".dimmed(), source.local_path.display());
-            source
+    let source: ferrum_models::source::ResolvedModelSource = if let Some(p) = gguf_path.clone() {
+        println!("{} {}", "Path:".dimmed(), p.display());
+        ferrum_models::source::ResolvedModelSource {
+            original: model_name.clone(),
+            local_path: p,
+            format: ModelFormat::Unknown, // GGUF — handled by engine
+            from_cache: true,
         }
-        None => {
-            eprintln!(
-                "{} Model '{}' not found. Run: ferrum pull {}",
-                "Error:".red().bold(),
-                model_id,
-                model_name
-            );
-            return Err(ferrum_types::FerrumError::model("Model not found"));
+    } else {
+        // Find cached model
+        let cache_dir = get_hf_cache_dir(&config);
+        match find_cached_model(&cache_dir, &model_id) {
+            Some(source) => {
+                println!("{} {}", "Path:".dimmed(), source.local_path.display());
+                source
+            }
+            None => {
+                eprintln!(
+                    "{} Model '{}' not found. Run: ferrum pull {}",
+                    "Error:".red().bold(),
+                    model_id,
+                    model_name
+                );
+                return Err(ferrum_types::FerrumError::model("Model not found"));
+            }
         }
     };
 
@@ -104,8 +133,14 @@ pub async fn execute(cmd: ServeCommand, config: CliConfig) -> Result<()> {
     // the engine builder picks it up. Validates that the draft model is
     // actually cached before the target load kicks in.
     if let Some(ref draft_name) = spec_draft {
+        if gguf_path.is_some() {
+            return Err(ferrum_types::FerrumError::unsupported(
+                "Speculative decoding is not yet wired through the GGUF path",
+            ));
+        }
         let draft_id = resolve_model_alias(draft_name);
         println!("{} {}", "Draft model:".dimmed(), draft_id.cyan());
+        let cache_dir = get_hf_cache_dir(&config);
         let draft_source = find_cached_model(&cache_dir, &draft_id).ok_or_else(|| {
             eprintln!(
                 "{} Draft model '{}' not in HF cache. Run: ferrum pull {}",
@@ -131,13 +166,21 @@ pub async fn execute(cmd: ServeCommand, config: CliConfig) -> Result<()> {
     let device = select_device();
     println!("{} {:?}", "Device:".dimmed(), device);
 
-    // Detect architecture to choose engine type
+    // Detect architecture to choose engine type. For GGUF we skip
+    // ConfigManager::load_from_path (which expects HF safetensors layout)
+    // and route directly to the continuous-batching LLM engine — the
+    // engine's CandleExecutorFactory branches to GgufLoader internally.
     println!();
-    let mut config_manager = ferrum_models::ConfigManager::new();
-    let model_def = config_manager.load_from_path(&source.local_path).await?;
+    let arch_for_dispatch: Option<ferrum_models::Architecture> = if gguf_path.is_some() {
+        None
+    } else {
+        let mut config_manager = ferrum_models::ConfigManager::new();
+        let model_def = config_manager.load_from_path(&source.local_path).await?;
+        Some(model_def.architecture)
+    };
 
-    let engine: Arc<dyn InferenceEngine + Send + Sync> = match model_def.architecture {
-        ferrum_models::Architecture::Clip => {
+    let engine: Arc<dyn InferenceEngine + Send + Sync> = match arch_for_dispatch {
+        Some(ferrum_models::Architecture::Clip) => {
             println!("{}", "Initializing CLIP embedding engine...".dimmed());
             let candle_device = candle_core::Device::Cpu;
             let executor = ferrum_models::ClipModelExecutor::from_path(
@@ -152,7 +195,7 @@ pub async fn execute(cmd: ServeCommand, config: CliConfig) -> Result<()> {
                     .with_tokenizer(tokenizer),
             )
         }
-        ferrum_models::Architecture::Whisper => {
+        Some(ferrum_models::Architecture::Whisper) => {
             println!("{}", "Initializing Whisper ASR engine...".dimmed());
             let candle_device = to_candle_device(&device);
             let executor = ferrum_models::WhisperModelExecutor::from_path(
@@ -168,7 +211,7 @@ pub async fn execute(cmd: ServeCommand, config: CliConfig) -> Result<()> {
                 ),
             )
         }
-        ferrum_models::Architecture::Qwen3TTS => {
+        Some(ferrum_models::Architecture::Qwen3TTS) => {
             let n_slots = tts_slots.max(1);
             println!(
                 "{} ({} slot{})",
@@ -205,7 +248,7 @@ pub async fn execute(cmd: ServeCommand, config: CliConfig) -> Result<()> {
             let mut engine_config = ferrum_engine::simple_engine_config(model_id.clone(), device);
             engine_config.scheduler.policy = ferrum_types::SchedulingPolicy::ContinuousBatch;
             engine_config.kv_cache.cache_type = ferrum_types::KvCacheType::Paged;
-            let engine = ferrum_engine::create_mvp_engine(engine_config).await?;
+            let engine = ferrum_engine::create_default_engine(engine_config).await?;
             Arc::from(engine)
         }
     };

--- a/crates/ferrum-cli/src/commands/serve.rs
+++ b/crates/ferrum-cli/src/commands/serve.rs
@@ -70,13 +70,29 @@ pub async fn execute(cmd: ServeCommand, config: CliConfig) -> Result<()> {
         .or(config.models.default_model.clone())
         .unwrap_or_else(|| "TinyLlama/TinyLlama-1.1B-Chat-v1.0".to_string());
 
-    // GGUF short-circuit: if the user passed a `.gguf` file path directly,
-    // skip alias / HF cache resolution and ConfigManager::load_from_path
-    // (which expects an HF safetensors directory layout). The engine's
-    // CandleExecutorFactory + HuggingFaceTokenizerFactory both detect
-    // `.gguf` and route to GgufLoader + sibling-tokenizer auto-discovery.
+    // GGUF short-circuit: if the user passed a `.gguf` file path directly OR
+    // an alias resolving to a GGUF (e.g. `qwen3:8b-q4_k_m`), look up the
+    // file in the HF cache (or accept the path) and skip
+    // `ConfigManager::load_from_path` (which expects an HF safetensors
+    // directory). The engine's CandleExecutorFactory +
+    // HuggingFaceTokenizerFactory both detect `.gguf` and route to
+    // GgufLoader + sibling-tokenizer auto-discovery.
+    let cache_dir_for_gguf = get_hf_cache_dir(&config);
     let gguf_path: Option<PathBuf> = if super::run::looks_like_gguf_path(&model_name) {
         Some(PathBuf::from(&model_name))
+    } else if let Some((repo, filename)) = super::run::resolve_gguf_alias(&model_name) {
+        match super::run::find_cached_gguf(&cache_dir_for_gguf, &repo, &filename) {
+            Some(p) => Some(p),
+            None => {
+                eprintln!(
+                    "{} GGUF alias '{}' not in cache. Run: ferrum pull {}",
+                    "Error:".red().bold(),
+                    model_name,
+                    model_name
+                );
+                return Err(ferrum_types::FerrumError::model("GGUF model not found"));
+            }
+        }
     } else {
         None
     };

--- a/crates/ferrum-engine/src/lib.rs
+++ b/crates/ferrum-engine/src/lib.rs
@@ -127,13 +127,6 @@ pub async fn create_default_engine(
     create_engine(config).await
 }
 
-/// Create MVP engine - alias for create_default_engine
-pub async fn create_mvp_engine(
-    config: EngineConfig,
-) -> Result<Box<dyn InferenceEngineInterface + Send + Sync>> {
-    create_default_engine(config).await
-}
-
 /// Create a simple engine config from minimal parameters
 pub fn simple_engine_config(
     model_id: impl Into<ferrum_types::ModelId>,

--- a/crates/ferrum-engine/src/registry.rs
+++ b/crates/ferrum-engine/src/registry.rs
@@ -511,7 +511,24 @@ impl ComponentFactory<Arc<dyn Tokenizer + Send + Sync>> for HuggingFaceTokenizer
             .or_else(|| std::env::var("FERRUM_MODEL_PATH").ok());
 
         if let Some(model_path) = tokenizer_path {
-            let tokenizer_file = std::path::Path::new(&model_path).join("tokenizer.json");
+            let path = std::path::Path::new(&model_path);
+            // GGUF path: model_path is a file. Auto-discover a sibling
+            // tokenizer.json (or the convention used by ~/ferrum-bench).
+            let tokenizer_file = if ferrum_models::gguf_engine_loader::is_gguf_path(&model_path) {
+                ferrum_models::gguf_engine_loader::auto_discover_tokenizer_path(path).ok_or_else(
+                    || {
+                        FerrumError::tokenizer(format!(
+                            "Could not find tokenizer.json for {} — \
+                             place it next to the .gguf file or in a \
+                             sibling tokenizers/ directory",
+                            path.display()
+                        ))
+                    },
+                )?
+            } else {
+                // HF safetensors layout: model_path is a directory.
+                path.join("tokenizer.json")
+            };
 
             if tokenizer_file.exists() {
                 info!("Loading HuggingFace tokenizer from: {:?}", tokenizer_file);
@@ -900,6 +917,22 @@ impl ComponentFactory<Arc<dyn ModelExecutor + Send + Sync>> for CandleExecutorFa
         };
 
         info!("Loading Candle model from: {}", model_path);
+
+        // GGUF fast path — `model_path` points directly at a `.gguf` file.
+        // Bypass the safetensors `ConfigManager::load_from_path` (which
+        // expects an HF directory layout) and route through ferrum's own
+        // GgufLoader to build a `LlamaFamilyModel` / `Qwen3MoeModel`. The
+        // resulting `DecoderOnlyLLM` plugs into `LlmExecutor` exactly like
+        // the safetensors path, so the rest of the engine is unchanged.
+        if ferrum_models::gguf_engine_loader::is_gguf_path(&model_path) {
+            info!("  Detected GGUF file — using GgufLoader path");
+            let (llm, model_info) = ferrum_models::gguf_engine_loader::load_gguf_decoder_with_info(
+                std::path::Path::new(&model_path),
+                &config.device,
+                config.engine_config.model.model_id.clone(),
+            )?;
+            return Ok(Arc::new(ferrum_models::LlmExecutor::new(llm, model_info)));
+        }
 
         // Load model definition
         let mut config_manager = ferrum_models::ConfigManager::new();

--- a/crates/ferrum-engine/tests/qwen_concurrency.rs
+++ b/crates/ferrum-engine/tests/qwen_concurrency.rs
@@ -1,4 +1,4 @@
-use ferrum_engine::{create_mvp_engine, simple_engine_config};
+use ferrum_engine::{create_default_engine, simple_engine_config};
 use ferrum_interfaces::InferenceEngine;
 use ferrum_types::{Device, InferenceRequest, SamplingParams};
 use std::{path::Path, sync::Arc, time::Duration};
@@ -29,7 +29,7 @@ async fn qwen_25_05b_requests_are_serialized_for_correctness() {
     config.scheduler.max_running_requests = 4;
 
     let engine: Arc<dyn InferenceEngine + Send + Sync> =
-        Arc::from(create_mvp_engine(config).await.expect("create engine"));
+        Arc::from(create_default_engine(config).await.expect("create engine"));
 
     let monitor_engine = engine.clone();
     let monitor = tokio::spawn(async move {

--- a/crates/ferrum-models/src/gguf_engine_loader.rs
+++ b/crates/ferrum-models/src/gguf_engine_loader.rs
@@ -1,0 +1,267 @@
+//! GGUF → engine glue. Lets `ferrum serve` / `ferrum bench` accept a
+//! `.gguf` path (or an alias resolving to one) and produce a
+//! `Box<dyn DecoderOnlyLLM>` that the existing `LlmExecutor` +
+//! `ContinuousBatchEngine` can drive.
+//!
+//! Mirrors the runtime-construction half of `ferrum-cli`'s `run_gguf`
+//! path so the ergonomic CLI flow and the engine's executor flow share
+//! one code path for "load LlamaFamilyModel<B> from a GGUF file".
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use ferrum_quantization::gguf::{GgufFile, GgufLoader};
+use ferrum_types::{DataType, Device, FerrumError, ModelId, ModelInfo, ModelType, Result};
+
+use crate::common::DecoderOnlyLLM;
+use crate::models::llama_family::{LlamaFamilyConfig, LlamaFamilyModel};
+use crate::models::Qwen3MoeModel;
+use crate::moe_config::Qwen3MoeConfig;
+
+/// Returns `true` if the path looks like a GGUF model (ends in `.gguf`
+/// case-insensitively). Used by the engine factory to branch model loading.
+pub fn is_gguf_path(path: &str) -> bool {
+    Path::new(path)
+        .extension()
+        .map(|e| e.eq_ignore_ascii_case("gguf"))
+        .unwrap_or(false)
+}
+
+/// Best-effort tokenizer auto-discovery for a GGUF file.
+///
+/// Search order (first match wins):
+/// 1. `<gguf-stem>.tokenizer.json` next to the GGUF (e.g.
+///    `Qwen3-8B-Q4_K_M.tokenizer.json`).
+/// 2. `tokenizer.json` next to the GGUF.
+/// 3. `<stem-without-quant>.tokenizer.json` in a sibling
+///    `../tokenizers/` directory (matches the `~/ferrum-bench/{models,tokenizers}/`
+///    layout used by the Group A benchmark scripts).
+///
+/// Returns `None` if nothing is found — caller should surface a clear
+/// error. We keep this in `ferrum-models` (not `ferrum-cli`) because both
+/// the CLI and the engine's tokenizer factory need it.
+pub fn auto_discover_tokenizer_path(gguf_path: &Path) -> Option<PathBuf> {
+    let dir = gguf_path.parent()?;
+    if let Some(stem) = gguf_path.file_stem() {
+        let candidate = dir.join(format!("{}.tokenizer.json", stem.to_string_lossy()));
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+    let bare = dir.join("tokenizer.json");
+    if bare.is_file() {
+        return Some(bare);
+    }
+    // Sibling tokenizers/ directory — strip a trailing -Q*_K_M / -Q*_0 / -Q*_1
+    // quant suffix from the stem to find the canonical tokenizer.
+    if let Some(stem) = gguf_path.file_stem().and_then(|s| s.to_str()) {
+        let base = strip_quant_suffix(stem);
+        if let Some(parent) = dir.parent() {
+            let sibling = parent
+                .join("tokenizers")
+                .join(format!("{base}.tokenizer.json"));
+            if sibling.is_file() {
+                return Some(sibling);
+            }
+        }
+    }
+    None
+}
+
+fn strip_quant_suffix(stem: &str) -> &str {
+    // Strip e.g. "-Q4_K_M", "-Q5_K_M", "-Q8_0", "-Q4_0", "-IQ4_NL", "-Q3_K_L"
+    // Anything after the last `-Q` that matches the pattern. Conservative —
+    // only strips when the suffix is short and looks quant-y.
+    if let Some(idx) = stem.rfind("-Q") {
+        let suffix = &stem[idx + 1..];
+        let upper_alphanum = suffix
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_');
+        if upper_alphanum && suffix.len() <= 8 {
+            return &stem[..idx];
+        }
+    }
+    if let Some(idx) = stem.rfind("-IQ") {
+        let suffix = &stem[idx + 1..];
+        let upper_alphanum = suffix
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_');
+        if upper_alphanum && suffix.len() <= 8 {
+            return &stem[..idx];
+        }
+    }
+    stem
+}
+
+/// Load a GGUF model file as a `Box<dyn DecoderOnlyLLM>` ready for
+/// `LlmExecutor` / `ContinuousBatchEngine`. Auto-detects MoE
+/// (qwen3moe) vs dense (qwen3 / qwen2 / llama / mistral) from the
+/// GGUF metadata.
+///
+/// `device` selects the backend:
+///   - [`Device::CPU`] → `LlamaFamilyModel<CpuBackend>` / `Qwen3MoeModel<CpuBackend>`
+///   - [`Device::Metal`] → same on `MetalBackend` (also registers the
+///     mmap with the Metal weight cache so subsequent `B::load_quant*`
+///     calls wrap weights as zero-copy `MTLBuffer`s — see
+///     `register_gguf_mmap` in ferrum-kernels).
+///
+/// CUDA is not currently wired here — the GGUF Q4_K_M decode path on
+/// CUDA still goes through candle's `quantized_*` modules in
+/// `gguf_runtime.rs`. Add a CUDA branch below when we have native
+/// CUDA Q4_K_M kernels in `ferrum-kernels`.
+pub fn load_gguf_decoder(gguf_path: &Path, device: &Device) -> Result<Box<dyn DecoderOnlyLLM>> {
+    let (llm, _info) = load_gguf_decoder_with_info(
+        gguf_path,
+        device,
+        ModelId::new(gguf_path.display().to_string()),
+    )?;
+    Ok(llm)
+}
+
+/// Same as [`load_gguf_decoder`], but also returns a [`ModelInfo`] derived
+/// from the GGUF metadata — needed by the engine's `LlmExecutor`.
+pub fn load_gguf_decoder_with_info(
+    gguf_path: &Path,
+    device: &Device,
+    model_id: ModelId,
+) -> Result<(Box<dyn DecoderOnlyLLM>, ModelInfo)> {
+    let gguf = GgufFile::open(gguf_path)
+        .map_err(|e| FerrumError::model(format!("GgufFile::open {}: {e}", gguf_path.display())))?;
+    let arch = gguf
+        .architecture()
+        .map_err(|e| FerrumError::model(format!("read GGUF arch: {e}")))?
+        .to_string();
+    let is_moe = arch == "qwen3moe";
+
+    let dense_cfg = if is_moe {
+        None
+    } else {
+        Some(LlamaFamilyConfig::from_gguf(&gguf)?)
+    };
+    let moe_cfg = if is_moe {
+        Some(Qwen3MoeConfig::from_gguf(&gguf)?)
+    } else {
+        None
+    };
+
+    // Build a ModelInfo for the engine's LlmExecutor. The fields here drive
+    // memory estimation + OpenAI /v1/models responses; the inference hot path
+    // doesn't read them.
+    let base_cfg = if let Some(c) = dense_cfg.as_ref() {
+        c.clone()
+    } else {
+        moe_cfg.as_ref().unwrap().base.clone()
+    };
+    let model_type = match arch.as_str() {
+        "qwen3" | "qwen3moe" | "qwen2" | "qwen" => ModelType::Qwen,
+        "llama" => ModelType::Llama,
+        "mistral" => ModelType::Mistral,
+        other => ModelType::Custom(other.to_string()),
+    };
+    let model_info = ModelInfo {
+        model_id,
+        model_type,
+        num_parameters: 0,
+        hidden_size: base_cfg.hidden_size,
+        num_layers: base_cfg.num_layers,
+        num_heads: base_cfg.num_heads,
+        num_kv_heads: base_cfg.num_kv_heads,
+        vocab_size: base_cfg.vocab_size,
+        max_sequence_length: base_cfg.max_seq_len,
+        dtype: DataType::FP32,
+        device: device.clone(),
+        version: None,
+        license: None,
+        metadata: std::collections::HashMap::new(),
+    };
+
+    let gguf_arc = Arc::new(gguf);
+
+    let llm: Box<dyn DecoderOnlyLLM> = match device {
+        Device::CPU => {
+            use ferrum_kernels::backend::cpu::CpuBackend;
+            let loader = GgufLoader::<CpuBackend>::from_file(gguf_arc.clone());
+            if let Some(mc) = moe_cfg {
+                let model = Qwen3MoeModel::<CpuBackend>::new(mc, &loader, &gguf_arc)?;
+                Box::new(model)
+            } else {
+                let dc = dense_cfg.unwrap();
+                let model = LlamaFamilyModel::<CpuBackend>::new(dc, &loader)?;
+                Box::new(model)
+            }
+        }
+        #[cfg(any(target_os = "macos", target_os = "ios"))]
+        Device::Metal => {
+            #[cfg(feature = "metal")]
+            {
+                use ferrum_kernels::backend::metal::MetalBackend;
+                // Wire the GGUF mmap into the Metal weight loader so subsequent
+                // `B::load_quant_*` calls produce zero-copy MTLBuffers. CRITICAL
+                // on a 32 GB Mac for 30B-A3B Q4_K_M (saves ~17 GB resident).
+                ferrum_kernels::backend::metal::register_gguf_mmap(
+                    gguf_arc.mmap_bytes(),
+                    gguf_arc.clone(),
+                )
+                .map_err(|e| FerrumError::model(format!("register_gguf_mmap: {e}")))?;
+                let loader = GgufLoader::<MetalBackend>::from_file(gguf_arc.clone());
+                if let Some(mc) = moe_cfg {
+                    let model = Qwen3MoeModel::<MetalBackend>::new(mc, &loader, &gguf_arc)?;
+                    Box::new(model)
+                } else {
+                    let dc = dense_cfg.unwrap();
+                    let model = LlamaFamilyModel::<MetalBackend>::new(dc, &loader)?;
+                    Box::new(model)
+                }
+            }
+            #[cfg(not(feature = "metal"))]
+            {
+                return Err(FerrumError::device(
+                    "Metal device requested but `metal` feature not enabled",
+                ));
+            }
+        }
+        Device::CUDA(_) => {
+            return Err(FerrumError::unsupported(
+                "GGUF decoder loading on CUDA is not yet wired through the engine — \
+                 use --features cuda with the safetensors path, or fall back to \
+                 `ferrum run <path.gguf>` which uses candle's quantized_* modules.",
+            ));
+        }
+        other => {
+            return Err(FerrumError::device(format!(
+                "GGUF decoder loading does not support device {other:?}"
+            )));
+        }
+    };
+
+    Ok((llm, model_info))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn gguf_path_detected() {
+        assert!(is_gguf_path("foo.gguf"));
+        assert!(is_gguf_path("/abs/path/Qwen3-8B-Q4_K_M.GGUF"));
+        assert!(!is_gguf_path("config.json"));
+        assert!(!is_gguf_path("model.safetensors"));
+        assert!(!is_gguf_path(""));
+    }
+
+    #[test]
+    fn quant_suffix_stripped() {
+        assert_eq!(strip_quant_suffix("Qwen3-8B-Q4_K_M"), "Qwen3-8B");
+        assert_eq!(
+            strip_quant_suffix("Meta-Llama-3.1-8B-Instruct-Q4_K_M"),
+            "Meta-Llama-3.1-8B-Instruct"
+        );
+        assert_eq!(strip_quant_suffix("Qwen3-30B-A3B-Q5_K_M"), "Qwen3-30B-A3B");
+        assert_eq!(strip_quant_suffix("Qwen3-8B-IQ4_NL"), "Qwen3-8B");
+        // No quant suffix — unchanged
+        assert_eq!(strip_quant_suffix("Qwen3-8B"), "Qwen3-8B");
+        // Quirky names with `-Q` mid-string but no trailing quant pattern
+        assert_eq!(strip_quant_suffix("My-Model"), "My-Model");
+    }
+}

--- a/crates/ferrum-models/src/hf_download.rs
+++ b/crates/ferrum-models/src/hf_download.rs
@@ -79,6 +79,110 @@ impl HfDownloader {
         })
     }
 
+    /// Download a single GGUF file (plus tokenizer / config files) from a
+    /// HuggingFace repo. Returns the absolute path to the downloaded
+    /// `.gguf` file in the snapshot directory.
+    ///
+    /// Use this for GGUF aliases like `qwen3:8b-q4_k_m` where the repo
+    /// (e.g. `Qwen/Qwen3-8B-GGUF`) hosts many quantizations and we only
+    /// want one. The accompanying tokenizer files (tokenizer.json,
+    /// tokenizer_config.json, special_tokens_map.json) are pulled along
+    /// so that `auto_discover_tokenizer_path` finds them next to the
+    /// GGUF file at serve / bench time.
+    pub async fn download_gguf(
+        &self,
+        model_id: &str,
+        revision: Option<&str>,
+        gguf_filename: &str,
+    ) -> Result<PathBuf> {
+        let revision = revision.unwrap_or("main");
+        let model_cache_name = format!("models--{}", model_id.replace('/', "--"));
+        let model_dir = self.cache_dir.join("hub").join(&model_cache_name);
+        let snapshots_dir = model_dir.join("snapshots");
+        let blobs_dir = model_dir.join("blobs");
+        let refs_dir = model_dir.join("refs");
+        fs::create_dir_all(&snapshots_dir).await?;
+        fs::create_dir_all(&blobs_dir).await?;
+        fs::create_dir_all(&refs_dir).await?;
+
+        let files = self.list_files(model_id, revision).await?;
+        let gguf_lower = gguf_filename.to_ascii_lowercase();
+        let files_to_download: Vec<_> = files
+            .iter()
+            .filter(|f| {
+                if f.file_type.as_deref() == Some("directory") {
+                    return false;
+                }
+                let path = f.path.as_str();
+                let path_lower = path.to_ascii_lowercase();
+                // Only the requested GGUF file (case-insensitive).
+                if path_lower == gguf_lower {
+                    return true;
+                }
+                // Plus the small accompanying tokenizer / config metadata
+                // so a downstream `serve` / `bench` finds them next to
+                // the GGUF without a second download.
+                matches!(
+                    path,
+                    "tokenizer.json"
+                        | "tokenizer_config.json"
+                        | "special_tokens_map.json"
+                        | "config.json"
+                        | "generation_config.json"
+                        | "chat_template.json"
+                        | "chat_template.jinja"
+                )
+            })
+            .collect();
+        if !files_to_download
+            .iter()
+            .any(|f| f.path.eq_ignore_ascii_case(gguf_filename))
+        {
+            return Err(FerrumError::model(format!(
+                "GGUF file '{}' not found in repo '{}'",
+                gguf_filename, model_id
+            )));
+        }
+
+        let commit_sha = self.get_commit_sha(model_id, revision).await?;
+        let snapshot_dir = snapshots_dir.join(&commit_sha);
+        fs::create_dir_all(&snapshot_dir).await?;
+
+        let total_size: u64 = files_to_download.iter().filter_map(|f| f.size).sum();
+        println!(
+            "📦 Downloading {} files ({:.2} GB)",
+            files_to_download.len(),
+            total_size as f64 / 1_073_741_824.0
+        );
+
+        for f in &files_to_download {
+            self.download_file_concurrent(
+                model_id,
+                revision,
+                &f.path,
+                f.size.unwrap_or(0),
+                &blobs_dir,
+                &snapshot_dir,
+                None,
+            )
+            .await?;
+        }
+
+        let ref_file = refs_dir.join(revision);
+        fs::write(&ref_file, &commit_sha).await?;
+
+        // Locate the GGUF case-insensitively, since the API may return a
+        // capitalisation that differs from the alias key.
+        let actual_filename = files_to_download
+            .iter()
+            .find(|f| f.path.eq_ignore_ascii_case(gguf_filename))
+            .map(|f| f.path.clone())
+            .unwrap_or_else(|| gguf_filename.to_string());
+
+        let gguf_path = snapshot_dir.join(&actual_filename);
+        Ok(gguf_path)
+    }
+
     /// Download a model from HuggingFace
     pub async fn download(&self, model_id: &str, revision: Option<&str>) -> Result<PathBuf> {
         let revision = revision.unwrap_or("main");

--- a/crates/ferrum-models/src/lib.rs
+++ b/crates/ferrum-models/src/lib.rs
@@ -23,6 +23,7 @@ pub mod common;
 pub mod definition;
 pub mod executor;
 pub mod gguf_config;
+pub mod gguf_engine_loader;
 pub mod gguf_runtime;
 pub mod hf_download;
 pub mod image_processor;


### PR DESCRIPTION
## Summary

Lets `ferrum serve` / `ferrum bench` / `ferrum pull` operate on GGUF
models — both via direct paths and via short aliases. Unblocks Group A
concurrent benchmarking (Llama-3.1-8B, Qwen3-8B, Qwen3-30B-A3B all in
Q4_K_M) which was previously only reachable through the one-shot
`ferrum run <path.gguf>` REPL.

## Stage A — engine accepts GGUF model_path

* New `ferrum-models::gguf_engine_loader`:
  - `is_gguf_path()`, `auto_discover_tokenizer_path()` (looks at sibling
    `.tokenizer.json`, then `tokenizer.json`, then `../tokenizers/<stem-no-quant>.tokenizer.json`)
  - `load_gguf_decoder_with_info()` returns `Box<dyn DecoderOnlyLLM> + ModelInfo`,
    handles dense + MoE, registers GGUF mmap with the Metal weight cache
    for zero-copy MTLBuffers.
* `CandleExecutorFactory::create()` and `HuggingFaceTokenizerFactory::create()`
  in `ferrum-engine/src/registry.rs` detect `.gguf` and route through the
  loader / auto-discovery path.
* `serve.rs` / `bench.rs` short-circuit alias / HF-cache resolution when
  the model arg ends in `.gguf`.

Drops the dead `create_mvp_engine` alias — all CLI entry points now call
`create_default_engine` directly.

## Stage B — GGUF aliases for pull/serve/bench

* `resolve_gguf_alias()` maps short aliases → `(repo, gguf_filename)`:
  - `qwen3:8b-q4_k_m`, `qwen3:4b-q4_k_m`, `qwen3-moe:30b-a3b-q4_k_m`
  - `qwen3:0.6b-q8_0`, `qwen3:1.7b-q8_0` (these repos only host Q8_0)
  - `llama3.1:8b-q4_k_m`, `llama3.2:{1b,3b}-q4_k_m`
* `tokenizer_sibling_repo()` strips trailing `-GGUF` so pull can fall
  back to the safetensors sibling (Qwen GGUF repos don't host tokenizer.json).
  After pull, tokenizer files are copied next to the gguf so auto-discovery
  finds them at serve time.
* `HfDownloader::download_gguf()` downloads exactly one quantization +
  any tokenizer/config metadata in the repo (avoids pulling every quant
  in a multi-quant repo).
* `find_cached_gguf()` returns the cached `.gguf` file path.

## End-to-end test (M1 Max)

```
$ ferrum pull qwen3:0.6b-q8_0
  Pulling GGUF Qwen/Qwen3-0.6B-GGUF (file: Qwen3-0.6B-Q8_0.gguf)
  📦 Downloading 1 files (0.60 GB)
  → tokenizer.json missing in GGUF repo — fetching from Qwen/Qwen3-0.6B
  ✓ tokenizer placed at <snapshot>
  Run with:
    ferrum serve qwen3:0.6b-q8_0
    ferrum bench qwen3:0.6b-q8_0 --concurrency 8

$ ferrum serve qwen3:0.6b-q8_0
  🚀 Server running at http://127.0.0.1:8000

$ python concurrent_bench.py -c 1 -n 32 -m Qwen3-0.6B-Q8_0
  TG 82.8 tok/s, TPOT 12.4ms ✓

$ python concurrent_bench.py -c 4 -n 32 -m Qwen3-0.6B-Q8_0
  TG 82.9 tok/s total (4 reqs / 1544ms wall, batched at the engine,
  per-item attention path until #73 lands)
```

## Test plan

- [x] `cargo build --workspace --features metal` clean
- [x] `cargo fmt --all` clean
- [x] `ferrum pull qwen3:0.6b-q8_0` end-to-end
- [x] `ferrum serve qwen3:0.6b-q8_0` end-to-end via HTTP
- [x] `ferrum serve <local.gguf>` (path-based) regression
- [x] Concurrent HTTP load (c=4) survives 4 batched iterations
- [ ] CI green

## Out of scope

* CUDA GGUF — still falls through to `ferrum run` candle path until
  ferrum-kernels has native Q4_K_M kernels
* Speculative decoding on GGUF — explicitly errors
* The 4× concurrency speedup arrives with PR #73 (Phase 4b batched
  paged dispatch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)