### PR TITLE
fix(kernels/cuda): match Backend::gemm_quant trait signature

### DIFF
--- a/crates/ferrum-kernels/src/backend/cuda.rs
+++ b/crates/ferrum-kernels/src/backend/cuda.rs
@@ -1073,19 +1073,21 @@ impl Backend for CudaBackend {
     // is already production-grade (112 tok/s on RTX PRO 6000 per pre-v2
     // benchmarks); wiring is a structural concern, not a kernel concern.
 
+    // Trait signature was tightened (`Self::QuantStore` instead of the
+    // historical 8-param `QuantWeights` shape). The CUDA path no longer
+    // dispatches through this entry — INT4 goes through `gemm_gptq +
+    // GptqStore`, k-quants stay on Metal/CPU. Stub kept so the trait
+    // is satisfied and the cuda feature builds on Linux.
     fn gemm_quant(
         _ctx: &mut Self::Context,
         _a: &Self::Buffer,
-        _weights: &QuantWeights<'_, Self>,
+        _weight: &Self::QuantStore,
         _out: &mut Self::Buffer,
         _m: usize,
-        _n: usize,
-        _k: usize,
-        kind: &QuantKind,
     ) -> Result<()> {
-        Err(FerrumError::unsupported(format!(
-            "CudaBackend::gemm_quant({kind:?}) deprecated — use gemm_gptq + GptqStore"
-        )))
+        Err(FerrumError::unsupported(
+            "CudaBackend::gemm_quant deprecated — use gemm_gptq + GptqStore",
+        ))
     }
 
     // ── GPTQ INT4 dispatch (Marlin default; Triton-rs alt via env) ──────


### PR DESCRIPTION
The CUDA \`Backend::gemm_quant\` impl was at an old 8-param signature; the trait expects 5 params. Compiled fine on macOS (cuda feature gated off) and in CI (\`cargo check\` apparently misses this path). Real Linux + CUDA + RTX 4090 (\`cargo build --release --features cuda\`) immediately fails.

The body is just a \`FerrumError::unsupported\` stub — runtime INT4 dispatches via \`gemm_gptq + GptqStore\`, this entry is never hit. Just bringing the signature back in line with the trait so the cuda feature builds on Linux for the v0.2 bench.

Discovered during v0.2 RTX 4090 bench setup (pod 36043869). Need this merged + a fresh \`v0.7.4\` (or just a main pull on the pod) to unblock setup.sh.