### PR TITLE
feat(bench): v0.2 CUDA bench scripts (pre-flight)

### DIFF
--- a/bench/v0.2-cuda/models.txt
+++ b/bench/v0.2-cuda/models.txt
@@ -1,0 +1,20 @@
+# v0.2 CUDA bench — frozen model IDs.
+#
+# Format: <tag>|<hf_repo>|<precision>|<approx_disk_size>
+# tag goes in result filenames; hf_repo is the canonical HuggingFace
+# repo to download from (`huggingface-cli download <repo>`); precision
+# is informational only.
+#
+# Verified on HF as of 2026-05-03:
+#   M1: gated=manual, 9.6M downloads/30d
+#   M2: open, 21k downloads/30d
+#   M3: open, **official Qwen org**, 239k downloads/30d
+#   M4: open, community pack, 26k downloads/30d (highest GPTQ Int4
+#        Qwen3-Coder-30B I could find; if it ever flakes the
+#        most-used INT4 alt is `cyankiwi/Qwen3-Coder-30B-A3B-Instruct-AWQ-4bit`
+#        but that's AWQ not GPTQ — would break the matrix axis.)
+#
+M1|meta-llama/Llama-3.1-8B-Instruct|FP16|16GB
+M2|hugging-quants/Meta-Llama-3.1-8B-Instruct-GPTQ-INT4|GPTQ_INT4|5.7GB
+M3|Qwen/Qwen3-30B-A3B-GPTQ-Int4|GPTQ_INT4|17GB
+M4|btbtyler09/Qwen3-Coder-30B-A3B-Instruct-gptq-4bit|GPTQ_INT4|17GB

--- a/bench/v0.2-cuda/prompts_subset.py
+++ b/bench/v0.2-cuda/prompts_subset.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Build the deterministic 128-prompt subset for the v0.2 CUDA bench.
+
+Reads ShareGPT_V3_unfiltered_cleaned_split.json, filters to single-turn
+human prompts whose token length falls in [128, 512] (a well-defined
+range for the W2/W3/W4 workloads at prompt_len=512), seeds an RNG with
+the ferrum repo HEAD short hash, and samples 128 prompts. Writes
+prompts.json with the exact prompts every run will use.
+
+Usage:
+    huggingface-cli download anon8231489123/ShareGPT_Vicuna_unfiltered \\
+        ShareGPT_V3_unfiltered_cleaned_split.json \\
+        --local-dir /workspace/datasets
+    python3 prompts_subset.py \\
+        --input  /workspace/datasets/ShareGPT_V3_unfiltered_cleaned_split.json \\
+        --output prompts.json \\
+        --seed   "$(git -C $FERRUM_DIR rev-parse --short HEAD)"
+
+Produces prompts.json:
+    {
+      "seed": "...",
+      "count": 128,
+      "tokenizer": "tiktoken/cl100k_base",
+      "prompts": [
+         {"id": 0, "text": "...", "approx_tokens": 234},
+         ...
+      ]
+    }
+"""
+import argparse
+import hashlib
+import json
+import random
+import sys
+from pathlib import Path
+
+
+def approx_token_count(text: str) -> int:
+    """Rough token estimate without loading a real tokenizer.
+
+    cl100k_base averages ~4 bytes/token on English. Good enough for
+    length filtering — we don't need exact bucketing here, just to
+    reject obvious 50-token / 5000-token prompts.
+    """
+    return max(1, len(text.encode("utf-8")) // 4)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--input", required=True, help="ShareGPT_V3_*.json path")
+    ap.add_argument("--output", required=True, help="prompts.json output path")
+    ap.add_argument("--seed", required=True, help="RNG seed (use repo HEAD short hash)")
+    ap.add_argument("--count", type=int, default=128)
+    ap.add_argument("--min-tokens", type=int, default=128)
+    ap.add_argument("--max-tokens", type=int, default=512)
+    args = ap.parse_args()
+
+    src = Path(args.input)
+    if not src.is_file():
+        print(f"input not found: {src}", file=sys.stderr)
+        sys.exit(2)
+
+    print(f"loading {src} (~640 MB)...", file=sys.stderr, flush=True)
+    convos = json.loads(src.read_text())
+    print(f"  {len(convos)} conversations loaded", file=sys.stderr)
+
+    candidates: list[str] = []
+    for c in convos:
+        for turn in c.get("conversations", []):
+            if turn.get("from") != "human":
+                continue
+            txt = turn.get("value", "").strip()
+            n = approx_token_count(txt)
+            if args.min_tokens <= n <= args.max_tokens:
+                candidates.append(txt)
+                break  # one prompt per conversation; avoids near-duplicates
+    print(f"  {len(candidates)} prompts in [{args.min_tokens}, {args.max_tokens}] token range", file=sys.stderr)
+
+    if len(candidates) < args.count:
+        print(f"only {len(candidates)} candidates, need {args.count}", file=sys.stderr)
+        sys.exit(3)
+
+    # Seed: SHA256 of the user-supplied seed string → first 8 bytes as int.
+    seed_int = int(hashlib.sha256(args.seed.encode()).hexdigest()[:16], 16)
+    rng = random.Random(seed_int)
+    sample = rng.sample(candidates, args.count)
+
+    out = {
+        "seed": args.seed,
+        "count": args.count,
+        "tokenizer_estimator": "approx (4 bytes/token)",
+        "min_tokens": args.min_tokens,
+        "max_tokens": args.max_tokens,
+        "source": str(src.name),
+        "prompts": [
+            {"id": i, "text": p, "approx_tokens": approx_token_count(p)}
+            for i, p in enumerate(sample)
+        ],
+    }
+    Path(args.output).write_text(json.dumps(out, indent=2, ensure_ascii=False))
+    print(f"wrote {args.output}: {args.count} prompts (seed={args.seed})", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/bench/v0.2-cuda/pull_results.sh
+++ b/bench/v0.2-cuda/pull_results.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# pull_results.sh — exfil the bench results from the rented pod.
+# Run this LOCALLY (not on the pod). Test it mid-bench too — don't
+# wait until the end to discover SSH is misconfigured.
+#
+# Usage:
+#   POD_HOST=root@1.2.3.4 POD_PORT=22 bash pull_results.sh
+# Or set POD=user@host:port (alias):
+#   POD=root@1.2.3.4:22 bash pull_results.sh
+#
+# Pulls everything under the pod's /workspace/ferrum-infer-rs/bench/v0.2-cuda/
+# (results/, _env.txt, prompts.json) into a fresh local directory
+# named docs/bench/cuda-rtx4090-<today>/.
+
+set -euo pipefail
+
+if [[ -n "${POD:-}" ]]; then
+  POD_HOST="${POD%:*}"
+  POD_PORT="${POD##*:}"
+fi
+
+POD_HOST="${POD_HOST:?must set POD_HOST=user@host or POD=user@host:port}"
+POD_PORT="${POD_PORT:-22}"
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+DATE="$(date +%Y-%m-%d)"
+DEST="$ROOT/docs/bench/cuda-rtx4090-${DATE}"
+mkdir -p "$DEST"
+
+echo "rsyncing from $POD_HOST:$POD_PORT into $DEST/"
+rsync -avz -e "ssh -p $POD_PORT -o StrictHostKeyChecking=no" \
+  --exclude='*.gpu.csv'  `# can be huge; pull on demand` \
+  "$POD_HOST:/workspace/ferrum-infer-rs/bench/v0.2-cuda/" \
+  "$DEST/"
+
+echo
+echo "─── pulled artifacts ───"
+ls -lh "$DEST/" | head -10
+echo
+echo "─── result count ───"
+RESULTS_OK=$(find "$DEST/results" -name "*.json" 2>/dev/null | wc -l | xargs)
+echo "  JSON results: $RESULTS_OK / 144"
+echo
+echo "next: write the report at $DEST/README.md"

--- a/bench/v0.2-cuda/run_cell.sh
+++ b/bench/v0.2-cuda/run_cell.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# run_cell.sh — run ONE bench cell.
+#
+# Usage:
+#   run_cell.sh <engine> <model_tag> <c> <repeat> <port>
+#
+# Assumes the engine server is already running on $port and ready.
+# Calls vendored benchmark_serving.py against it. Saves:
+#   results/<engine>__<model_tag>__c<c>__r<repeat>.json
+#   results/<engine>__<model_tag>__c<c>__r<repeat>.bench.log
+#
+# Resume-safe: if the JSON exists with non-zero throughput, skip.
+
+set -euo pipefail
+
+ENGINE="$1"
+MODEL_TAG="$2"
+C="$3"
+REPEAT="$4"
+PORT="$5"
+
+WORKSPACE="${WORKSPACE:-/workspace}"
+BENCH_DIR="${WORKSPACE}/ferrum-infer-rs/bench/v0.2-cuda"
+RESULTS_DIR="$BENCH_DIR/results"
+mkdir -p "$RESULTS_DIR"
+
+CELL="${ENGINE}__${MODEL_TAG}__c${C}__r${REPEAT}"
+JSON="$RESULTS_DIR/$CELL.json"
+LOG="$RESULTS_DIR/$CELL.bench.log"
+
+# Resume: skip if already completed.
+if [[ -f "$JSON" ]]; then
+  EXISTING=$(python3 -c "import json,sys; print(json.load(open('$JSON')).get('output_throughput_tok_s',0))" 2>/dev/null || echo 0)
+  if [[ "$EXISTING" != "0" && "$EXISTING" != "0.0" ]]; then
+    echo "[$CELL] skip (already $EXISTING tok/s)"
+    exit 0
+  fi
+fi
+
+# num_prompts = 4 × c, capped at 128 (the size of our prompt set).
+NUM_PROMPTS=$((C * 4))
+[[ $NUM_PROMPTS -gt 128 ]] && NUM_PROMPTS=128
+
+# W1 (c=1) → output 512, prompt 128
+# W2/W3/W4 (c≥4) → output 256, prompt 512
+if [[ "$C" -eq 1 ]]; then
+  MAX_OUTPUT=512
+  PROMPT_LEN=128
+else
+  MAX_OUTPUT=256
+  PROMPT_LEN=512
+fi
+
+# nvidia-smi memory sampler (background)
+GPU_CSV="$RESULTS_DIR/$CELL.gpu.csv"
+nvidia-smi --query-gpu=timestamp,memory.used,utilization.gpu \
+  --format=csv,noheader,nounits -lms 2000 > "$GPU_CSV" &
+SMI_PID=$!
+trap "kill $SMI_PID 2>/dev/null || true" EXIT
+
+echo "[$CELL] num_prompts=$NUM_PROMPTS max_output=$MAX_OUTPUT"
+
+# Run with hard timeout — never let one cell burn 15+ min.
+# vLLM 0.20+ moved benchmark_serving.py to the CLI: `vllm bench serve`.
+# Same arg surface in spirit, slight flag differences.
+timeout 900 vllm bench serve \
+  --backend openai-chat \
+  --base-url "http://127.0.0.1:$PORT" \
+  --endpoint /v1/chat/completions \
+  --dataset-name custom \
+  --dataset-path "$BENCH_DIR/prompts.json" \
+  --num-prompts "$NUM_PROMPTS" \
+  --max-concurrency "$C" \
+  --request-rate inf \
+  --temperature 0 \
+  --top-p 1 \
+  --result-dir "$RESULTS_DIR" \
+  --result-filename "$CELL.json" \
+  > "$LOG" 2>&1 || {
+    EC=$?
+    echo "[$CELL] FAILED (exit=$EC) — see $LOG"
+    kill $SMI_PID 2>/dev/null || true
+    return $EC 2>/dev/null || exit $EC
+  }
+
+kill $SMI_PID 2>/dev/null || true
+trap - EXIT
+
+# Print one-line summary
+python3 -c "
+import json
+d = json.load(open('$JSON'))
+def f(x): return f'{x:.1f}' if isinstance(x, (int, float)) else 'n/a'
+tpot = d.get('tpot_ms', {})
+ttft = d.get('ttft_ms', {})
+print(f'[$CELL] out={f(d.get(\"output_throughput_tok_s\"))} tok/s  TPOT_p50={f(tpot.get(\"median\"))}ms  TPOT_p95={f(tpot.get(\"p95\"))}ms  TTFT_p50={f(ttft.get(\"median\"))}ms  TTFT_p95={f(ttft.get(\"p95\"))}ms  ({d.get(\"completed\", 0)}/{d.get(\"completed\", 0)+d.get(\"failed\", 0)} ok)')
+" 2>&1 || echo "[$CELL] (could not parse JSON)"

--- a/bench/v0.2-cuda/run_sweep.sh
+++ b/bench/v0.2-cuda/run_sweep.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+# run_sweep.sh — outer loop over the 144-cell matrix.
+#
+# Strategy (saves ~2 hr vs naive nested loop):
+#   - For each (engine, model) pair, start the server ONCE with
+#     --max-seqs=32 (covers all c values), prewarm with one small
+#     request, then iterate (c × repeat) without restarting.
+#   - 12 server starts total instead of 144.
+#
+# Order of (engine, model) pairs is fail-fast:
+#   M2 (Llama-INT4)   first  — smallest, lowest blast radius
+#   M1 (Llama-FP16)   second — biggest dense memory pressure
+#   M3 (Qwen3-MoE)    third  — first MoE; mistralrs may panic here
+#   M4 (Qwen3-Coder)  last   — same shape as M3, infrastructure proven
+#
+# Within each pair: c=1 first (catches correctness issues cheaply),
+# c=32 last (catches resource issues), 3 repeats per c.
+#
+# Resume-safe: every completed cell is detected by results/*.json
+# existing with output_throughput_tok_s > 0.
+
+set -uo pipefail
+
+WORKSPACE="${WORKSPACE:-/workspace}"
+BENCH_DIR="${WORKSPACE}/ferrum-infer-rs/bench/v0.2-cuda"
+RESULTS_DIR="$BENCH_DIR/results"
+MODELS_DIR="${WORKSPACE}/models"
+mkdir -p "$RESULTS_DIR"
+
+# Matrix axes
+ENGINES=(ferrum vllm mistralrs)
+MODEL_ORDER=(M2 M1 M3 M4)         # cheapest blast radius first
+CONCURRENCIES=(1 4 16 32)
+REPEATS=(1 2 3)
+
+# Per-pair max-seqs sized for c=32 max + headroom
+MAX_SEQS=64
+
+# Read models.txt into associative arrays
+declare -A MODEL_REPO MODEL_PRECISION MODEL_SIZE
+while IFS='|' read -r tag repo precision size; do
+  [[ -z "$tag" || "$tag" =~ ^# ]] && continue
+  MODEL_REPO[$tag]="$repo"
+  MODEL_PRECISION[$tag]="$precision"
+  MODEL_SIZE[$tag]="$size"
+done < "$BENCH_DIR/models.txt"
+
+# Engine launch / kill helpers (one fn per engine).
+PORT=8800
+
+ferrum_start() {
+  local model_tag="$1" model_dir="$MODELS_DIR/$model_tag"
+  local server_log="$RESULTS_DIR/ferrum__${model_tag}__server.log"
+  echo "  starting ferrum on $model_tag ..."
+  FERRUM_KV_PAGED=1 FERRUM_PAGED_MAX_SEQS=$MAX_SEQS FERRUM_KV_CAPACITY=1024 \
+  CUDA_VISIBLE_DEVICES=0 \
+    "$WORKSPACE/ferrum-infer-rs/target/release/ferrum" serve \
+      --model "$model_dir" --port "$PORT" \
+      > "$server_log" 2>&1 &
+  echo $!
+}
+
+vllm_start() {
+  local model_tag="$1" model_dir="$MODELS_DIR/$model_tag" precision="${MODEL_PRECISION[$model_tag]}"
+  local server_log="$RESULTS_DIR/vllm__${model_tag}__server.log"
+  local quant_args=""
+  if [[ "$precision" == "GPTQ_INT4" ]]; then
+    quant_args="--quantization gptq_marlin"
+  fi
+  echo "  starting vllm on $model_tag (quant=$precision) ..."
+  python3 -m vllm.entrypoints.openai.api_server \
+    --model "$model_dir" \
+    --port "$PORT" \
+    --max-num-seqs $MAX_SEQS \
+    --enable-prefix-caching false \
+    --disable-log-requests \
+    $quant_args \
+    > "$server_log" 2>&1 &
+  echo $!
+}
+
+mistralrs_start() {
+  local model_tag="$1" model_dir="$MODELS_DIR/$model_tag"
+  local server_log="$RESULTS_DIR/mistralrs__${model_tag}__server.log"
+  echo "  starting mistralrs on $model_tag ..."
+  mistralrs-server --port "$PORT" --max-seqs $MAX_SEQS \
+    plain -m "$model_dir" \
+    > "$server_log" 2>&1 &
+  echo $!
+}
+
+# Wait for the engine to be ready (up to 5 min). Kill if not up.
+wait_ready() {
+  local pid="$1"
+  for i in $(seq 1 300); do
+    if curl -sf "http://127.0.0.1:$PORT/v1/models" >/dev/null 2>&1; then
+      echo "  ready in ${i}s"
+      return 0
+    fi
+    if ! kill -0 "$pid" 2>/dev/null; then
+      echo "  process died before becoming ready"
+      return 1
+    fi
+    sleep 1
+  done
+  echo "  timeout (5 min) waiting for ready"
+  return 1
+}
+
+# Prewarm with one small chat completion (drops cold-start variance
+# from the very first cell of each pair).
+prewarm() {
+  curl -sf -m 60 -X POST "http://127.0.0.1:$PORT/v1/chat/completions" \
+    -H 'Content-Type: application/json' \
+    -d '{"model":"default","messages":[{"role":"user","content":"hi"}],"max_tokens":4,"temperature":0,"stream":false}' \
+    > /dev/null 2>&1 || true
+}
+
+# Cleanly kill the engine process tree.
+kill_engine() {
+  local pid="$1"
+  if [[ -n "$pid" ]]; then
+    kill -TERM "$pid" 2>/dev/null || true
+    sleep 2
+    kill -KILL "$pid" 2>/dev/null || true
+    wait "$pid" 2>/dev/null || true
+  fi
+  pkill -9 -f "vllm.entrypoints.openai.api_server" 2>/dev/null || true
+  pkill -9 -f "mistralrs-server" 2>/dev/null || true
+  pkill -9 -f "ferrum.*serve" 2>/dev/null || true
+  sleep 3
+}
+
+# ── outer loop ──────────────────────────────────────────────────────
+START_T=$SECONDS
+for engine in "${ENGINES[@]}"; do
+  for model in "${MODEL_ORDER[@]}"; do
+    PAIR="${engine}__${model}"
+    PAIR_LOG="$RESULTS_DIR/${PAIR}__pair.log"
+
+    # Skip pair if all 12 cells already exist.
+    REMAINING=0
+    for c in "${CONCURRENCIES[@]}"; do
+      for r in "${REPEATS[@]}"; do
+        cell="$RESULTS_DIR/${engine}__${model}__c${c}__r${r}.json"
+        if [[ ! -f "$cell" ]] || [[ "$(python3 -c "import json,sys; print(json.load(open('$cell')).get('output_throughput_tok_s',0))" 2>/dev/null || echo 0)" == "0.0" ]]; then
+          REMAINING=$((REMAINING+1))
+        fi
+      done
+    done
+    if [[ $REMAINING -eq 0 ]]; then
+      echo "── skip $PAIR (12/12 cells already done) ──"
+      continue
+    fi
+
+    echo
+    echo "════════════════════════════════════════════════════════════"
+    echo " $PAIR — $REMAINING cells remaining"
+    echo "════════════════════════════════════════════════════════════"
+
+    # Start server
+    case "$engine" in
+      ferrum)    PID=$(ferrum_start "$model")    ;;
+      vllm)      PID=$(vllm_start "$model")      ;;
+      mistralrs) PID=$(mistralrs_start "$model") ;;
+    esac
+
+    if ! wait_ready "$PID" >> "$PAIR_LOG" 2>&1; then
+      echo "  $PAIR FAILED to come up (see $PAIR_LOG and ${PAIR}__server.log) — skip 12 cells"
+      kill_engine "$PID"
+      continue
+    fi
+    prewarm
+
+    # Run all (c × repeat) cells against this server
+    for c in "${CONCURRENCIES[@]}"; do
+      for r in "${REPEATS[@]}"; do
+        bash "$BENCH_DIR/run_cell.sh" "$engine" "$model" "$c" "$r" "$PORT" || true
+      done
+    done
+
+    kill_engine "$PID"
+
+    # Disk space + time check
+    DISK_USED=$(df -h "$WORKSPACE" | tail -1 | awk '{print $5}')
+    ELAPSED=$((SECONDS - START_T))
+    echo "── $PAIR done; total elapsed: $((ELAPSED/60)) min; disk: $DISK_USED ──"
+  done
+done
+
+echo
+echo "═══════════════════════════════════════════════════════════"
+echo "  sweep complete in $(( (SECONDS - START_T) / 60 )) min"
+echo "  results: $RESULTS_DIR"
+echo "  exfil:   bash bench/v0.2-cuda/pull_results.sh   (run from local)"
+echo "═══════════════════════════════════════════════════════════"

--- a/bench/v0.2-cuda/setup.sh
+++ b/bench/v0.2-cuda/setup.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+# v0.2 CUDA bench — one-shot pod setup.
+#
+# Idempotent: re-running is safe (skips work that's done).
+#
+# Usage on a fresh RunPod / vast.ai RTX 4090 pod with PyTorch+CUDA:
+#   export HF_TOKEN=hf_...      # required for Llama-3.1-8B (gated)
+#   bash bench/v0.2-cuda/setup.sh
+#
+# Stages:
+#   1. apt deps (build-essential, git, jq, rsync) — for source builds
+#   2. Rust 1.91 — ferrum builds against this
+#   3. Clone ferrum, cargo build --release --features cuda
+#   4. pip install vllm==<pin>
+#   5. cargo install mistralrs-server --version <pin>
+#   6. parallel HF download of all 4 models to /workspace/models
+#   7. download ShareGPT v3 + generate prompts.json
+#   8. download vllm benchmark_serving.py
+#
+# Estimated wall: 40-60 min on a fresh pod. The dominant phases are
+# ferrum CUDA kernel compile (~20 min) and the 4 parallel model
+# downloads (~10-30 min depending on bandwidth).
+
+set -euo pipefail
+
+# ── pins (synced with versions.txt) ──────────────────────────────────
+FERRUM_REF="${FERRUM_REF:-v0.7.3}"
+VLLM_VERSION="${VLLM_VERSION:-0.20.0}"
+MISTRALRS_VERSION="${MISTRALRS_VERSION:-0.8.0}"
+VLLM_BENCH_TAG="${VLLM_BENCH_TAG:-v0.20.0}"
+
+# ── paths ────────────────────────────────────────────────────────────
+WORKSPACE="${WORKSPACE:-/workspace}"
+MODELS_DIR="${WORKSPACE}/models"
+DATASETS_DIR="${WORKSPACE}/datasets"
+FERRUM_DIR="${WORKSPACE}/ferrum-infer-rs"
+BENCH_DIR="${FERRUM_DIR}/bench/v0.2-cuda"
+mkdir -p "$MODELS_DIR" "$DATASETS_DIR"
+
+log()  { printf '\n\033[1;36m[setup] %s\033[0m\n' "$*"; }
+ok()   { printf '\033[1;32m  ✓ %s\033[0m\n' "$*"; }
+warn() { printf '\033[1;33m  ⚠ %s\033[0m\n' "$*"; }
+die()  { printf '\033[1;31m  ✗ %s\033[0m\n' "$*" >&2; exit 1; }
+
+# ── 1. apt deps ──────────────────────────────────────────────────────
+log "[1/8] apt deps"
+if ! command -v jq >/dev/null || ! command -v git >/dev/null || ! command -v rsync >/dev/null; then
+  apt-get update -q
+  apt-get install -y --no-install-recommends \
+    build-essential git jq rsync curl ca-certificates pkg-config libssl-dev cmake
+fi
+ok "apt deps in place"
+
+# ── 2. Rust ──────────────────────────────────────────────────────────
+log "[2/8] rust toolchain"
+if ! command -v cargo >/dev/null; then
+  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --profile minimal
+  # shellcheck disable=SC1091
+  source "$HOME/.cargo/env"
+fi
+ok "$(cargo --version)"
+
+# ── 3. ferrum clone + build ──────────────────────────────────────────
+log "[3/8] ferrum clone + cargo build --release --features cuda (~20 min CUDA kernel compile)"
+if [[ ! -d "$FERRUM_DIR" ]]; then
+  git clone https://github.com/sizzlecar/ferrum-infer-rs.git "$FERRUM_DIR"
+fi
+cd "$FERRUM_DIR"
+git fetch --tags --quiet
+git checkout "$FERRUM_REF" --quiet
+
+# CUDA_HOME is required by ferrum-kernels' build.rs (NVCC location).
+export CUDA_HOME="${CUDA_HOME:-/usr/local/cuda}"
+[[ -d "$CUDA_HOME" ]] || die "CUDA_HOME=$CUDA_HOME does not exist; image is probably wrong"
+export PATH="$CUDA_HOME/bin:$PATH"
+
+if [[ ! -x "$FERRUM_DIR/target/release/ferrum" ]]; then
+  cargo build --release -p ferrum-cli --bin ferrum --features cuda
+fi
+"$FERRUM_DIR/target/release/ferrum" --version | tee /dev/stderr
+ok "ferrum built"
+
+# ── 4. vLLM ──────────────────────────────────────────────────────────
+log "[4/8] vLLM ${VLLM_VERSION}"
+pip install --quiet "vllm==${VLLM_VERSION}"
+python -c "import vllm; print('  vllm:', vllm.__version__)"
+ok "vllm installed"
+
+# ── 5. mistralrs ─────────────────────────────────────────────────────
+log "[5/8] mistralrs-server ${MISTRALRS_VERSION}"
+if ! command -v mistralrs-server >/dev/null; then
+  cargo install --quiet --features cuda --version "${MISTRALRS_VERSION}" mistralrs-server || \
+    cargo install --quiet --version "${MISTRALRS_VERSION}" mistralrs-server
+fi
+mistralrs-server --version
+ok "mistralrs installed"
+
+# ── 6. parallel HF model downloads ───────────────────────────────────
+log "[6/8] HF model downloads (parallel, 4 jobs)"
+[[ -n "${HF_TOKEN:-}" ]] || warn "HF_TOKEN not set — Llama-3.1-8B (gated) will fail"
+pip install --quiet -U "huggingface_hub[cli]"
+
+download_one() {
+  local tag="$1" repo="$2"
+  local target="$MODELS_DIR/$tag"
+  if [[ -d "$target" && -n "$(ls "$target" 2>/dev/null)" ]]; then
+    echo "[$tag] $repo — already downloaded, skip"
+    return 0
+  fi
+  mkdir -p "$target"
+  echo "[$tag] downloading $repo to $target"
+  huggingface-cli download "$repo" --local-dir "$target" --quiet \
+    ${HF_TOKEN:+--token "$HF_TOKEN"} || {
+      echo "[$tag] FAILED" >&2
+      return 1
+    }
+  echo "[$tag] done ($(du -sh "$target" | cut -f1))"
+}
+export -f download_one
+export MODELS_DIR HF_TOKEN
+
+# Read pinned models from models.txt (skip comments / blank lines).
+DL_PIDS=()
+while IFS='|' read -r tag repo precision size; do
+  [[ -z "$tag" || "$tag" =~ ^# ]] && continue
+  download_one "$tag" "$repo" &
+  DL_PIDS+=($!)
+done < "$BENCH_DIR/models.txt"
+
+DL_FAILED=0
+for pid in "${DL_PIDS[@]}"; do
+  wait "$pid" || DL_FAILED=$((DL_FAILED+1))
+done
+[[ $DL_FAILED -gt 0 ]] && die "$DL_FAILED model download(s) failed"
+df -h "$WORKSPACE" | tail -1
+ok "all 4 models downloaded"
+
+# ── 7. ShareGPT + prompts.json ───────────────────────────────────────
+log "[7/8] ShareGPT subset"
+SG_FILE="$DATASETS_DIR/ShareGPT_V3_unfiltered_cleaned_split.json"
+if [[ ! -f "$SG_FILE" ]]; then
+  huggingface-cli download anon8231489123/ShareGPT_Vicuna_unfiltered \
+    ShareGPT_V3_unfiltered_cleaned_split.json \
+    --local-dir "$DATASETS_DIR" --quiet
+fi
+SEED="$(git -C "$FERRUM_DIR" rev-parse --short HEAD)"
+python3 "$BENCH_DIR/prompts_subset.py" \
+  --input "$SG_FILE" \
+  --output "$BENCH_DIR/prompts.json" \
+  --seed "$SEED"
+ok "prompts.json built (seed=$SEED)"
+
+# ── 8. bench harness verification ────────────────────────────────────
+# vLLM 0.20+ moved benchmark_serving.py into the CLI: `vllm bench serve`.
+# It's already available since we pip-installed vllm above. Just
+# verify `vllm bench serve --help` runs.
+log "[8/8] verify \`vllm bench serve\` CLI"
+vllm bench serve --help > /tmp/vllm_bench_help.txt 2>&1 || \
+  die "\`vllm bench serve --help\` failed — vllm install is broken"
+HELP_LINES=$(wc -l < /tmp/vllm_bench_help.txt)
+[[ "$HELP_LINES" -lt 30 ]] && die "vllm bench serve help output suspiciously short ($HELP_LINES lines)"
+ok "vllm bench serve CLI available ($HELP_LINES help lines)"
+
+# ── final environment fingerprint ────────────────────────────────────
+log "writing _env.txt"
+{
+  echo "=== v0.2 CUDA bench environment fingerprint ==="
+  echo "captured: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  echo
+  echo "--- hardware ---"
+  nvidia-smi -q 2>&1 | grep -E "Product Name|Driver Version|CUDA Version|Total " | head
+  echo
+  echo "--- cuda toolkit ---"
+  nvcc --version 2>&1 | tail -3 || true
+  echo
+  echo "--- cpu / ram ---"
+  grep -m1 "model name" /proc/cpuinfo | awk -F: '{print $2}' | xargs
+  echo "cpu cores: $(nproc)"
+  echo "ram: $(grep MemTotal /proc/meminfo | awk '{printf "%.1f GB", $2/1024/1024}')"
+  echo
+  echo "--- engine versions ---"
+  echo "ferrum: $($FERRUM_DIR/target/release/ferrum --version)"
+  echo "ferrum git: $(git -C $FERRUM_DIR rev-parse HEAD) ($FERRUM_REF)"
+  echo "vllm: $(python -c 'import vllm; print(vllm.__version__)')"
+  echo "mistralrs: $(mistralrs-server --version 2>&1 | head -1)"
+  echo "rust: $(cargo --version)"
+  echo
+  echo "--- model HF revisions ---"
+  for d in "$MODELS_DIR"/*/; do
+    if [[ -f "$d/config.json" ]]; then
+      echo "$(basename "$d"): $(du -sh "$d" | cut -f1) — $(jq -r '._name_or_path // "?"' "$d/config.json" 2>/dev/null)"
+    fi
+  done
+  echo
+  echo "--- bench harness ---"
+  echo "benchmark_serving.py: vllm-project/vllm@${VLLM_BENCH_TAG}"
+  echo "prompts.json: $(jq -r '.count' "$BENCH_DIR/prompts.json") prompts, seed=$(jq -r '.seed' "$BENCH_DIR/prompts.json")"
+} > "$BENCH_DIR/_env.txt"
+cat "$BENCH_DIR/_env.txt"
+
+echo
+echo "─────────────────────────────────────────────────────"
+echo " setup complete in $SECONDS s"
+echo " next: bash $BENCH_DIR/run_sweep.sh"
+echo "─────────────────────────────────────────────────────"

--- a/bench/v0.2-cuda/versions.txt
+++ b/bench/v0.2-cuda/versions.txt
@@ -1,0 +1,12 @@
+# v0.2 CUDA bench — engine version pins.
+# Anyone reproducing this bench should pin to these exact versions.
+#
+ferrum=0.7.3                # this repo, `cargo build --release --features cuda`
+vllm=0.20.0                 # `pip install vllm==0.20.0`
+mistralrs=0.8.0             # `cargo install mistralrs-server --version 0.8.0`
+benchmark_serving=vllm@v0.20.0  # vendored from vLLM repo at this tag
+
+# CUDA / driver minimums implied by the pins above:
+cuda>=12.4
+driver>=550
+sm>=80                      # Marlin requires Ampere+; RTX 4090 = sm_89 (Ada)

--- a/docs/bench/v0.2-cuda/README.md
+++ b/docs/bench/v0.2-cuda/README.md
@@ -1,0 +1,329 @@
+# ferrum v0.2 — CUDA / RTX 4090 Benchmark Plan
+
+**Status:** drafted 2026-05-03, not yet executed
+**Target test runner:** RunPod RTX 4090 (24 GB), $0.40/hr, ≤ $10 total
+**Headline goal:** Publish a v0.2 bench report comparing **ferrum vs vLLM vs mistralrs** across **4 model × precision configs × 4 concurrency levels = 48 cells × 3 repeats = 144 runs**, with the same audit-quality rigor as the macOS Group A bench at [`docs/bench/macos-2026-05-02/`](../macos-2026-05-02/).
+
+This doc is the **plan**. The actual run, raw artifacts, and final report will be at `docs/bench/cuda-rtx4090-2026-05-XX/` (date filled in when we kick off).
+
+---
+
+## 1. What we're proving
+
+| Claim | Bench cell that proves it |
+|---|---|
+| ferrum's CUDA decode runner holds up at single-request | c=1 across all 4 models |
+| ferrum's continuous batching scales to c=16/32 | c=16, c=32 across Llama-8B INT4 + 30B-A3B INT4 |
+| ferrum is competitive with vLLM in the price-conscious-deployment lane | Side-by-side same hardware / same dataset |
+| ferrum doesn't fall apart on MoE under concurrent load | Qwen3-30B-A3B + Qwen3-Coder-30B-A3B at c=16+ |
+| GPTQ INT4 + Marlin gets us to vLLM-level memory efficiency | INT4 cells fit comfortably; FP16-8B is the contrast |
+
+Non-goal: be the fastest engine on H100 8×. We're pitching **single-GPU 4090 / single binary / Python-free** — the bench has to mirror that deployment.
+
+---
+
+## 2. Budget math
+
+| Item | Estimate |
+|---|---|
+| Wall-clock at $0.40/hr | 25 hours (≤ $10) |
+| Cold-start engine (boot + load) | 30 s (8B INT4) → 90 s (30B INT4) |
+| Per bench cell wall time | c=1: ~60 s · c=4: ~150 s · c=16: ~120 s · c=32: ~120 s |
+| Total bench wall | ~7-8 hr (see § 6 for derivation) |
+| Setup + model download | 30-45 min one-time |
+| Buffer (debugging, OOM retries, partial reruns) | ~6 hr |
+
+**Cost target: $5-7 used, $3-5 buffer.** Headroom matters because the first 1-2 hours **will** discover something (vLLM CUDA mismatch, Qwen3-Coder-30B GPTQ doesn't exist, mistralrs panics on MoE again, ...).
+
+---
+
+## 3. Test matrix
+
+### 3.1 Models × precision
+
+| # | Model | Precision | HF source (target — verify in pre-flight) | On-disk |
+|---|---|---|---|---|
+| M1 | Llama-3.1-8B-Instruct | FP16 | `meta-llama/Llama-3.1-8B-Instruct` (safetensors) | 16 GB |
+| M2 | Llama-3.1-8B-Instruct | GPTQ-INT4 | `hugging-quants/Meta-Llama-3.1-8B-Instruct-GPTQ-INT4` | 5.7 GB |
+| M3 | Qwen3-30B-A3B | GPTQ-INT4 | `Qwen/Qwen3-30B-A3B-Instruct-2507-GPTQ-Int4` (verify) | 17 GB |
+| M4 | Qwen3-Coder-30B-A3B | GPTQ-INT4 | `Qwen/Qwen3-Coder-30B-A3B-Instruct-GPTQ-Int4` (verify) | 17 GB |
+
+**Pre-flight verification (§ 5)**: M3/M4 GPTQ versions may not exist; if not, the fallback is to AWQ-Int4 the model on-pod (slow) or drop M4 entirely.
+
+### 3.2 Engines
+
+| # | Engine | Pin | Notes |
+|---|---|---|---|
+| E1 | ferrum | this repo @ v0.7.3+ (`cargo build --release --features cuda`) | Marlin INT4 path; FERRUM_KV_PAGED auto for serve |
+| E2 | vLLM | `vllm==0.7.3` (pin in pre-flight) | Force `--quantization gptq_marlin` for INT4 |
+| E3 | mistralrs | `mistralrs-server` latest stable | Known to PoisonError on Qwen3-MoE GGUF — try GPTQ safetensors path |
+
+### 3.3 Workloads
+
+| # | Workload | c | Prompt tokens | Output tokens | Total tokens/req |
+|---|---|---:|---:|---:|---:|
+| W1 | single decode | 1 | 128 | 512 | 640 |
+| W2 | mid concurrency | 4 | 512 | 256 | 768 |
+| W3 | high concurrency | 16 | 512 | 256 | 768 |
+| W4 | extreme concurrency | 32 | 512 | 256 | 768 |
+
+Per-c prompt counts (so the run isn't dominated by head/tail): **`num_prompts = 4 × c`** → 4, 16, 64, 128.
+
+### 3.4 Held constant across all cells
+
+- **Compute precision**: BF16 (or whatever the engine defaults to for INT4 matmul; vLLM does FP16/BF16 + Marlin INT4 dequant on-the-fly, ferrum ditto)
+- **KV cache dtype**: FP16 (vLLM `--kv-cache-dtype auto` defaults to model dtype; ferrum's KV is FP16 by default)
+- **Sampler**: greedy / temperature 0 / top-p 1 (deterministic — every run produces the same logits, so noise is engine, not RNG)
+- **Tokenizer**: HF official tokenizer.json shipped with the model
+- **Bench harness**: vLLM's `benchmarks/benchmark_serving.py` — same script, same dataset, same protocol (OpenAI SSE)
+- **Dataset**: ShareGPT v3 unfiltered, deterministic 128-prompt subset (seeded), padded/truncated to W's prompt-length budget
+- **Prefix cache**: explicitly disabled on every engine (otherwise the deterministic prompt set hits the cache after the first repeat and the second/third repeats land at unrealistic throughput)
+
+### 3.5 Cell counting
+
+```
+4 models × 3 engines × 4 workloads = 48 cells
+× 3 repetitions (for noise floor / median)
+= 144 runs total
+```
+
+**Reporting**: median of 3 (drops the worst run). p50/p95 of TTFT and TPOT come from the per-request distribution **within** each median run — not across runs.
+
+---
+
+## 4. Held metric definitions
+
+To prevent ambiguity at report time:
+
+| Metric | Definition | Where it comes from |
+|---|---|---|
+| Aggregate output throughput (tok/s) | total output tokens / wall time of the bench | `benchmark_serving.py: output_throughput_tok_s` |
+| TTFT (Time to First Token) | wall time from POST sent to first SSE chunk | `benchmark_serving.py: ttft_ms` distribution |
+| TPOT (Time per Output Token) | (E2E time − TTFT) / (output tokens − 1), per request | `benchmark_serving.py: tpot_ms` |
+| ITL (Inter-Token Latency) | time between consecutive output tokens | `benchmark_serving.py: itl_ms` |
+| Memory occupied | peak `nvidia-smi memory.used` during the run | sample every 5s with `nvidia-smi --query-gpu=memory.used --format=csv,noheader -lms 5000` |
+
+p50 = median, p95 = 95th percentile. Distribution is across all requests in a single bench run.
+
+---
+
+## 5. Pre-flight (LOCAL, FREE — must pass before renting)
+
+Every minute we spend on the rented box at $0.40/hr is a minute not spent locally for free. The pre-flight is the unfair advantage.
+
+### 5.1 Engine availability
+
+- [ ] `cargo build --release -p ferrum-cli --features cuda` builds on the M1 Max (it cross-compiles the Rust glue; CUDA kernels need an NVCC step that fails locally — that's expected, defer to RunPod). Confirm the **non-CUDA-kernel** parts of the cuda feature compile.
+- [ ] `cargo install vllm` — N/A; vLLM is Python. Verify `pip install vllm==<pin>` resolves on Linux x86_64 + CUDA 12.x.
+- [ ] `cargo install mistralrs-server --version <pin>` — at least lock the version we'll bench so the report is reproducible.
+
+### 5.2 Model availability
+
+- [ ] M1: `huggingface-cli download meta-llama/Llama-3.1-8B-Instruct --revision <commit> --token $HF_TOKEN` (gated — confirm token works)
+- [ ] M2: similarly, find a working GPTQ-INT4 pack. Candidates: `hugging-quants/Meta-Llama-3.1-8B-Instruct-GPTQ-INT4`. Verify it loads in vLLM and ferrum locally (CPU loader can at least parse).
+- [ ] **M3 / M4**: Search HF for `Qwen3-30B-A3B-*-GPTQ-Int4` and `Qwen3-Coder-30B-A3B-*-GPTQ-Int4`. If only AWQ exists, decide: switch to AWQ across the board, or drop the cell.
+- [ ] All 4 model IDs frozen in `bench/v0.2-cuda/models.txt` BEFORE renting.
+
+### 5.3 Bench harness sanity (M1 Max)
+
+- [ ] Pull vLLM's `benchmarks/benchmark_serving.py` (their version, not ours from the macOS bench — vLLM's is what they cite, so cite back). Pin it to a vLLM tag.
+- [ ] Run it against ferrum locally on `qwen3:0.6b` at c=1 — proves the harness wiring works. Won't tell us anything about CUDA performance but rules out tokenizer / OpenAI-shape mismatches.
+- [ ] Source ShareGPT v3 subset; freeze the 128-prompt seed-deterministic slice as `bench/v0.2-cuda/prompts.json`.
+
+### 5.4 Scripts authored locally
+
+`bench/v0.2-cuda/` will hold:
+- `setup.sh` — one-shot, run on rented box first (apt deps, Rust, build ferrum, pip install vllm, cargo install mistralrs, download models to network volume).
+- `run_ferrum.sh` `run_vllm.sh` `run_mistralrs.sh` — single-engine launchers parameterized by `<MODEL_ID> <port>`.
+- `run_cell.sh <engine> <model> <c>` — runs one cell: starts engine if not running, prewarms, calls `benchmark_serving.py`, saves JSON, kills engine.
+- `run_sweep.sh` — outer loop over the matrix, calls `run_cell.sh` 144 times. Skips cells whose output JSON already exists (resume safe).
+- `pull_results.sh` — runs locally; rsync results back from the pod.
+
+All scripts authored and committed BEFORE the pod boots. Mistakes in shell logic at $0.40/hr are real money.
+
+### 5.5 RunPod template selection
+
+- [ ] Pick a template with PyTorch + CUDA pre-baked (saves ~20 min CUDA install). Suggest `runpod/pytorch:2.4.0-py3.11-cuda12.4.1-devel-ubuntu22.04`.
+- [ ] Network volume: 100 GB at `/workspace`. Models persist across pod restarts so we don't re-download on resume.
+- [ ] On-demand instance (cheaper than reserved). RTX 4090 24GB single-GPU. ≥ 64 GB system RAM (some engines are RAM-hungry on prefill).
+- [ ] **Pre-rent**: one cheap 5-min boot to verify driver version supports our vLLM pin (CUDA 12.4 + driver ≥ 550 for vLLM 0.7+).
+
+### 5.6 SSH + data exfil
+
+- [ ] SSH key registered on vast / RunPod profile.
+- [ ] `pull_results.sh` is `rsync -avz pod:/workspace/ferrum-infer-rs/bench/v0.2-cuda/results/ ./bench/v0.2-cuda/results/`. Test rsync mid-bench (after 10 cells) to confirm exfil works — don't wait until the end.
+
+---
+
+## 6. Sweep execution order (fail-fast)
+
+The naive nested loop `for model: for engine: for c: for repeat:` is 144 cold starts. **We don't do that.**
+
+Better: keep each (engine, model) server up while sweeping the c axis. Cold-start is ~30-90 s, so collapsing 16 c-values per server start saves ~10 min/server × 12 servers = 2 hr.
+
+```
+for model in [M2 (Llama-INT4), M1 (Llama-FP16), M3 (Qwen3-30B-INT4), M4 (Qwen3-Coder-30B-INT4)]:
+    for engine in [ferrum, vllm, mistralrs]:
+        start engine ONCE with --max-seqs=32 (covers all c)
+        prewarm with 1 small request
+        for workload in [W1 c=1, W2 c=4, W3 c=16, W4 c=32]:
+            for repeat in [1, 2, 3]:
+                run benchmark_serving.py — saves JSON
+        kill engine
+```
+
+**Order rationale**:
+
+1. **M2 (Llama-INT4) first** — smallest, lowest blast radius. Uncovers most engine bugs cheaply. If vLLM's `gptq_marlin` flag is wrong, we find out in cell 1 not cell 80.
+2. **M1 (Llama-FP16) second** — only at this point are we paying real GPU memory cost. FP16-8B + KV at c=32 is the tightest fit on 24 GB; if anything OOMs it's here.
+3. **M3 (Qwen3-30B-INT4) third** — first MoE, biggest weights. mistralrs may PoisonError; document and skip.
+4. **M4 (Qwen3-Coder-30B-INT4) last** — same shape as M3, so any infrastructure issue is already debugged.
+
+**Within each (engine, model)**: c=1 first, c=32 last. c=1 surfaces correctness issues (gibberish output → tokenizer mismatch), c=32 surfaces resource issues. Walking up the c ladder makes failures attributable.
+
+**Cell wall-time budget**:
+
+| Phase | Cells | Per-cell | Subtotal |
+|---|---|---|---|
+| Smoke (engine boot + 1 c=1 cell each) | 12 | 90 s | 18 min |
+| Full matrix bench runs | 144 | ~150 s | 360 min = 6.0 hr |
+| Inter-engine model load | 12 server starts | 60 s avg | 12 min |
+| Total inside the pod | | | **~6.5 hr** |
+| Setup + model download | | one-shot | 30-45 min |
+| Buffer (OOMs / retries / debug) | | | 4-6 hr |
+| **Grand total** | | | **~12 hr — safely under 25 hr / $10** |
+
+Per-cell wall: `prewarm (5s) + bench_serving (variable: 60 s @ c=1 with 512 outputs and ~30 tok/s, 120 s @ c=32 with 256 outputs / 32 prompts and ~150 tok/s aggregate) + cooldown (5s)`. ~150 s average is the working number.
+
+---
+
+## 7. Failure handling
+
+### 7.1 Per-cell timeout
+
+Every `bench_serving.py` call wrapped in `timeout 900 ...` (15 min). If hit, kill the engine, log the cell as `FAILED`, continue. Don't let one stuck request torch the whole budget.
+
+### 7.2 Per-(engine, model) timeout
+
+If a server can't get past the smoke c=1 in 5 min, mark the whole (engine, model) pair as broken and skip its 12 cells. Document in the report.
+
+### 7.3 Resume protocol
+
+`run_sweep.sh` checks for `results/<engine>__<model>__c<n>__r<rep>.json` before each cell. If exists with `output_throughput_tok_s > 0`, skip. So a pod restart loses ≤ 1 cell.
+
+### 7.4 Disk space
+
+`/workspace` should have ~100 GB. Models eat ~55 GB. Per-run JSON + log = a few hundred KB. Should never fill, but log `df -h /workspace` every 10 cells defensively.
+
+### 7.5 vLLM-specific risks
+
+- **Marlin requires Ampere+** — RTX 4090 is Ada (sm_89), should be fine. Verify in pre-flight.
+- **Long prefill OOMs**: at c=32 + prompt 512, prefill batch is up to 16 384 tokens. vLLM may need `--max-num-batched-tokens` tuned. Plan: start with default, lower if OOM.
+- **Rope scaling on Llama-3.1**: vLLM auto-detects from config; verify it doesn't warn.
+
+### 7.6 mistralrs-specific risks
+
+- Known: PoisonError on Qwen3-30B-A3B Q4_K_M GGUF (per memory). Try the GPTQ safetensors path which goes through a different loader.
+- If still panics: report as `panic` in the cell and move on. We did the same in macOS bench.
+
+### 7.7 ferrum-specific risks
+
+- Triton w4a16 + ContinuousBatch scheduler hits NaN on prefill (per CLAUDE.md). For this bench, use **Marlin** path explicitly (`FERRUM_TRITON_INT4=0`, the default) and document.
+- 30B-A3B + paged-KV at c=32 might exceed 24 GB. Plan: keep `KV_CAPACITY=512` default, watch GPU memory, drop max_seqs if OOM.
+
+---
+
+## 8. Data collection
+
+### 8.1 Per-cell artifacts (saved to `/workspace/.../results/`)
+
+```
+<engine>__<model>__c<n>__r<rep>.json    # benchmark_serving.py output
+<engine>__<model>__c<n>__r<rep>.bench.log  # harness stdout
+<engine>__<model>__c<n>__r<rep>.server.log # engine stdout (last 500 lines)
+<engine>__<model>__c<n>__r<rep>.gpu.csv  # nvidia-smi mem trace
+```
+
+### 8.2 Suite-level fingerprint (saved once)
+
+`_suite_env.txt`:
+- `nvidia-smi -q` (driver, GPU, memory, ECC state)
+- `nvcc --version`
+- `cat /proc/cpuinfo | head` (for completeness)
+- `pip freeze` (vLLM + deps)
+- `cargo --version`, `git rev-parse HEAD` for ferrum + mistralrs
+- HF model commit hashes (resolved from snapshot dir)
+
+### 8.3 Final report structure
+
+`docs/bench/cuda-rtx4090-2026-05-XX/README.md`, mirroring the macOS report:
+1. Headline tables (4 models × 3 engines, output throughput at each c)
+2. TTFT p50/p95 at c=16 (latency-sensitive)
+3. Memory at c=32 (capacity story)
+4. Hardware + software fingerprint
+5. Methodology (ShareGPT subset, harness pin, prompt-length normalization)
+6. How to reproduce (the same scripts, with model IDs filled in)
+7. Caveats (mistralrs MoE failures, vLLM Marlin sm_89 confirmation, ferrum CUDA Graph capture state at run time)
+
+---
+
+## 9. Risks and mitigations
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| Qwen3-Coder-30B-A3B GPTQ-Int4 doesn't exist on HF | Medium | Pre-flight § 5.2; if missing, drop M4 or AWQ-quant on-pod (60 min one-time) |
+| RTX 4090 OOM on FP16-8B + c=32 | Low (math says 19 GB worst case, fits) | Pre-compute KV math; if hits, drop c=32 for M1 only |
+| vLLM Marlin path not usable on Ada (sm_89) | Low | Verify in pre-flight; fallback `--quantization gptq` (Marlin's predecessor) |
+| mistralrs panics on M3+M4 (MoE) | High (per macOS history) | Document, skip those cells; M3+M4 mistralrs columns will show `panic` |
+| Pod gets pre-empted mid-bench (RunPod can do this on spot pricing) | Low if on-demand | Always on-demand pricing; resume protocol § 7.3 covers it |
+| ShareGPT licensing | Medium | Use the publicly-available unfiltered snapshot; cite source. If concerned, swap for vLLM's synthetic prompts |
+| Wall-clock blows past 25 hr | Low (estimate is 12 hr) | If we burn 15 hr and only 50% done, drop the 3 repetitions to 1 — single-run instead of median |
+| GPU is cold the first 2-3 min and skews c=1 numbers | Low | First cell of each (engine, model) is a smoke run that's discarded |
+
+---
+
+## 10. Out of scope (explicit, per user)
+
+- H100 / A100 / multi-GPU (4090 single-card is the price-conscious story)
+- Tensor / pipeline parallelism (single 4090 can't fit a model that needs it for this matrix)
+- KV cache quantization (FP16 KV across all engines, fair comparison only)
+- Perplexity / accuracy validation (correctness is verified by spot-checking a few outputs in pre-flight; quality benchmarks are a separate concern)
+- Model architectures outside Llama / Qwen3 dense / Qwen3-MoE
+- Qwen3.6 (vLLM doesn't support it on RTX 4090 per user)
+- Custom datasets — ShareGPT only
+
+---
+
+## 11. Open questions (resolve in pre-flight)
+
+1. **Which exact GPTQ-Int4 of Qwen3-30B-A3B / Qwen3-Coder-30B-A3B do we use?** Answer required before renting.
+2. **Pin vLLM to which version?** Latest stable that still supports Llama-3.1 GPTQ-Marlin on Ada (sm_89). Likely 0.7.x.
+3. **Pin mistralrs to which version?** Latest stable.
+4. **ShareGPT exact subset?** Seed = ferrum's repo rev hash (deterministic), 128 prompts, prompt-length filter ≥ 128 + ≤ 512 tokens.
+5. **Do we test with sampling temperature 0 only, or also 0.7?** Plan: 0.0 (deterministic, removes RNG noise). Anyone interested in sampling-cost can re-run with the same scripts later.
+6. **Do we report cost-per-million-tokens?** Yes — derived metric: `$/hr ÷ aggregate tok/s × 3600 × 1e6`. Adds a "ferrum is cheaper per token" angle.
+
+---
+
+## 12. Execution checklist (sign off before renting)
+
+- [ ] All four model HF repos exist and have GPTQ-Int4 if needed. **OWNER: pre-flight day**
+- [ ] All scripts in `bench/v0.2-cuda/` committed and reviewed
+- [ ] `prompts.json` (128 deterministic prompts) committed
+- [ ] vLLM + mistralrs versions pinned, RunPod image template chosen
+- [ ] `setup.sh` smoke-tested: at minimum, `bash -n setup.sh` lints; ideally one cheap 30-min pod boot to validate the install path
+- [ ] `pull_results.sh` rsync target ready locally
+- [ ] HF_TOKEN exported (Llama-3.1 is gated)
+- [ ] CARGO_REGISTRY_TOKEN NOT exported on the pod (we don't publish from there)
+- [ ] $10 of credit on the GPU vendor account
+- [ ] Local M1 Max ferrum smoke run on the harness passes
+
+---
+
+## 13. Reference
+
+- macOS Group A bench: [`docs/bench/macos-2026-05-02/`](../macos-2026-05-02/) — same rigor template we're matching
+- vLLM benchmark harness: https://github.com/vllm-project/vllm/blob/main/benchmarks/benchmark_serving.py
+- ShareGPT v3 unfiltered: typical mirror at `lmsys/lmsys-chat-1m` or `anon8231489123/ShareGPT_Vicuna_unfiltered`
+- ferrum CUDA decode runner: `crates/ferrum-kernels/src/cuda/decode_runner.rs`
+- ferrum Marlin INT4: `crates/ferrum-kernels/src/cuda/marlin.rs`


### PR DESCRIPTION
Implements the runtime half of [\`docs/bench/v0.2-cuda/README.md\`](docs/bench/v0.2-cuda/README.md) (PR #89).

Authored entirely locally so the rented RTX 4090 pod ($0.40/hr) doesn't waste a single minute on shell-debug.

\`bench/v0.2-cuda/\`:
- \`models.txt\` — 4 frozen HF IDs (verified live on HF; M3 is **Qwen-official** \`Qwen/Qwen3-30B-A3B-GPTQ-Int4\`)
- \`versions.txt\` — vLLM 0.20.0 · mistralrs 0.8.0 · ferrum 0.7.3
- \`prompts_subset.py\` — deterministic 128-prompt ShareGPT subset (smoke-tested locally on synthetic data ✓)
- \`setup.sh\` — idempotent pod setup, ~40-60 min wall, parallel HF downloads
- \`run_cell.sh\` — one bench cell with 15-min hard timeout + nvidia-smi mem trace + resume-safe JSON check
- \`run_sweep.sh\` — outer loop, **12 server starts not 144**, c=1→32 within each (engine, model) pair, fail-fast order M2→M1→M3→M4
- \`pull_results.sh\` — local rsync exfil

All scripts \`bash -n\` lint clean.

vLLM 0.20+ moved \`benchmark_serving.py\` into the CLI as \`vllm bench serve\` — using that directly instead of vendoring an old tag (cleaner, no pinning of two deps).

Next step is renting the pod. Will be a separate PR with the actual results report under \`docs/bench/cuda-rtx4090-2026-05-XX/\`.