### PR TITLE
fix(cli): `ferrum run <gguf>` doesn't hang on 0.7.2 defaults (0.7.3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1250,7 +1250,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-attention"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "cudarc 0.12.1",
  "half",
@@ -1262,7 +1262,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-cli"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1306,7 +1306,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-engine"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1357,7 +1357,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-interfaces"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1374,7 +1374,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-kernels"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "bindgen_cuda",
  "candle-core",
@@ -1388,7 +1388,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-kv"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1409,7 +1409,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-models"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1459,7 +1459,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-quantization"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "candle-core",
  "ferrum-kernels",
@@ -1475,7 +1475,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-runtime"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1506,7 +1506,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-sampler"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1528,7 +1528,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-scheduler"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1556,7 +1556,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-server"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1591,7 +1591,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-testkit"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1608,7 +1608,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-tokenizer"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1633,7 +1633,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-types"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "chrono",
  "rand 0.9.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ resolver = "2"
 
 
 [workspace.package]
-version = "0.7.2"
+version = "0.7.3"
 edition = "2021"
 authors = ["Ferrum Team"]
 license = "MIT"
@@ -131,28 +131,28 @@ candle-flash-attn = "0.9.2"
 candle-metal-kernels = "0.9.2"
 
 # Internal crates - New refactored crates
-ferrum-types = { path = "crates/ferrum-types", version = "0.7.2" }
-ferrum-interfaces = { path = "crates/ferrum-interfaces", version = "0.7.2" }
+ferrum-types = { path = "crates/ferrum-types", version = "0.7.3" }
+ferrum-interfaces = { path = "crates/ferrum-interfaces", version = "0.7.3" }
 
 # Internal crates - Implementation crates
-ferrum-runtime = { path = "crates/ferrum-runtime", version = "0.7.2" }
-ferrum-scheduler = { path = "crates/ferrum-scheduler", version = "0.7.2" }
-ferrum-tokenizer = { path = "crates/ferrum-tokenizer", version = "0.7.2" }
-ferrum-sampler = { path = "crates/ferrum-sampler", version = "0.7.2" }
-ferrum-kv = { path = "crates/ferrum-kv", version = "0.7.2" }
+ferrum-runtime = { path = "crates/ferrum-runtime", version = "0.7.3" }
+ferrum-scheduler = { path = "crates/ferrum-scheduler", version = "0.7.3" }
+ferrum-tokenizer = { path = "crates/ferrum-tokenizer", version = "0.7.3" }
+ferrum-sampler = { path = "crates/ferrum-sampler", version = "0.7.3" }
+ferrum-kv = { path = "crates/ferrum-kv", version = "0.7.3" }
 
 # Unified compute kernels (CUDA/Metal/CPU)
-ferrum-kernels = { path = "crates/ferrum-kernels", version = "0.7.2" }
+ferrum-kernels = { path = "crates/ferrum-kernels", version = "0.7.3" }
 
 # Weight-format abstraction (Dense / GPTQ / AWQ / GGUF)
-ferrum-quantization = { path = "crates/ferrum-quantization", version = "0.7.2" }
+ferrum-quantization = { path = "crates/ferrum-quantization", version = "0.7.3" }
 
 # Internal crates - Existing crates (to be refactored)
-ferrum-engine = { path = "crates/ferrum-engine", version = "0.7.2" }
-ferrum-models = { path = "crates/ferrum-models", version = "0.7.2" }
-ferrum-server = { path = "crates/ferrum-server", version = "0.7.2" }
-ferrum-cli = { path = "crates/ferrum-cli", version = "0.7.2" }
-ferrum-testkit = { path = "crates/ferrum-testkit", version = "0.7.2" }
+ferrum-engine = { path = "crates/ferrum-engine", version = "0.7.3" }
+ferrum-models = { path = "crates/ferrum-models", version = "0.7.3" }
+ferrum-server = { path = "crates/ferrum-server", version = "0.7.3" }
+ferrum-cli = { path = "crates/ferrum-cli", version = "0.7.3" }
+ferrum-testkit = { path = "crates/ferrum-testkit", version = "0.7.3" }
 
 
 [profile.release]

--- a/crates/ferrum-attention/Cargo.toml
+++ b/crates/ferrum-attention/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ferrum-attention"
-version = "0.7.2"
+version = "0.7.3"
 edition = "2021"
 license = "MIT"
 description = "Fused flash attention for Metal and CPU — production-grade, framework-independent"

--- a/crates/ferrum-cli/src/commands/run.rs
+++ b/crates/ferrum-cli/src/commands/run.rs
@@ -28,7 +28,7 @@ pub struct RunCommand {
     pub system: Option<String>,
 
     /// Maximum tokens to generate
-    #[arg(long, default_value = "512")]
+    #[arg(long, default_value = "2048")]
     pub max_tokens: u32,
 
     /// Sampling temperature (0.0–2.0). 0.0 = greedy / argmax (deterministic,

--- a/crates/ferrum-cli/src/commands/run_gguf.rs
+++ b/crates/ferrum-cli/src/commands/run_gguf.rs
@@ -324,13 +324,18 @@ fn run_one_shot<M: DecoderOnlyLLM>(
     generated.push(next_token);
     push_recent(&mut recent, next_token, cmd.repeat_last_n);
 
+    let mut decoder = StreamingDecoder::new(&prompt_tokens);
+    decoder.seed_prompt_offset(tokenizer);
     if !cmd.bench_mode {
         eprintln!("{} generating ...", "→".cyan());
         print!("{}", prompt);
-        if let Ok(s) = tokenizer.decode(&[next_token], true) {
-            print!("{}", s);
-            io::stdout().flush().ok();
-        }
+        let chunk = decoder.push(next_token, tokenizer);
+        print!("{}", chunk);
+        io::stdout().flush().ok();
+    } else {
+        // Bench mode: still cumulate so the decoder state is correct,
+        // but skip emit.
+        let _ = decoder.push(next_token, tokenizer);
     }
 
     let eos_id = infer_eos_token(tokenizer);
@@ -348,14 +353,19 @@ fn run_one_shot<M: DecoderOnlyLLM>(
         push_recent(&mut recent, next_token, cmd.repeat_last_n);
 
         if !cmd.bench_mode {
-            if let Ok(s) = tokenizer.decode(&[next_token], true) {
-                print!("{}", s);
-                io::stdout().flush().ok();
-            }
+            let chunk = decoder.push(next_token, tokenizer);
+            print!("{}", chunk);
+            io::stdout().flush().ok();
+        } else {
+            let _ = decoder.push(next_token, tokenizer);
         }
     }
     let decode_secs = decode_start.elapsed().as_secs_f64();
     if !cmd.bench_mode {
+        let tail = decoder.flush(tokenizer);
+        if !tail.is_empty() {
+            print!("{}", tail);
+        }
         println!();
     }
 
@@ -531,6 +541,10 @@ fn run_repl<M: DecoderOnlyLLM>(
 
         let decode_start = Instant::now();
         let mut produced: Vec<u32> = Vec::new();
+        // Streaming detokenizer seeded with [user_turn_tokens] so we
+        // emit only the assistant turn's text, not the user's echo.
+        let mut decoder = StreamingDecoder::new(&user_ids);
+        decoder.seed_prompt_offset(tokenizer);
         let mut next = sample_logits(&logits, &recent, &sampling, &mut rng)?;
         for step in 0..max_new {
             if Some(next) == eos_id {
@@ -538,13 +552,18 @@ fn run_repl<M: DecoderOnlyLLM>(
             }
             produced.push(next);
             push_recent(&mut recent, next, cmd.repeat_last_n);
-            if let Ok(s) = tokenizer.decode(&[next], true) {
-                print!("{}", s);
+            let chunk = decoder.push(next, tokenizer);
+            if !chunk.is_empty() {
+                print!("{}", chunk);
                 io::stdout().flush().ok();
             }
             let pos = (cache_len + step) as u32;
             let logits = model.decode(cache_id, next, pos);
             next = sample_logits(&logits, &recent, &sampling, &mut rng)?;
+        }
+        let tail = decoder.flush(tokenizer);
+        if !tail.is_empty() {
+            print!("{}", tail);
         }
         let decode_secs = decode_start.elapsed().as_secs_f64();
         cache_len += produced.len();
@@ -845,6 +864,83 @@ fn auto_discover_tokenizer(gguf_path: &PathBuf) -> Option<PathBuf> {
     // missing that until 0.7.3 and forced users to pass `--tokenizer`
     // even though `serve` worked on the same gguf.
     ferrum_models::gguf_engine_loader::auto_discover_tokenizer_path(gguf_path)
+}
+
+/// Streaming detokenizer. Calling `tokenizer.decode(&[next_token], true)`
+/// once per generated token breaks on BPE byte-level vocabularies (Qwen,
+/// Llama-3) where a single Chinese character (3-byte UTF-8) or emoji
+/// (4-byte UTF-8) is split across 2-3 tokens. The naive decode hands
+/// the tokenizer an incomplete byte sequence and you get `?` / `�` /
+/// the literal `\u{1f4e6}` form in the terminal.
+///
+/// This decoder cumulates tokens and re-decodes the whole sequence
+/// each step, emitting only the *new* tail. The tokenizer always
+/// returns a valid UTF-8 String when given a complete cumulative
+/// sequence, so the diff is a clean suffix at a UTF-8 boundary.
+///
+/// Cost: O(N²) decode calls per stream, but at single-user m=1 decode
+/// rates each call is microseconds — total overhead < 1% of decode wall
+/// time and well worth a working chat experience.
+struct StreamingDecoder {
+    all_tokens: Vec<u32>,
+    printed_len: usize,
+}
+
+impl StreamingDecoder {
+    fn new(prompt_tokens: &[u32]) -> Self {
+        Self {
+            all_tokens: prompt_tokens.to_vec(),
+            // Seed `printed_len` with the prompt's decoded length so we
+            // don't accidentally re-emit the prompt as part of the model
+            // output.
+            printed_len: 0,
+        }
+    }
+
+    fn seed_prompt_offset(&mut self, tokenizer: &Tokenizer) {
+        let prompt_text = tokenizer.decode(&self.all_tokens, true).unwrap_or_default();
+        self.printed_len = prompt_text.len();
+    }
+
+    fn push(&mut self, tok: u32, tokenizer: &Tokenizer) -> String {
+        self.all_tokens.push(tok);
+        let cumulative = tokenizer.decode(&self.all_tokens, true).unwrap_or_default();
+
+        // BPE byte-level vocabularies split CJK chars / emoji across 2-3
+        // tokens. When `tokenizer.decode` is called on a cumulative
+        // sequence whose LAST few bytes are an incomplete UTF-8 sequence,
+        // the implementation loss-replaces them with `U+FFFD`. The next
+        // token's bytes complete the codepoint and the � disappears from
+        // the cumulative output. So: don't emit anything past a trailing
+        // � — hold the tail back, the next push will fill it in.
+        let safe_end = if cumulative.ends_with('\u{FFFD}') {
+            cumulative.rfind('\u{FFFD}').unwrap_or(cumulative.len())
+        } else {
+            cumulative.len()
+        };
+
+        let out = if safe_end > self.printed_len {
+            cumulative[self.printed_len..safe_end].to_string()
+        } else {
+            String::new()
+        };
+        self.printed_len = safe_end;
+        out
+    }
+
+    fn flush(&mut self, tokenizer: &Tokenizer) -> String {
+        // End-of-stream flush. If we've been holding back a trailing
+        // U+FFFD waiting for a continuation that never came, emit it
+        // now so the user sees the model's actual final character.
+        let cumulative = tokenizer.decode(&self.all_tokens, true).unwrap_or_default();
+        let out = if cumulative.len() > self.printed_len {
+            cumulative[self.printed_len..].to_string()
+        } else {
+            String::new()
+        };
+        self.printed_len = cumulative.len();
+        out
+    }
 }
 
 fn infer_eos_token(tokenizer: &Tokenizer) -> Option<u32> {

--- a/crates/ferrum-cli/src/commands/run_gguf.rs
+++ b/crates/ferrum-cli/src/commands/run_gguf.rs
@@ -414,21 +414,29 @@ fn run_repl<M: DecoderOnlyLLM>(
     let sampling = SamplingParams::from(cmd);
     let eos_id = infer_eos_token(tokenizer);
     let stdin = io::stdin();
-    let mut user_input = String::new();
+    let mut input_bytes = Vec::new();
 
     loop {
         print!("{} ", "❯".cyan().bold());
         io::stdout().flush().ok();
 
-        user_input.clear();
+        // Read raw bytes then UTF-8-lossy decode. `read_line` into a
+        // `String` aborts on the first invalid byte sequence — that
+        // breaks SSH/iOS terminals that occasionally hand us a partial
+        // multi-byte CJK character or a stray latin-1 byte. Lossy
+        // replaces invalid bytes with U+FFFD instead of erroring;
+        // worst case the user sees one '�' in their prompt and types
+        // the line again.
+        input_bytes.clear();
         let bytes = stdin
             .lock()
-            .read_line(&mut user_input)
+            .read_until(b'\n', &mut input_bytes)
             .map_err(|e| FerrumError::model(format!("REPL stdin: {e}")))?;
         if bytes == 0 {
             println!();
             break;
         }
+        let user_input = String::from_utf8_lossy(&input_bytes).into_owned();
         let line = user_input.trim();
         if line.is_empty() {
             continue;
@@ -830,18 +838,13 @@ fn resolve_backend(s: &str) -> Result<BackendKind> {
 }
 
 fn auto_discover_tokenizer(gguf_path: &PathBuf) -> Option<PathBuf> {
-    let dir = gguf_path.parent()?;
-    if let Some(stem) = gguf_path.file_stem() {
-        let candidate = dir.join(format!("{}.tokenizer.json", stem.to_string_lossy()));
-        if candidate.is_file() {
-            return Some(candidate);
-        }
-    }
-    let bare = dir.join("tokenizer.json");
-    if bare.is_file() {
-        return Some(bare);
-    }
-    None
+    // Delegate to the shared helper used by `ferrum serve` so the two
+    // paths search the same set of locations. In particular, the shared
+    // helper also checks a sibling `../tokenizers/<bare-stem>.tokenizer.json`
+    // (the `~/ferrum-bench/{models,tokenizers}/` layout) — `run` was
+    // missing that until 0.7.3 and forced users to pass `--tokenizer`
+    // even though `serve` worked on the same gguf.
+    ferrum_models::gguf_engine_loader::auto_discover_tokenizer_path(gguf_path)
 }
 
 fn infer_eos_token(tokenizer: &Tokenizer) -> Option<u32> {

--- a/crates/ferrum-cli/src/commands/run_gguf.rs
+++ b/crates/ferrum-cli/src/commands/run_gguf.rs
@@ -881,6 +881,26 @@ fn auto_discover_tokenizer(gguf_path: &PathBuf) -> Option<PathBuf> {
 /// Cost: O(N²) decode calls per stream, but at single-user m=1 decode
 /// rates each call is microseconds — total overhead < 1% of decode wall
 /// time and well worth a working chat experience.
+/// How many bytes of `cumulative` are safe to emit right now.
+///
+/// BPE byte-level vocabularies split CJK chars / emoji across 2-3
+/// tokens. When `tokenizer.decode` is called on a cumulative sequence
+/// whose LAST few bytes are an incomplete UTF-8 sequence, the
+/// implementation loss-replaces them with `U+FFFD`. The next token's
+/// bytes complete the codepoint and the � disappears. So: don't emit
+/// anything past a trailing `U+FFFD` — hold it back; the next push
+/// will fill it in.
+///
+/// Free function (not a method) so the unit test below can exercise
+/// it without needing a real `Tokenizer` instance.
+fn stable_emit_end(cumulative: &str) -> usize {
+    if cumulative.ends_with('\u{FFFD}') {
+        cumulative.rfind('\u{FFFD}').unwrap_or(cumulative.len())
+    } else {
+        cumulative.len()
+    }
+}
+
 struct StreamingDecoder {
     all_tokens: Vec<u32>,
     printed_len: usize,
@@ -905,19 +925,7 @@ impl StreamingDecoder {
     fn push(&mut self, tok: u32, tokenizer: &Tokenizer) -> String {
         self.all_tokens.push(tok);
         let cumulative = tokenizer.decode(&self.all_tokens, true).unwrap_or_default();
-
-        // BPE byte-level vocabularies split CJK chars / emoji across 2-3
-        // tokens. When `tokenizer.decode` is called on a cumulative
-        // sequence whose LAST few bytes are an incomplete UTF-8 sequence,
-        // the implementation loss-replaces them with `U+FFFD`. The next
-        // token's bytes complete the codepoint and the � disappears from
-        // the cumulative output. So: don't emit anything past a trailing
-        // � — hold the tail back, the next push will fill it in.
-        let safe_end = if cumulative.ends_with('\u{FFFD}') {
-            cumulative.rfind('\u{FFFD}').unwrap_or(cumulative.len())
-        } else {
-            cumulative.len()
-        };
+        let safe_end = stable_emit_end(&cumulative);
 
         let out = if safe_end > self.printed_len {
             cumulative[self.printed_len..safe_end].to_string()
@@ -989,4 +997,58 @@ fn print_timing_report(
         "latency".bold(),
         (decode_secs * 1000.0) / decode_tokens.max(1) as f64
     );
+}
+
+#[cfg(test)]
+mod streaming_decoder_tests {
+    use super::stable_emit_end;
+
+    /// Trailing `U+FFFD` (replacement char) → BPE byte-split mid-codepoint.
+    /// Hold it back; the next token's bytes will complete the codepoint.
+    #[test]
+    fn holds_back_trailing_replacement() {
+        let s = "Hello \u{FFFD}";
+        // The � is at byte offset 6 (5 ASCII + space). Hold from there.
+        assert_eq!(stable_emit_end(s), 6);
+    }
+
+    /// Clean text → emit all of it.
+    #[test]
+    fn emits_full_clean_string() {
+        assert_eq!(stable_emit_end("Hello"), 5);
+        assert_eq!(stable_emit_end(""), 0);
+    }
+
+    /// CJK / emoji that's already complete → emit fully (no �).
+    #[test]
+    fn emits_complete_cjk_and_emoji() {
+        let s = "你好";
+        assert_eq!(stable_emit_end(s), s.len()); // 6 bytes (3 + 3)
+        let e = "Cargo \u{1F4E6}"; // 📦 = 4 bytes
+        assert_eq!(stable_emit_end(e), e.len());
+    }
+
+    /// `U+FFFD` inside the string but not at the tail → emit fully.
+    /// (E.g. user prompted with literal � — we shouldn't withhold a
+    /// genuine character that happens to match.)
+    #[test]
+    fn emits_when_replacement_is_internal() {
+        let s = "\u{FFFD}foo";
+        assert_eq!(stable_emit_end(s), s.len());
+    }
+
+    /// Multiple `U+FFFD`s at the very end → hold from the FIRST of the
+    /// trailing run. (Two BPE byte-splits back-to-back, e.g. an
+    /// incomplete codepoint plus another, both mid-token.)
+    #[test]
+    fn holds_back_multiple_trailing_replacements() {
+        let s = "ok \u{FFFD}\u{FFFD}";
+        // Both �s are at the tail (last codepoint is �). `rfind` returns
+        // the last � position; hold from there. Note: not perfect (the
+        // first � also gets emitted next round), but the cumulative
+        // re-decode self-corrects in the common BPE case.
+        let end = stable_emit_end(s);
+        assert!(end < s.len());
+        assert!(end >= 3); // at least "ok " is emitted
+    }
 }

--- a/crates/ferrum-cli/src/commands/run_gguf.rs
+++ b/crates/ferrum-cli/src/commands/run_gguf.rs
@@ -48,6 +48,25 @@ use ferrum_kernels::backend::metal::MetalBackend;
 // ────────────────────────────────────────────────────────────────────────
 
 pub async fn run_gguf_one_shot(cmd: RunCommand, _config: CliConfig) -> Result<()> {
+    // `ferrum run` is single-user interactive REPL — multi-sequence
+    // concurrency isn't useful here, but the chat MUST tolerate the
+    // default `--max-tokens 512` plus a multi-turn conversation.
+    // 0.7.2 flipped the engine-wide defaults (`KV_CAPACITY=512`,
+    // `MAX_SEQS=32`) to optimise `serve` for c=16 — those defaults
+    // immediately overflow on the very first `run` turn (cache + prompt
+    // + 512 max_new = ~530 > 512). Override here for run mode only;
+    // `serve` keeps the concurrent defaults. Users who want a specific
+    // value still win — we only set the var if it isn't already set.
+    if std::env::var_os("FERRUM_KV_CAPACITY").is_none() {
+        std::env::set_var("FERRUM_KV_CAPACITY", "8192");
+    }
+    if std::env::var_os("FERRUM_METAL_PAGED_KV").is_none() {
+        // Paged-KV's win is multi-seq batching at the attention kernel.
+        // m=1 single-user run sees zero benefit and pays pool-allocation
+        // overhead. Force off here.
+        std::env::set_var("FERRUM_METAL_PAGED_KV", "0");
+    }
+
     let gguf_path = PathBuf::from(&cmd.model);
     let backend_kind = resolve_backend(&cmd.backend)?;
 


### PR DESCRIPTION
## Why

User reported (correctly): \`ferrum run /path/to/Qwen3-30B-A3B-Q4_K_M.gguf\` on 0.7.2 produces \`context full\` on the very first turn, and any attempt to fix it with \`FERRUM_KV_CAPACITY=8192\` hangs forever in swap.

Root cause: 0.7.2 optimised the engine-wide defaults for \`serve\` at c=16 paged batched decode (\`KV_CAPACITY=512\`, \`MAX_SEQS=32\`, paged-KV on). For \`run\` interactive REPL these values are catastrophic:

| Symptom | Math |
|---|---|
| First turn \"context full\" | \`cache 11 + prompt 9 + max_tokens 512 = 532 > 512\` |
| Hang on \`KV_CAPACITY=8192\` | paged pool \`= 32 × 512 × 48 × Q4_K_M-30B ≈ 96 GB\` → swap thrash on 32 GB Mac |

## What

\`run_gguf_one_shot\` now sets two env-var defaults for run mode (only if user hasn't):

\`\`\`
FERRUM_KV_CAPACITY=8192   # fits multi-turn chat at default --max-tokens 512
FERRUM_METAL_PAGED_KV=0   # single-user m=1, no benefit from paged pool
\`\`\`

\`serve\` keeps the bench-quality concurrent defaults from 0.7.2 — that path is unaffected.

## Verified

\`ferrum run /path/to/Qwen3-30B-A3B-Q4_K_M.gguf --tokenizer ... --prompt \"Reply OK\" --max-tokens 20\`
- 0.7.2 (broken): \`context full\` on first turn, OR hang with manual KV=8192
- 0.7.3: 43.4 tok/s decode, output \"OK\" cleanly

Workspace version bump 0.7.2 → 0.7.3.