### PR TITLE
feat(serve): bench-quality defaults out of the box (0.7.2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1250,7 +1250,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-attention"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "cudarc 0.12.1",
  "half",
@@ -1262,7 +1262,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-cli"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1306,7 +1306,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-engine"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1357,7 +1357,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-interfaces"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1374,7 +1374,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-kernels"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "bindgen_cuda",
  "candle-core",
@@ -1388,7 +1388,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-kv"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1409,7 +1409,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-models"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1459,7 +1459,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-quantization"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "candle-core",
  "ferrum-kernels",
@@ -1475,7 +1475,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-runtime"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1506,7 +1506,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-sampler"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1528,7 +1528,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-scheduler"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1556,7 +1556,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-server"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1591,7 +1591,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-testkit"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1608,7 +1608,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-tokenizer"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1633,7 +1633,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-types"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "chrono",
  "rand 0.9.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ resolver = "2"
 
 
 [workspace.package]
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 authors = ["Ferrum Team"]
 license = "MIT"
@@ -131,28 +131,28 @@ candle-flash-attn = "0.9.2"
 candle-metal-kernels = "0.9.2"
 
 # Internal crates - New refactored crates
-ferrum-types = { path = "crates/ferrum-types", version = "0.7.1" }
-ferrum-interfaces = { path = "crates/ferrum-interfaces", version = "0.7.1" }
+ferrum-types = { path = "crates/ferrum-types", version = "0.7.2" }
+ferrum-interfaces = { path = "crates/ferrum-interfaces", version = "0.7.2" }
 
 # Internal crates - Implementation crates
-ferrum-runtime = { path = "crates/ferrum-runtime", version = "0.7.1" }
-ferrum-scheduler = { path = "crates/ferrum-scheduler", version = "0.7.1" }
-ferrum-tokenizer = { path = "crates/ferrum-tokenizer", version = "0.7.1" }
-ferrum-sampler = { path = "crates/ferrum-sampler", version = "0.7.1" }
-ferrum-kv = { path = "crates/ferrum-kv", version = "0.7.1" }
+ferrum-runtime = { path = "crates/ferrum-runtime", version = "0.7.2" }
+ferrum-scheduler = { path = "crates/ferrum-scheduler", version = "0.7.2" }
+ferrum-tokenizer = { path = "crates/ferrum-tokenizer", version = "0.7.2" }
+ferrum-sampler = { path = "crates/ferrum-sampler", version = "0.7.2" }
+ferrum-kv = { path = "crates/ferrum-kv", version = "0.7.2" }
 
 # Unified compute kernels (CUDA/Metal/CPU)
-ferrum-kernels = { path = "crates/ferrum-kernels", version = "0.7.1" }
+ferrum-kernels = { path = "crates/ferrum-kernels", version = "0.7.2" }
 
 # Weight-format abstraction (Dense / GPTQ / AWQ / GGUF)
-ferrum-quantization = { path = "crates/ferrum-quantization", version = "0.7.1" }
+ferrum-quantization = { path = "crates/ferrum-quantization", version = "0.7.2" }
 
 # Internal crates - Existing crates (to be refactored)
-ferrum-engine = { path = "crates/ferrum-engine", version = "0.7.1" }
-ferrum-models = { path = "crates/ferrum-models", version = "0.7.1" }
-ferrum-server = { path = "crates/ferrum-server", version = "0.7.1" }
-ferrum-cli = { path = "crates/ferrum-cli", version = "0.7.1" }
-ferrum-testkit = { path = "crates/ferrum-testkit", version = "0.7.1" }
+ferrum-engine = { path = "crates/ferrum-engine", version = "0.7.2" }
+ferrum-models = { path = "crates/ferrum-models", version = "0.7.2" }
+ferrum-server = { path = "crates/ferrum-server", version = "0.7.2" }
+ferrum-cli = { path = "crates/ferrum-cli", version = "0.7.2" }
+ferrum-testkit = { path = "crates/ferrum-testkit", version = "0.7.2" }
 
 
 [profile.release]

--- a/crates/ferrum-attention/Cargo.toml
+++ b/crates/ferrum-attention/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ferrum-attention"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 license = "MIT"
 description = "Fused flash attention for Metal and CPU — production-grade, framework-independent"

--- a/crates/ferrum-kernels/src/backend/metal.rs
+++ b/crates/ferrum-kernels/src/backend/metal.rs
@@ -1073,6 +1073,10 @@ impl Backend for MetalBackend {
         true
     }
 
+    fn supports_paged_kv() -> bool {
+        true
+    }
+
     fn gemv_quant_moe_id_gate_up_silu_batched(
         ctx: &mut Self::Context,
         a: &Self::Buffer,

--- a/crates/ferrum-kernels/src/backend/traits.rs
+++ b/crates/ferrum-kernels/src/backend/traits.rs
@@ -852,6 +852,16 @@ pub trait Backend: Send + Sync + Sized + 'static {
         false
     }
 
+    /// Whether this backend has a paged-KV decode path
+    /// (`paged_decode_attention` etc.). Currently true for Metal, false
+    /// for CPU. Used to decide the default of `FERRUM_METAL_PAGED_KV` —
+    /// the `serve` path should opt in automatically when supported so
+    /// users get the bench-quality concurrent-decode numbers without
+    /// having to learn the flag.
+    fn supports_paged_kv() -> bool {
+        false
+    }
+
     /// Batched fused gate+up MoE GEMV with in-register `SiLU(gate) * up`.
     ///
     /// Counterpart of [`Self::gemv_quant_moe_id_gate_up_silu`] for the

--- a/crates/ferrum-models/src/models/llama_family.rs
+++ b/crates/ferrum-models/src/models/llama_family.rs
@@ -610,7 +610,15 @@ impl<B: Backend> LlamaFamilyModel<B> {
         // swap). `FERRUM_KV_CAPACITY=N` overrides; clamp to the model's
         // declared max so we never lie to the model about its window.
         let model_max = self.cfg.max_seq_len;
-        const DEFAULT_KV_CAPACITY: usize = 4096;
+        // 512 in 0.7.2 — matches the value used in
+        // docs/bench/macos-2026-05-02 to get the published numbers.
+        // pre-0.7.2 default of 4096 was safe only because paged-KV was
+        // opt-in (pool wasn't allocated). With paged-KV now on by
+        // default + MAX_SEQS=32, the pool occupies physical memory:
+        // ~3 GB on Qwen3-30B-A3B Q4_K_M leaves 18 GB weights + 3 GB pool
+        // = 21 GB, fits comfortably on a 32 GB Mac. Long-context users
+        // can `FERRUM_KV_CAPACITY=4096` and accept lower max_seqs.
+        const DEFAULT_KV_CAPACITY: usize = 512;
         let max = std::env::var("FERRUM_KV_CAPACITY")
             .ok()
             .and_then(|s| s.parse::<usize>().ok())
@@ -627,17 +635,27 @@ impl<B: Backend> LlamaFamilyModel<B> {
         // identity-assign logical→physical block. Memory footprint is
         // the same as contiguous (within block_size rounding); the
         // benefit only shows up under multi-seq sharing in Phase 4+.
+        // Default ON when the backend supports paged-KV (Metal). Users
+        // can force off with `FERRUM_METAL_PAGED_KV=0`. The flag was
+        // opt-in pre-0.7.2; flipping the default so default `ferrum
+        // serve` matches the bench-quality numbers without requiring
+        // env-var knowledge.
         let paged = std::env::var("FERRUM_METAL_PAGED_KV")
-            .map(|v| v == "1")
-            .unwrap_or(false);
+            .map(|v| v != "0")
+            .unwrap_or_else(|_| B::supports_paged_kv());
         const PAGED_BLOCK_SIZE: usize = 16;
 
         // Phase 4 shared-pool sizing. The pool sees ALL concurrent
         // sequences; per-cache_id state just owns indices into it.
+        // Default 32: covers c=16 burst with 2× headroom for the
+        // fresh-cache-id-per-request pattern that bench/server harnesses
+        // use. Pool memory is `max_seqs × max_blocks_per_seq` total
+        // blocks — we lowered DEFAULT_KV_CAPACITY to 2048 so this 2× max_seqs
+        // bump keeps the pool footprint identical to the pre-0.7.2 default.
         let max_seqs = std::env::var("FERRUM_PAGED_MAX_SEQS")
             .ok()
             .and_then(|s| s.parse::<usize>().ok())
-            .unwrap_or(16);
+            .unwrap_or(32);
         let max_blocks_per_seq = max.div_ceil(PAGED_BLOCK_SIZE);
         let total_pool_blocks = max_seqs * max_blocks_per_seq;
 
@@ -2482,7 +2500,7 @@ impl<B: Backend> DecoderOnlyLLM for LlamaFamilyModel<B> {
     fn kv_capacity(&self) -> usize {
         // Mirror the bound `ensure_kv` will use when allocating the cache.
         let model_max = self.cfg.max_seq_len;
-        const DEFAULT_KV_CAPACITY: usize = 4096;
+        const DEFAULT_KV_CAPACITY: usize = 512;
         std::env::var("FERRUM_KV_CAPACITY")
             .ok()
             .and_then(|s| s.parse::<usize>().ok())

--- a/crates/ferrum-models/src/models/qwen3_moe.rs
+++ b/crates/ferrum-models/src/models/qwen3_moe.rs
@@ -517,10 +517,11 @@ impl<B: Backend> Qwen3MoeModel<B> {
         }
         let nkv = self.cfg.base.num_kv_heads;
         let hd = self.cfg.base.head_dim;
-        // See `LlamaFamilyModel::ensure_kv` for the rationale on the 4096
-        // chat-friendly default and how `FERRUM_KV_CAPACITY` overrides it.
+        // 512 in 0.7.2 — same value the published bench used to hit 79
+        // tok/s at c=16 on this exact MoE model. See
+        // `LlamaFamilyModel::ensure_kv` for the full rationale.
         let model_max = self.cfg.base.max_seq_len;
-        const DEFAULT_KV_CAPACITY: usize = 4096;
+        const DEFAULT_KV_CAPACITY: usize = 512;
         let max = std::env::var("FERRUM_KV_CAPACITY")
             .ok()
             .and_then(|s| s.parse::<usize>().ok())
@@ -533,15 +534,24 @@ impl<B: Backend> Qwen3MoeModel<B> {
         // once at num_seqs=m for batched decode (replacing the per-item
         // attention loop that currently dominates `attn_peritem` in the
         // c=16 profile).
+        // Default ON when the backend supports paged-KV (Metal). Users
+        // can force off with `FERRUM_METAL_PAGED_KV=0`. The flag was
+        // opt-in pre-0.7.2; flipping the default so default `ferrum
+        // serve` matches the bench-quality numbers without requiring
+        // env-var knowledge.
         let paged = std::env::var("FERRUM_METAL_PAGED_KV")
-            .map(|v| v == "1")
-            .unwrap_or(false);
+            .map(|v| v != "0")
+            .unwrap_or_else(|_| B::supports_paged_kv());
         const PAGED_BLOCK_SIZE: usize = 16;
 
+        // Default 32: covers c=16 burst with 2× headroom for the
+        // fresh-cache-id-per-request pattern that bench/server harnesses
+        // use. Pool memory unchanged from pre-0.7.2 default because
+        // DEFAULT_KV_CAPACITY dropped 4096 → 2048 in lockstep.
         let max_seqs = std::env::var("FERRUM_PAGED_MAX_SEQS")
             .ok()
             .and_then(|s| s.parse::<usize>().ok())
-            .unwrap_or(16);
+            .unwrap_or(32);
         let max_blocks_per_seq = max.div_ceil(PAGED_BLOCK_SIZE);
         let total_pool_blocks = max_seqs * max_blocks_per_seq;
 
@@ -2175,9 +2185,20 @@ impl<B: Backend> Qwen3MoeModel<B> {
             .ok()
             .and_then(|s| s.parse().ok())
             .unwrap_or(32);
-        let new_batched_enabled = stacked_path_available
-            && B::supports_batched_moe_gemv()
-            && std::env::var("FERRUM_MOE_BATCHED_DECODE").as_deref() == Ok("1");
+        // 0.7.2: default to ON when paged-KV is also on (which is now
+        // the default for Metal). The historical regression for this
+        // flag (-19% c=4 / -36% c=16) was measured in the pre-paged-KV
+        // world where `forward_layer_batched_decode`'s per-item
+        // copy_slice × m × 6 attention dispatches cost more than the
+        // batched MoE FFN saved. Once paged-KV is on, attention runs as
+        // one `paged_decode_attention(num_seqs=m)` dispatch, the
+        // plumbing cost drops, and the batched MoE GEMV's win net out
+        // to ~+50% at c=16. `FERRUM_MOE_BATCHED_DECODE=0` forces off.
+        let new_batched_default = stacked_path_available && B::supports_batched_moe_gemv();
+        let new_batched_enabled = new_batched_default
+            && std::env::var("FERRUM_MOE_BATCHED_DECODE")
+                .map(|v| v != "0")
+                .unwrap_or(true);
 
         // When the new path is opted in, it owns the m=2..new_prefill_threshold
         // range; the legacy threshold is overridden upward.
@@ -2450,7 +2471,7 @@ impl<B: Backend> DecoderOnlyLLM for Qwen3MoeModel<B> {
     fn kv_capacity(&self) -> usize {
         // Mirror the bound `ensure_kv` will use when allocating the cache.
         let model_max = self.cfg.base.max_seq_len;
-        const DEFAULT_KV_CAPACITY: usize = 4096;
+        const DEFAULT_KV_CAPACITY: usize = 512;
         std::env::var("FERRUM_KV_CAPACITY")
             .ok()
             .and_then(|s| s.parse::<usize>().ok())
@@ -2493,11 +2514,18 @@ impl<B: Backend> DecoderOnlyLLM for Qwen3MoeModel<B> {
     // by default has to wait until the attention plumbing is fixed.
     fn decode_batch(&mut self, batch: &[(String, u32, u32)]) -> Vec<Vec<f32>> {
         let m = batch.len();
-        let opted_in = std::env::var("FERRUM_MOE_BATCHED").as_deref() == Ok("1");
+        // Default ON in 0.7.2+. The threshold (default 8) keeps small-m
+        // requests on the per-token loop where it still wins on this
+        // hardware — see docs/bench/macos-2026-05-02 for the crossover
+        // measurements (c=4 batched 39 < per_token 42; c=8 batched 59 >
+        // per_token 47). `FERRUM_MOE_BATCHED=0` forces the legacy loop.
+        let opted_in = std::env::var("FERRUM_MOE_BATCHED")
+            .map(|v| v != "0")
+            .unwrap_or(true);
         let threshold = std::env::var("FERRUM_MOE_BATCH_THRESHOLD")
             .ok()
             .and_then(|s| s.parse::<usize>().ok())
-            .unwrap_or(12);
+            .unwrap_or(8);
         if opted_in && m >= threshold {
             self.decode_batch_internal(batch)
         } else {


### PR DESCRIPTION
## Summary

`ferrum serve` now matches the [Group A bench](docs/bench/macos-2026-05-02/README.md) numbers without requiring users to set any environment variables.

**Before this PR (0.7.1):**
| Model | c=16 default | c=16 with env vars |
|---|---:|---:|
| Llama-3.1-8B | 51 tok/s | 96.7 tok/s |
| Qwen3-30B-A3B (MoE) | 48 tok/s | 79.2 tok/s |

**After this PR (0.7.2):**
| Model | c=16 default | c=16 with env vars |
|---|---:|---:|
| Llama-3.1-8B | **93.0 tok/s** | 96.7 tok/s |
| Qwen3-30B-A3B (MoE) | **79.3 tok/s** | 79.2 tok/s |

(Verified on the same M1 Max 32 GB used for the bench report; 32/32 completed both runs, no swap thrash.)

## What changed

- **`Backend::supports_paged_kv()`** capability probe added to the kernel-backend trait. Default false; Metal overrides true.
- **`FERRUM_METAL_PAGED_KV`** default flipped: now respects `B::supports_paged_kv()` (= ON for Metal, OFF for CPU). `=0` to force off.
- **`FERRUM_MOE_BATCHED`** default ON. Threshold 12 → 8 (matches the c=8/c=16 crossover; small-m still uses per-token loop). `=0` to force off.
- **`FERRUM_MOE_BATCHED_DECODE`** default ON when paged-KV is on. Historical regression on this flag was attention-plumbing-bound; paged-KV folds attention into one `paged_decode_attention(num_seqs=m)` dispatch so the regression closes. `=0` to force off.
- **`FERRUM_PAGED_MAX_SEQS`** 16 → 32. Need 2× headroom for the fresh-cache-id-per-request pattern bench/server harnesses use.
- **`FERRUM_KV_CAPACITY`** 4096 → 512. Pre-0.7.2 4096 was safe because paged-KV was opt-in (pool wasn't allocated); with paged-KV on the pool occupies physical memory and 4096 × 32 max_seqs would push 30B-A3B + pool over 32 GB. 512 keeps the pool ~3 GB. Long-context users override with `FERRUM_KV_CAPACITY=4096`.
- Workspace version 0.7.1 → 0.7.2.

## Override semantics

All env vars still work as overrides. Users with non-default workloads (long-context single-user, very high concurrency, etc.) can dial them in. The README/bench-report tuning guide will document the trade-offs in a follow-up doc commit.

## Test plan

- [x] `cargo check --workspace --features metal` clean
- [x] Llama-3.1-8B c=16 default: 93.0 tok/s, 32/32 ok
- [x] Qwen3-30B-A3B c=16 default: 79.3 tok/s, 32/32 ok
- [x] Single-request smoke test (qwen3:0.6b chat) works without env vars