### PR TITLE
chore: bump workspace version to 0.7.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1250,7 +1250,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-attention"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "cudarc 0.12.1",
  "half",
@@ -1262,7 +1262,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-cli"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1306,7 +1306,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-engine"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1357,7 +1357,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-interfaces"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1374,7 +1374,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-kernels"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "bindgen_cuda",
  "candle-core",
@@ -1388,7 +1388,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-kv"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1409,7 +1409,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-models"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1459,7 +1459,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-quantization"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "candle-core",
  "ferrum-kernels",
@@ -1475,7 +1475,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-runtime"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1506,7 +1506,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-sampler"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1528,7 +1528,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-scheduler"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1556,7 +1556,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-server"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1591,7 +1591,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-testkit"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1608,7 +1608,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-tokenizer"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1633,7 +1633,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-types"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "chrono",
  "rand 0.9.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ resolver = "2"
 
 
 [workspace.package]
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 authors = ["Ferrum Team"]
 license = "MIT"
@@ -131,28 +131,28 @@ candle-flash-attn = "0.9.2"
 candle-metal-kernels = "0.9.2"
 
 # Internal crates - New refactored crates
-ferrum-types = { path = "crates/ferrum-types", version = "0.7.0" }
-ferrum-interfaces = { path = "crates/ferrum-interfaces", version = "0.7.0" }
+ferrum-types = { path = "crates/ferrum-types", version = "0.7.1" }
+ferrum-interfaces = { path = "crates/ferrum-interfaces", version = "0.7.1" }
 
 # Internal crates - Implementation crates
-ferrum-runtime = { path = "crates/ferrum-runtime", version = "0.7.0" }
-ferrum-scheduler = { path = "crates/ferrum-scheduler", version = "0.7.0" }
-ferrum-tokenizer = { path = "crates/ferrum-tokenizer", version = "0.7.0" }
-ferrum-sampler = { path = "crates/ferrum-sampler", version = "0.7.0" }
-ferrum-kv = { path = "crates/ferrum-kv", version = "0.7.0" }
+ferrum-runtime = { path = "crates/ferrum-runtime", version = "0.7.1" }
+ferrum-scheduler = { path = "crates/ferrum-scheduler", version = "0.7.1" }
+ferrum-tokenizer = { path = "crates/ferrum-tokenizer", version = "0.7.1" }
+ferrum-sampler = { path = "crates/ferrum-sampler", version = "0.7.1" }
+ferrum-kv = { path = "crates/ferrum-kv", version = "0.7.1" }
 
 # Unified compute kernels (CUDA/Metal/CPU)
-ferrum-kernels = { path = "crates/ferrum-kernels", version = "0.7.0" }
+ferrum-kernels = { path = "crates/ferrum-kernels", version = "0.7.1" }
 
 # Weight-format abstraction (Dense / GPTQ / AWQ / GGUF)
-ferrum-quantization = { path = "crates/ferrum-quantization", version = "0.7.0" }
+ferrum-quantization = { path = "crates/ferrum-quantization", version = "0.7.1" }
 
 # Internal crates - Existing crates (to be refactored)
-ferrum-engine = { path = "crates/ferrum-engine", version = "0.7.0" }
-ferrum-models = { path = "crates/ferrum-models", version = "0.7.0" }
-ferrum-server = { path = "crates/ferrum-server", version = "0.7.0" }
-ferrum-cli = { path = "crates/ferrum-cli", version = "0.7.0" }
-ferrum-testkit = { path = "crates/ferrum-testkit", version = "0.7.0" }
+ferrum-engine = { path = "crates/ferrum-engine", version = "0.7.1" }
+ferrum-models = { path = "crates/ferrum-models", version = "0.7.1" }
+ferrum-server = { path = "crates/ferrum-server", version = "0.7.1" }
+ferrum-cli = { path = "crates/ferrum-cli", version = "0.7.1" }
+ferrum-testkit = { path = "crates/ferrum-testkit", version = "0.7.1" }
 
 
 [profile.release]

--- a/crates/ferrum-attention/Cargo.toml
+++ b/crates/ferrum-attention/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ferrum-attention"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 license = "MIT"
 description = "Fused flash attention for Metal and CPU — production-grade, framework-independent"


### PR DESCRIPTION
Workspace version bump for the first prebuilt-binary release. After merge, tag `v0.7.1` triggers `release.yml` to build and publish:
- `ferrum-linux-x86_64.tar.gz` (CPU)
- `ferrum-macos-aarch64.tar.gz` (Metal)

Mechanical changes only:
- Root `Cargo.toml` workspace `version = "0.7.0"` → `"0.7.1"`
- `crates/ferrum-attention/Cargo.toml` (the only crate that doesn't use `version.workspace = true`)
- `Cargo.lock` regenerated by `cargo update --workspace`

`cargo check --workspace` passes locally.