### PR TITLE
docs(readme): add brew install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,15 @@ vLLM-style scheduling features included: PagedAttention, continuous batching, Fl
 
 ## Quick Start
 
-### Prebuilt binaries
+### Homebrew (macOS Apple Silicon, Linux x86_64)
+
+```bash
+brew tap sizzlecar/ferrum
+brew install ferrum
+ferrum --version
+```
+
+### Prebuilt binaries (raw tarball)
 
 ```bash
 # Linux x86_64

--- a/README_zh.md
+++ b/README_zh.md
@@ -73,7 +73,15 @@ ferrum 拥有自研 CUDA decode runner,支持 INT4 Marlin。来自 RTX PRO 6000 
 
 ## 快速开始
 
-### 预编译二进制
+### Homebrew (macOS Apple Silicon、Linux x86_64)
+
+```bash
+brew tap sizzlecar/ferrum
+brew install ferrum
+ferrum --version
+```
+
+### 预编译二进制 (原始 tarball)
 
 ```bash
 # Linux x86_64


### PR DESCRIPTION
v0.7.1 is now available via three channels:

1. **Homebrew** — `brew tap sizzlecar/ferrum && brew install ferrum` (verified working on M1 Max)
2. Prebuilt tarball — `curl -L .../ferrum-{linux-x86_64,macos-aarch64}.tar.gz | tar xz`
3. crates.io — `cargo install ferrum-cli`

Tap repo: https://github.com/sizzlecar/homebrew-ferrum