### PR TITLE
perf(moe-cuda): Stage 11+12+12.1 — 256→320 tok/s c=32 (+25%) on M3

### DIFF
--- a/bench/v0.2-cuda/m3_fused.sh
+++ b/bench/v0.2-cuda/m3_fused.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+# M3 fused MoE Marlin bench (Stage 12). Adds FERRUM_MOE_FUSED=1 to
+# m3_clean.sh — same model, same workload, ONE-launch-per-bucket
+# Marlin path instead of multi-stream per-expert. Direct A/B vs Stage
+# 9 baseline (267.7 tok/s c=32 on 2026-05-08).
+
+set -uo pipefail
+
+WORKSPACE="${WORKSPACE:-/workspace}"
+BENCH_DIR="${WORKSPACE}/ferrum-infer-rs/bench/v0.2-cuda"
+RESULTS_DIR="$BENCH_DIR/results_m3_fused"
+MODEL_DIR="${WORKSPACE}/models/M3"
+mkdir -p "$RESULTS_DIR"
+
+PORT=8800
+
+echo "=== M3 fused MoE Marlin bench (Stage 12) ==="
+nvidia-smi --query-gpu=name,memory.free --format=csv,noheader
+echo ""
+
+SERVER_LOG="$RESULTS_DIR/ferrum_fused__server.log"
+
+CUDA_VISIBLE_DEVICES=0 \
+FERRUM_KV_CAPACITY=2048 \
+FERRUM_KV_MAX_BLOCKS=4096 \
+FERRUM_PAGED_MAX_SEQS=32 \
+FERRUM_METAL_PAGED_KV=1 \
+FERRUM_MIXED_BATCH=0 \
+FERRUM_GREEDY_ARGMAX=1 \
+FERRUM_MOE_BUCKETED=1 \
+FERRUM_MARLIN_SKIP_WS_ZERO=1 \
+FERRUM_MOE_STREAMS=4 \
+FERRUM_MOE_FUSED=1 \
+  "$WORKSPACE/ferrum-infer-rs/target/release/ferrum" serve \
+    --model "$MODEL_DIR" --port "$PORT" \
+    --gpu-memory-utilization 0.95 \
+    > "$SERVER_LOG" 2>&1 &
+PID=$!
+
+for i in $(seq 1 600); do
+  if curl -sf "http://127.0.0.1:$PORT/v1/models" >/dev/null 2>&1; then
+    echo "ready in ${i}s"
+    break
+  fi
+  if ! kill -0 "$PID" 2>/dev/null; then
+    echo "process died"
+    tail -50 "$SERVER_LOG"
+    exit 1
+  fi
+  sleep 1
+done
+
+curl -s "http://127.0.0.1:$PORT/v1/chat/completions" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"x","messages":[{"role":"user","content":"hi"}],"max_tokens":4,"stream":false}' \
+  >/dev/null
+
+for c in 1 8 16 32; do
+  vllm bench serve \
+    --backend openai-chat \
+    --base-url "http://127.0.0.1:$PORT" \
+    --endpoint /v1/chat/completions \
+    --model "$MODEL_DIR" \
+    --tokenizer "$MODEL_DIR" \
+    --dataset-name random \
+    --random-input-len 256 --random-output-len 128 \
+    --num-prompts $((c * 4)) \
+    --max-concurrency $c \
+    --save-result --result-dir "$RESULTS_DIR" \
+    --result-filename "ferrum_fused_c${c}.json" \
+    --percentile-metrics "ttft,tpot,itl" 2>&1 | tee "$RESULTS_DIR/ferrum_fused_c${c}.log"
+done
+
+kill -INT "$PID" 2>/dev/null
+wait "$PID" 2>/dev/null
+
+echo ""
+echo "=== headlines (FERRUM_MOE_FUSED=1) ==="
+for c in 1 8 16 32; do
+  python3 -c "
+import json
+d = json.load(open('$RESULTS_DIR/ferrum_fused_c${c}.json'))
+print(f'c=${c}  output_throughput={d[\"output_throughput\"]:.1f} tok/s   mean_tpot={d[\"mean_tpot_ms\"]:.2f} ms   mean_ttft={d[\"mean_ttft_ms\"]:.0f} ms')
+"
+done

--- a/bench/v0.2-cuda/m3_fused_flash.sh
+++ b/bench/v0.2-cuda/m3_fused_flash.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+# Stage 13a bench: fused MoE Marlin + batched paged-decode flash split-K.
+# Adds FERRUM_PAGED_FLASH=1 over m3_fused.sh.
+
+set -uo pipefail
+
+WORKSPACE="${WORKSPACE:-/workspace}"
+BENCH_DIR="${WORKSPACE}/ferrum-infer-rs/bench/v0.2-cuda"
+RESULTS_DIR="$BENCH_DIR/results_m3_fused_flash"
+MODEL_DIR="${WORKSPACE}/models/M3"
+mkdir -p "$RESULTS_DIR"
+
+PORT=8800
+
+echo "=== M3 fused MoE Marlin + paged-flash bench (Stage 13a) ==="
+nvidia-smi --query-gpu=name,memory.free --format=csv,noheader
+echo ""
+
+SERVER_LOG="$RESULTS_DIR/ferrum_fused_flash__server.log"
+
+CUDA_VISIBLE_DEVICES=0 \
+FERRUM_KV_CAPACITY=2048 \
+FERRUM_KV_MAX_BLOCKS=4096 \
+FERRUM_PAGED_MAX_SEQS=32 \
+FERRUM_METAL_PAGED_KV=1 \
+FERRUM_MIXED_BATCH=0 \
+FERRUM_GREEDY_ARGMAX=1 \
+FERRUM_MOE_BUCKETED=1 \
+FERRUM_MARLIN_SKIP_WS_ZERO=1 \
+FERRUM_MOE_STREAMS=4 \
+FERRUM_MOE_FUSED=1 \
+FERRUM_PAGED_FLASH=1 \
+  "$WORKSPACE/ferrum-infer-rs/target/release/ferrum" serve \
+    --model "$MODEL_DIR" --port "$PORT" \
+    --gpu-memory-utilization 0.95 \
+    > "$SERVER_LOG" 2>&1 &
+PID=$!
+
+for i in $(seq 1 600); do
+  if curl -sf "http://127.0.0.1:$PORT/v1/models" >/dev/null 2>&1; then
+    echo "ready in ${i}s"
+    break
+  fi
+  if ! kill -0 "$PID" 2>/dev/null; then
+    echo "process died"
+    tail -50 "$SERVER_LOG"
+    exit 1
+  fi
+  sleep 1
+done
+
+curl -s "http://127.0.0.1:$PORT/v1/chat/completions" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"x","messages":[{"role":"user","content":"hi"}],"max_tokens":4,"stream":false}' \
+  >/dev/null
+
+for c in 1 8 16 32; do
+  vllm bench serve \
+    --backend openai-chat \
+    --base-url "http://127.0.0.1:$PORT" \
+    --endpoint /v1/chat/completions \
+    --model "$MODEL_DIR" \
+    --tokenizer "$MODEL_DIR" \
+    --dataset-name random \
+    --random-input-len 256 --random-output-len 128 \
+    --num-prompts $((c * 4)) \
+    --max-concurrency $c \
+    --save-result --result-dir "$RESULTS_DIR" \
+    --result-filename "ferrum_fused_flash_c${c}.json" \
+    --percentile-metrics "ttft,tpot,itl" 2>&1 | tee "$RESULTS_DIR/ferrum_fused_flash_c${c}.log"
+done
+
+kill -INT "$PID" 2>/dev/null
+wait "$PID" 2>/dev/null
+
+echo ""
+echo "=== headlines (FERRUM_MOE_FUSED=1 + FERRUM_PAGED_FLASH=1) ==="
+for c in 1 8 16 32; do
+  python3 -c "
+import json
+d = json.load(open('$RESULTS_DIR/ferrum_fused_flash_c${c}.json'))
+print(f'c=${c}  output_throughput={d[\"output_throughput\"]:.1f} tok/s   mean_tpot={d[\"mean_tpot_ms\"]:.2f} ms   mean_ttft={d[\"mean_ttft_ms\"]:.0f} ms')
+"
+done

--- a/bench/v0.2-cuda/m3_prof_fused.sh
+++ b/bench/v0.2-cuda/m3_prof_fused.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# c=32 only, FERRUM_DECODE_OP_PROFILE on. Surfaces per-op timings to
+# the server log. Used to find the bottleneck driving Stage 12's small
+# 5% gain.
+
+set -uo pipefail
+WORKSPACE="${WORKSPACE:-/workspace}"
+BENCH_DIR="${WORKSPACE}/ferrum-infer-rs/bench/v0.2-cuda"
+RESULTS_DIR="$BENCH_DIR/results_m3_prof_fused"
+MODEL_DIR="${WORKSPACE}/models/M3"
+mkdir -p "$RESULTS_DIR"
+PORT=8800
+SERVER_LOG="$RESULTS_DIR/server_prof.log"
+
+CUDA_VISIBLE_DEVICES=0 \
+FERRUM_KV_CAPACITY=2048 \
+FERRUM_KV_MAX_BLOCKS=4096 \
+FERRUM_PAGED_MAX_SEQS=32 \
+FERRUM_METAL_PAGED_KV=1 \
+FERRUM_MIXED_BATCH=0 \
+FERRUM_GREEDY_ARGMAX=1 \
+FERRUM_MOE_BUCKETED=1 \
+FERRUM_MARLIN_SKIP_WS_ZERO=1 \
+FERRUM_MOE_STREAMS=4 \
+FERRUM_MOE_FUSED=1 \
+FERRUM_DECODE_OP_PROFILE=1 \
+  "$WORKSPACE/ferrum-infer-rs/target/release/ferrum" serve \
+    --model "$MODEL_DIR" --port "$PORT" \
+    --gpu-memory-utilization 0.95 > "$SERVER_LOG" 2>&1 &
+PID=$!
+for i in $(seq 1 600); do
+  if curl -sf "http://127.0.0.1:$PORT/v1/models" >/dev/null 2>&1; then echo "ready in ${i}s"; break; fi
+  if ! kill -0 "$PID" 2>/dev/null; then echo "died"; tail -50 "$SERVER_LOG"; exit 1; fi
+  sleep 1
+done
+curl -s "http://127.0.0.1:$PORT/v1/chat/completions" -H "Content-Type: application/json" \
+  -d '{"model":"x","messages":[{"role":"user","content":"hi"}],"max_tokens":4,"stream":false}' >/dev/null
+vllm bench serve --backend openai-chat --base-url "http://127.0.0.1:$PORT" \
+  --endpoint /v1/chat/completions --model "$MODEL_DIR" --tokenizer "$MODEL_DIR" \
+  --dataset-name random --random-input-len 256 --random-output-len 128 \
+  --num-prompts 128 --max-concurrency 32 --percentile-metrics ttft,tpot,itl 2>&1 | tail -25
+kill -INT "$PID" 2>/dev/null
+wait "$PID" 2>/dev/null
+echo === DECODE PROFILE TAIL ===
+grep -E "\[decode-prof\]|\[bucket-prof\]|\[moe-prof\]|\[attn-prof\]|\[stage-prof\]" "$SERVER_LOG" | tail -80

--- a/crates/ferrum-kernels/kernels/marlin_cuda_kernel.cu
+++ b/crates/ferrum-kernels/kernels/marlin_cuda_kernel.cu
@@ -1000,7 +1000,24 @@ extern "C" int marlin_cuda_moe(
   }
   int thread_m_blocks = tot_m_blocks;
 
-  int blocks = sms;  // gridDim.x
+  // ── gridDim.x = n_tiles_per_expert (NOT sms) — Stage 12.1 ────────────
+  // Original Marlin uses gridDim.x = sms cooperating blocks per GEMM,
+  // each doing 1 tile. Setup overhead per block (~3 µs) >> per-tile work
+  // when m=16. Stage 12 inherited that → 100 active experts × 128
+  // blocks/expert = 12800 blocks/launch, 96 do work, 32 idle. Setup
+  // dominates.
+  //
+  // For MoE-fused with gridDim.y = num_experts, we already get parallelism
+  // across experts. Within one expert, n_tiles=3 is enough — pick blocks
+  // = n_tiles so each block processes ALL k-tiles for one n-tile. Per-
+  // block work scales 32×, setup amortizes. Total grid = (3, 100) =
+  // 300 blocks → 2.3 waves on 128 SMs vs 100 waves before.
+  //
+  // Cooperating-block barriers are bypassed: slice_count=1 so locks
+  // are never read/written. Existing kernel logic handles this case.
+  int n_tiles = prob_n / (16 * thread_n_blocks);
+  if (n_tiles <= 0) n_tiles = 1;
+  int blocks = n_tiles;
   int* locks = (int*) workspace;
   const int4* A_ptr = (const int4*) A;
   const int4* B_ptr = (const int4*) B;

--- a/crates/ferrum-kernels/kernels/marlin_cuda_kernel.cu
+++ b/crates/ferrum-kernels/kernels/marlin_cuda_kernel.cu
@@ -206,17 +206,64 @@ __global__ void Marlin(
   int  prob_n_full, // full N stride of B + s buffers (≥ prob_n;
                     // for stacked-MoE offset GEMM, stride is total_n
                     // while iteration covers only expert_n cols)
-  int* locks // extra global storage for barrier synchronization
+  int* locks, // extra global storage for barrier synchronization
+  // ── MoE-fused dispatch (Stage 11) ────────────────────────────────────
+  // When all four pointers are non-null and `expert_count > 0`, the
+  // kernel reads `e_local = blockIdx.y` (∈ [0, expert_count)), maps it
+  // to a real expert id `e = active_expert_ids[e_local]`, and adjusts
+  // A/B/C/s/locks pointers + prob_m so this block processes that
+  // expert's column-slice GEMM. gridDim.y must equal `expert_count`;
+  // gridDim.x stays `sms` (cooperating blocks per expert).
+  //
+  // Layout assumptions (built by `load_gptq_stacked` + caller):
+  //   A: pre-gathered `[total_pairs, prob_k]` fp16, expert e's rows
+  //      live at `[A_row_offsets[e], A_row_offsets[e] + tokens_per_expert[e])`.
+  //   B / s: stacked per-expert with stride `b_int4_per_expert` /
+  //      `s_int4_per_expert` int4 elements between experts.
+  //   locks: stacked per-expert with stride `locks_i32_per_expert`
+  //      int32 elements between experts.
+  //
+  // When any of these pointers is null OR expert_count == 0, the kernel
+  // runs as the original single-GEMM path (existing call sites).
+  const int* __restrict__ A_row_offsets        = nullptr,
+  const int* __restrict__ tokens_per_expert    = nullptr,
+  const int* __restrict__ active_expert_ids    = nullptr,
+  int        expert_count                      = 0,
+  int        b_int4_per_expert                 = 0,
+  int        s_int4_per_expert                 = 0,
+  int        locks_i32_per_expert              = 0
 ) {
-  // Each threadblock processes one "stripe" of the B matrix with (roughly) the same size, which might involve multiple 
-  // column "slices" (of width 16 * `thread_n_blocks`). Stripes are defined as shown in the 3x3 matrix 5 SM example: 
-  //   0 1 3 
+  // Each threadblock processes one "stripe" of the B matrix with (roughly) the same size, which might involve multiple
+  // column "slices" (of width 16 * `thread_n_blocks`). Stripes are defined as shown in the 3x3 matrix 5 SM example:
+  //   0 1 3
   //   0 2 3
   //   1 2 4
   // While this kind of partitioning makes things somewhat more complicated, it ensures good utilization of all SMs
-  // for many kinds of shape and GPU configurations, while requiring as few slow global cross-threadblock reductions as 
+  // for many kinds of shape and GPU configurations, while requiring as few slow global cross-threadblock reductions as
   // possible.
-  
+
+  // ── MoE pre-amble: pointer + prob_m fixup before any other logic ─────
+  // After this block, the rest of the kernel sees the same args as if
+  // it had been launched with this expert's per-GEMM parameters. The
+  // existing slice-distribution logic (uses gridDim.x / blockIdx.x) is
+  // unchanged — gridDim.y just selects which expert this block handles.
+  if (A_row_offsets != nullptr && expert_count > 0) {
+    int e_local = blockIdx.y;
+    int e = (active_expert_ids != nullptr) ? active_expert_ids[e_local] : e_local;
+    int row_start = A_row_offsets[e];
+    int m_e = tokens_per_expert[e];
+    if (m_e <= 0) return;  // expert with zero tokens — skip cleanly
+    prob_m = m_e;
+    // Each row of A is `prob_k / 8` int4; each row of C is `prob_n / 8`
+    // int4 (here prob_n is the per-expert output width, equal to
+    // prob_n_full when bucket members all have the same N tile).
+    A += (long long)row_start * (prob_k / 8);
+    C += (long long)row_start * (prob_n / 8);
+    B += (long long)e * (long long)b_int4_per_expert;
+    s += (long long)e * (long long)s_int4_per_expert;
+    locks += (long long)e * (long long)locks_i32_per_expert;
+  }
+
   // For larger GEMMs we run multiple batchsize 64 versions in parallel for a better partitioning with less reductions
   int parallel = 1;
   if (prob_m > 16 * thread_m_blocks) {
@@ -729,7 +776,35 @@ const int SHARED_MEM = 96 * 1024; // max shared memory on compute capability 8.6
     ><<<blocks, THREADS, SHARED_MEM, stream>>>( \
       A_ptr, B_ptr, C_ptr, s_ptr, \
       prob_m, prob_n, prob_k, prob_n_full, \
-      locks \
+      locks, \
+      nullptr, nullptr, nullptr, 0, 0, 0, 0 \
+    ); \
+  }
+
+// MoE-fused launch: gridDim.y = expert_count, each block handles one expert.
+// thread_m_blocks here is the BUCKET-WIDE worst-case (= ceil(max_tokens_per_expert_in_bucket / 16)),
+// which means experts with fewer tokens get the kernel's existing pad-with-zero
+// path engaged. This is ~1.5× wasted compute for under-filled experts but
+// eliminates the per-expert launch overhead (~5µs each).
+#define CALL_IF_MOE(THREAD_M_BLOCKS, THREAD_N_BLOCKS, THREAD_K_BLOCKS, GROUP_BLOCKS) \
+  else if ( \
+    thread_m_blocks == THREAD_M_BLOCKS && thread_n_blocks == THREAD_N_BLOCKS && thread_k_blocks == THREAD_K_BLOCKS && \
+    group_blocks == GROUP_BLOCKS \
+  ) { \
+    cudaFuncSetAttribute( \
+      Marlin<THREADS, THREAD_M_BLOCKS, THREAD_N_BLOCKS, THREAD_K_BLOCKS, STAGES, GROUP_BLOCKS>, \
+      cudaFuncAttributeMaxDynamicSharedMemorySize, \
+      SHARED_MEM \
+    ); \
+    dim3 grid_dim(blocks, expert_count, 1); \
+    Marlin< \
+      THREADS, THREAD_M_BLOCKS, THREAD_N_BLOCKS, THREAD_K_BLOCKS, STAGES, GROUP_BLOCKS \
+    ><<<grid_dim, THREADS, SHARED_MEM, stream>>>( \
+      A_ptr, B_ptr, C_ptr, s_ptr, \
+      prob_m, prob_n, prob_k, prob_n_full, \
+      locks, \
+      A_row_offsets, tokens_per_expert, active_expert_ids, \
+      expert_count, b_int4_per_expert, s_int4_per_expert, locks_i32_per_expert \
     ); \
   }
 
@@ -835,6 +910,117 @@ extern "C" int marlin_cuda(
     A_ptr += 16 * thread_m_blocks * (prob_k / 8) * par;
     C_ptr += 16 * thread_m_blocks * (prob_n / 8) * par;
   }
+
+  return ret;
+}
+
+
+// ────────────────────────────────────────────────────────────────────────
+// Stage 11 — Fused MoE Marlin: ONE launch processes all experts in a
+// bucket via gridDim.y indirection. Caller pre-buckets experts by their
+// thread_m_blocks selection (≤ 4) and fires one call per bucket.
+//
+// Layout assumptions (built by `load_gptq_stacked` + caller):
+//   A: pre-gathered `[total_pairs, prob_k]` fp16. Row range
+//      [A_row_offsets[e], A_row_offsets[e] + tokens_per_expert[e]) holds
+//      expert e's input rows.
+//   B: stacked, expert e at int4 offset `e * b_int4_per_expert`.
+//   s: stacked, expert e at int4 offset `e * s_int4_per_expert`.
+//   workspace: stacked, expert e at int32 offset `e * locks_i32_per_expert`.
+//   C: pre-allocated `[total_pairs, prob_n]` fp16, same row range as A.
+//
+// `active_expert_ids[i]` (i ∈ [0, expert_count)) gives the global expert
+// id for bucket slot i; can be NULL for identity (all experts in bucket
+// order [0..expert_count)). Caller is responsible for ensuring all
+// experts in this call share the same prob_n, prob_k, group_size.
+//
+// Returns 0 on success, ERR_PROB_SHAPE / ERR_KERN_SHAPE otherwise.
+// ────────────────────────────────────────────────────────────────────────
+extern "C" int marlin_cuda_moe(
+  const void* A,                 // pre-gathered [total_pairs, prob_k] fp16
+  const void* B,                 // stacked [E, n_per_expert, k/8 i32]
+        void* C,                 // [total_pairs, prob_n] fp16
+        void* s,                 // stacked [E, k/group_size, n_per_expert] fp16
+  int prob_m,                    // bucket-wide max-m (= 16 * thread_m_blocks bucket choice)
+  int prob_n,                    // per-expert N (uniform within bucket)
+  int prob_k,                    // K (uniform across all experts)
+  void* workspace,               // stacked [E, locks_i32_per_expert] i32 (caller pre-zeroed)
+  const int* A_row_offsets,      // device [E] cumulative row offset of expert e in A
+  const int* tokens_per_expert,  // device [E] m for expert e (0 = skip)
+  const int* active_expert_ids,  // device [expert_count] bucket→global; or NULL for identity
+  int expert_count,              // experts in this bucket
+  int b_int4_per_expert,         // = (n_per_expert * k) / 32 int4
+  int s_int4_per_expert,         // = (k/group_size * n_per_expert) / 8 int4
+  int locks_i32_per_expert,      // = (n_per_expert / 128) * MAX_PAR
+  int groupsize = -1,
+  int dev = 0,
+  cudaStream_t stream = 0,
+  int thread_k = -1,
+  int thread_n = -1,
+  int sms = -1,
+  int prob_n_full = -1
+) {
+  if (expert_count <= 0) return 0;
+  if (prob_n_full < 0) prob_n_full = prob_n;
+  if (sms == -1) cudaDeviceGetAttribute(&sms, cudaDevAttrMultiProcessorCount, dev);
+
+  if (thread_k == -1 || thread_n == -1) {
+    if (prob_m <= 16) {
+      thread_k = 128;
+      thread_n = 128;
+    } else {
+      thread_k = 64;
+      thread_n = 256;
+    }
+    const char* env = std::getenv("FERRUM_MARLIN_TILE");
+    if (env != nullptr) {
+      if (strcmp(env, "64x256") == 0) { thread_k = 64;  thread_n = 256; }
+      else if (strcmp(env, "128x128") == 0) { thread_k = 128; thread_n = 128; }
+      else if (strcmp(env, "64x128") == 0) { thread_k = 64;  thread_n = 128; }
+      else if (strcmp(env, "128x64") == 0) { thread_k = 128; thread_n = 64;  }
+    }
+  }
+
+  int thread_k_blocks = thread_k / 16;
+  int thread_n_blocks = thread_n / 16;
+  int group_blocks = (groupsize == -1) ? -1 : groupsize / 16;
+
+  if (prob_n % thread_n != 0 || prob_k % thread_k != 0 ||
+      (group_blocks != -1 && prob_k % group_blocks != 0)) {
+    return ERR_PROB_SHAPE;
+  }
+  if (prob_n == 0 || prob_k == 0 || prob_m == 0) return 0;
+
+  // Bucket choice: thread_m_blocks ∈ {1, 2, 3, 4} based on prob_m
+  // (= 16 × thread_m_blocks for a properly bucketed call).
+  int tot_m_blocks = ceildiv(prob_m, 16);
+  if (tot_m_blocks <= 0 || tot_m_blocks > 4) {
+    // Caller must split bucket if max m > 64.
+    return ERR_PROB_SHAPE;
+  }
+  int thread_m_blocks = tot_m_blocks;
+
+  int blocks = sms;  // gridDim.x
+  int* locks = (int*) workspace;
+  const int4* A_ptr = (const int4*) A;
+  const int4* B_ptr = (const int4*) B;
+  int4* C_ptr = (int4*) C;
+  const int4* s_ptr = (const int4*) s;
+
+  int ret = 0;
+  if (false) {}
+  CALL_IF_MOE(1,  8,  8, -1)
+  CALL_IF_MOE(1,  8,  8,  8)
+  CALL_IF_MOE(1, 16,  4, -1)
+  CALL_IF_MOE(1, 16,  4,  8)
+  CALL_IF_MOE(2, 16,  4, -1)
+  CALL_IF_MOE(2, 16,  4,  8)
+  CALL_IF_MOE(3, 16,  4, -1)
+  CALL_IF_MOE(3, 16,  4,  8)
+  CALL_IF_MOE(4, 16,  4, -1)
+  CALL_IF_MOE(4, 16,  4,  8)
+  else
+    ret = ERR_KERN_SHAPE;
 
   return ret;
 }

--- a/crates/ferrum-kernels/kernels/paged_decode_attention.cu
+++ b/crates/ferrum-kernels/kernels/paged_decode_attention.cu
@@ -387,3 +387,184 @@ extern "C" __global__ void paged_flash_decode_attn_f16(
 
 // Phase 2 reduce is identical to flash_decode_attention.cu — reuse that kernel.
 // The reduce kernel only reads from partial_out/m/l which are layout-independent.
+
+// ===================== Batched (multi-seq) Flash Decode for Paged KV =====================
+//
+// Same algorithm as paged_flash_decode_attn_f16 but the grid carries an
+// extra seq_idx so c=32 decode dispatches in ONE kernel launch instead
+// of 32 per-seq calls. Each (q_head, seq, split) block does its chunk
+// of one (q, k, v) attention. Phase 2 reduces partials per (seq, head).
+//
+// Layout:
+//   q              [num_seqs, num_q_heads, head_dim]
+//   k_pool/v_pool  [max_blocks, block_size, num_kv_heads, head_dim]
+//   block_tables   [num_seqs, max_blocks_per_seq]
+//   valid_kv_lens  [num_seqs]
+//   partial_out    [num_seqs, num_q_heads, num_splits, head_dim] f32
+//   partial_m / l  [num_seqs, num_q_heads, num_splits]            f32
+//
+// Grid: (num_q_heads, num_seqs, num_splits)
+// Block: 256 threads
+// Shared: chunk_size * sizeof(float)
+extern "C" __global__ void paged_batched_flash_decode_attn_f16(
+    const __half* __restrict__ q,
+    const __half* __restrict__ k_block_pool,
+    const __half* __restrict__ v_block_pool,
+    const int*    __restrict__ block_tables,    // [num_seqs, max_blocks_per_seq]
+    const int*    __restrict__ valid_kv_lens,   // [num_seqs]
+    float* __restrict__ partial_out,
+    float* __restrict__ partial_m,
+    float* __restrict__ partial_l,
+    const int num_q_heads,
+    const int num_kv_heads,
+    const int head_dim,
+    const int max_blocks_per_seq,
+    const int block_size,
+    const float scale,
+    const int num_splits
+) {
+    const int q_head   = blockIdx.x;
+    const int seq_idx  = blockIdx.y;
+    const int split_id = blockIdx.z;
+    const int kv_head  = q_head / (num_q_heads / num_kv_heads);
+
+    const int valid_kv_len = valid_kv_lens[seq_idx];
+    const int chunk_size = (valid_kv_len + num_splits - 1) / num_splits;
+    const int split_start = split_id * chunk_size;
+    const int split_end = min(split_start + chunk_size, valid_kv_len);
+    const int my_len = split_end - split_start;
+
+    // Linear index into [seq, head, split] partials.
+    const int sh_idx = seq_idx * num_q_heads + q_head;
+    const int out_idx = sh_idx * num_splits + split_id;
+
+    if (my_len <= 0) {
+        if (threadIdx.x == 0) {
+            partial_m[out_idx] = -1e20f;
+            partial_l[out_idx] = 0.0f;
+        }
+        for (int d = threadIdx.x; d < head_dim; d += blockDim.x)
+            partial_out[out_idx * head_dim + d] = 0.0f;
+        return;
+    }
+
+    const int kv_stride = num_kv_heads * head_dim;
+    const int block_stride_val = block_size * kv_stride;
+    const int* my_block_table = block_tables + seq_idx * max_blocks_per_seq;
+
+    // q is [num_seqs, num_q_heads, head_dim] token-major.
+    const __half* q_ptr =
+        q + ((size_t)seq_idx * num_q_heads + q_head) * head_dim;
+
+    const int elems_per_thread = (head_dim + WARP_SIZE - 1) / WARP_SIZE;
+    float q_reg[8];
+    #pragma unroll
+    for (int i = 0; i < 8; i++) {
+        int d = (threadIdx.x % WARP_SIZE) + i * WARP_SIZE;
+        q_reg[i] = (i < elems_per_thread && d < head_dim)
+            ? __half2float(q_ptr[d]) : 0.0f;
+    }
+
+    int warp_id = threadIdx.x / WARP_SIZE;
+    int lane_id = threadIdx.x % WARP_SIZE;
+    int num_warps = blockDim.x / WARP_SIZE;
+
+    extern __shared__ float smem[];
+
+    // Step 1: Q·K^T for this chunk (paged)
+    for (int pos = warp_id; pos < my_len; pos += num_warps) {
+        int kv_pos = split_start + pos;
+        const __half* k_row = paged_kv_ptr(
+            k_block_pool, my_block_table, kv_pos,
+            block_size, block_stride_val, kv_stride, kv_head, head_dim);
+        float dot = 0.0f;
+        #pragma unroll
+        for (int i = 0; i < 8; i++) {
+            int d = lane_id + i * WARP_SIZE;
+            if (i < elems_per_thread && d < head_dim)
+                dot += q_reg[i] * __half2float(k_row[d]);
+        }
+        float score = warp_reduce_sum(dot) * scale;
+        if (lane_id == 0)
+            smem[pos] = score;
+    }
+    __syncthreads();
+
+    // Step 2: Local softmax
+    float thread_max = -1e20f;
+    for (int i = threadIdx.x; i < my_len; i += blockDim.x)
+        thread_max = fmaxf(thread_max, smem[i]);
+    float local_max = block_reduce_max(thread_max);
+    __shared__ float s_max;
+    if (threadIdx.x == 0) s_max = local_max;
+    __syncthreads();
+    local_max = s_max;
+
+    float thread_sum = 0.0f;
+    for (int i = threadIdx.x; i < my_len; i += blockDim.x) {
+        float v = expf(smem[i] - local_max);
+        smem[i] = v;
+        thread_sum += v;
+    }
+    __syncthreads();
+    float local_sum = block_reduce_sum(thread_sum);
+    __shared__ float s_sum;
+    if (threadIdx.x == 0) s_sum = local_sum;
+    __syncthreads();
+
+    if (threadIdx.x == 0) {
+        partial_m[out_idx] = local_max;
+        partial_l[out_idx] = s_sum;
+    }
+
+    // Step 3: Weighted V sum (paged, unnormalized)
+    float* out_ptr = partial_out + out_idx * head_dim;
+    for (int d = threadIdx.x; d < head_dim; d += blockDim.x) {
+        float acc = 0.0f;
+        for (int i = 0; i < my_len; i++) {
+            int kv_pos = split_start + i;
+            const __half* v_row = paged_kv_ptr(
+                v_block_pool, my_block_table, kv_pos,
+                block_size, block_stride_val, kv_stride, kv_head, head_dim);
+            acc += smem[i] * __half2float(v_row[d]);
+        }
+        out_ptr[d] = acc;
+    }
+}
+
+// Phase 2: per-(seq, head) reduce across splits.
+// Grid: (num_q_heads, num_seqs); Block: 128 threads (head_dim parallel).
+extern "C" __global__ void paged_batched_flash_decode_reduce_f16(
+    const float* __restrict__ partial_out,  // [num_seqs, num_q_heads, num_splits, head_dim]
+    const float* __restrict__ partial_m,    // [num_seqs, num_q_heads, num_splits]
+    const float* __restrict__ partial_l,    // [num_seqs, num_q_heads, num_splits]
+    __half* __restrict__ output,            // [num_seqs, num_q_heads, head_dim]
+    const int num_q_heads,
+    const int head_dim,
+    const int num_splits
+) {
+    const int q_head = blockIdx.x;
+    const int seq_idx = blockIdx.y;
+    const int sh_idx = seq_idx * num_q_heads + q_head;
+    const int base = sh_idx * num_splits;
+
+    float global_max = -1e20f;
+    for (int s = 0; s < num_splits; s++)
+        global_max = fmaxf(global_max, partial_m[base + s]);
+
+    float rescale[MAX_SPLITS];
+    float global_sum = 0.0f;
+    for (int s = 0; s < num_splits; s++) {
+        rescale[s] = expf(partial_m[base + s] - global_max);
+        global_sum += partial_l[base + s] * rescale[s];
+    }
+    float inv_sum = (global_sum > 0.0f) ? (1.0f / global_sum) : 0.0f;
+
+    __half* out_ptr = output + sh_idx * head_dim;
+    for (int d = threadIdx.x; d < head_dim; d += blockDim.x) {
+        float acc = 0.0f;
+        for (int s = 0; s < num_splits; s++)
+            acc += partial_out[(base + s) * head_dim + d] * rescale[s];
+        out_ptr[d] = __float2half(acc * inv_sum);
+    }
+}

--- a/crates/ferrum-kernels/src/backend/cuda.rs
+++ b/crates/ferrum-kernels/src/backend/cuda.rs
@@ -1644,6 +1644,30 @@ impl Backend for CudaBackend {
         if num_seqs == 0 {
             return Ok(());
         }
+
+        // Stage 13a: optional split-K path for batched paged decode. With
+        // num_seqs * num_q_heads ≥ sms (saturated grid), splitting kv adds
+        // launch overhead but improves pipelining at long kv_len. Default
+        // OFF (FERRUM_PAGED_FLASH unset) so existing path stays.
+        if std::env::var("FERRUM_PAGED_FLASH").map_or(false, |v| v == "1") {
+            return paged_batched_flash_dispatch(
+                ctx,
+                q,
+                k_pool,
+                v_pool,
+                out,
+                block_tables,
+                valid_kv_lens,
+                num_seqs,
+                max_kv_len,
+                num_heads,
+                num_kv_heads,
+                head_dim,
+                block_size,
+                max_blocks_per_seq,
+            );
+        }
+
         let func = ctx.func(
             "paged_batched_decode_attn",
             ptx::PAGED_DECODE_ATTENTION,
@@ -4021,6 +4045,225 @@ fn paged_varlen_split_k_dispatch(
             Ok::<(), FerrumError>(())
         },
     )
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Stage 13a — Batched paged-decode flash (split-K)
+//
+// Same idea as the varlen split-K path but for q_len=1 batched decode
+// (gridDim.y = num_seqs). Phase 1 splits each seq's kv across `num_splits`
+// chunks; phase 2 reduces partials per (seq, head).
+//
+// FERRUM_PAGED_FLASH=1 selects this over the single-pass kernel. Default
+// OFF.
+// ────────────────────────────────────────────────────────────────────────
+#[allow(clippy::too_many_arguments)]
+fn paged_batched_flash_dispatch(
+    ctx: &mut CudaState,
+    q: &CudaSlice<f16>,
+    k_pool: &CudaSlice<f16>,
+    v_pool: &CudaSlice<f16>,
+    out: &mut CudaSlice<f16>,
+    block_tables: &CudaSlice<f16>,
+    valid_kv_lens: &CudaSlice<f16>,
+    num_seqs: usize,
+    max_kv_len: usize,
+    num_heads: usize,
+    num_kv_heads: usize,
+    head_dim: usize,
+    block_size: usize,
+    max_blocks_per_seq: usize,
+) -> Result<()> {
+    // Pick num_splits. For batched decode the grid is already saturated
+    // (num_seqs * num_heads ≥ 1024 at c=32), so splits add cost. Only
+    // worth it when kv is long enough that split parallelism overcomes
+    // launch overhead.
+    let num_splits: usize = match max_kv_len {
+        kv if kv <= 256 => 1, // skip split-K — single pass faster
+        kv if kv <= 1024 => 2,
+        kv if kv <= 2048 => 4,
+        _ => 8,
+    };
+    if num_splits <= 1 {
+        // Caller's main path is the single-pass kernel.
+        // FERRUM_PAGED_FLASH=1 still routes here, so do the single-pass
+        // launch inline (avoids env-flag round-trip).
+        return paged_batched_decode_single_pass(
+            ctx,
+            q,
+            k_pool,
+            v_pool,
+            out,
+            block_tables,
+            valid_kv_lens,
+            num_seqs,
+            max_kv_len,
+            num_heads,
+            num_kv_heads,
+            head_dim,
+            block_size,
+            max_blocks_per_seq,
+        );
+    }
+
+    let chunk = (max_kv_len + num_splits - 1) / num_splits;
+    let total_qh = num_seqs * num_heads;
+    let out_required = total_qh * num_splits * head_dim;
+    let ml_required = total_qh * num_splits;
+    let scale: f32 = 1.0 / (head_dim as f32).sqrt();
+    let stream = ctx.stream.clone();
+
+    let phase1 = ctx.func(
+        "paged_batched_flash_attn",
+        ptx::PAGED_DECODE_ATTENTION,
+        "paged_batched_flash_decode_attn_f16",
+    );
+    let phase2 = ctx.func(
+        "paged_batched_flash_reduce",
+        ptx::PAGED_DECODE_ATTENTION,
+        "paged_batched_flash_decode_reduce_f16",
+    );
+
+    with_split_k_scratch(
+        &stream,
+        out_required,
+        ml_required,
+        |partial_out, partial_m, partial_l| {
+            let qv = q.slice(..);
+            let kp = k_pool.slice(..);
+            let vp = v_pool.slice(..);
+            let bt = block_tables.slice(..);
+            let kvl = valid_kv_lens.slice(..);
+            let pout = partial_out.slice(..);
+            let pm = partial_m.slice(..);
+            let pl = partial_l.slice(..);
+            let nqi = num_heads as i32;
+            let nkvi = num_kv_heads as i32;
+            let hdi = head_dim as i32;
+            let mbps = max_blocks_per_seq as i32;
+            let bsi = block_size as i32;
+            let nsp = num_splits as i32;
+
+            let mut b1 = stream.launch_builder(&phase1);
+            b1.arg(&qv);
+            b1.arg(&kp);
+            b1.arg(&vp);
+            b1.arg(&bt);
+            b1.arg(&kvl);
+            b1.arg(&pout);
+            b1.arg(&pm);
+            b1.arg(&pl);
+            b1.arg(&nqi);
+            b1.arg(&nkvi);
+            b1.arg(&hdi);
+            b1.arg(&mbps);
+            b1.arg(&bsi);
+            b1.arg(&scale);
+            b1.arg(&nsp);
+            // Match graph-capture sizing rationale used elsewhere — size
+            // shared to FERRUM_KV_CAPACITY ceiling, not current chunk.
+            let safe_kv: usize = std::env::var("FERRUM_KV_CAPACITY")
+                .ok()
+                .and_then(|v| v.parse::<usize>().ok())
+                .unwrap_or(512);
+            let safe_chunk = (safe_kv + num_splits - 1) / num_splits;
+            let shmem1 = (safe_chunk.max(chunk).max(1) as u32) * 4;
+            unsafe {
+                b1.launch(LaunchConfig {
+                    grid_dim: (num_heads as u32, num_seqs as u32, num_splits as u32),
+                    block_dim: (256, 1, 1),
+                    shared_mem_bytes: shmem1,
+                })
+            }
+            .map_err(|e| FerrumError::model(format!("paged_batched_flash phase1: {e}")))?;
+
+            let pout2 = partial_out.slice(..);
+            let pm2 = partial_m.slice(..);
+            let pl2 = partial_l.slice(..);
+            let mut b2 = stream.launch_builder(&phase2);
+            b2.arg(&pout2);
+            b2.arg(&pm2);
+            b2.arg(&pl2);
+            b2.arg(out);
+            b2.arg(&nqi);
+            b2.arg(&hdi);
+            b2.arg(&nsp);
+            unsafe {
+                b2.launch(LaunchConfig {
+                    grid_dim: (num_heads as u32, num_seqs as u32, 1),
+                    block_dim: (128, 1, 1),
+                    shared_mem_bytes: 0,
+                })
+            }
+            .map_err(|e| FerrumError::model(format!("paged_batched_flash phase2: {e}")))?;
+
+            Ok::<(), FerrumError>(())
+        },
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn paged_batched_decode_single_pass(
+    ctx: &mut CudaState,
+    q: &CudaSlice<f16>,
+    k_pool: &CudaSlice<f16>,
+    v_pool: &CudaSlice<f16>,
+    out: &mut CudaSlice<f16>,
+    block_tables: &CudaSlice<f16>,
+    valid_kv_lens: &CudaSlice<f16>,
+    num_seqs: usize,
+    max_kv_len: usize,
+    num_heads: usize,
+    num_kv_heads: usize,
+    head_dim: usize,
+    block_size: usize,
+    max_blocks_per_seq: usize,
+) -> Result<()> {
+    let func = ctx.func(
+        "paged_batched_decode_attn",
+        ptx::PAGED_DECODE_ATTENTION,
+        "paged_batched_decode_attn_f16",
+    );
+    let scale: f32 = 1.0 / (head_dim as f32).sqrt();
+    let stream = ctx.stream.clone();
+    let qv = q.slice(..);
+    let kp = k_pool.slice(..);
+    let vp = v_pool.slice(..);
+    let bt = block_tables.slice(..);
+    let kvl = valid_kv_lens.slice(..);
+    let nqi = num_heads as i32;
+    let nkvi = num_kv_heads as i32;
+    let hdi = head_dim as i32;
+    let mbps = max_blocks_per_seq as i32;
+    let bsi = block_size as i32;
+    let mut b = stream.launch_builder(&func);
+    b.arg(&qv);
+    b.arg(&kp);
+    b.arg(&vp);
+    b.arg(&bt);
+    b.arg(&kvl);
+    b.arg(out);
+    b.arg(&nqi);
+    b.arg(&nkvi);
+    b.arg(&hdi);
+    b.arg(&mbps);
+    b.arg(&bsi);
+    b.arg(&scale);
+    let safe_kv_max: usize = std::env::var("FERRUM_KV_CAPACITY")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or(512);
+    let shared_kv = safe_kv_max.max(max_kv_len).max(1);
+    let shared_bytes = (shared_kv as u32) * 4;
+    unsafe {
+        b.launch(LaunchConfig {
+            grid_dim: (num_heads as u32, num_seqs as u32, 1),
+            block_dim: (256, 1, 1),
+            shared_mem_bytes: shared_bytes,
+        })
+    }
+    .map(|_| ())
+    .map_err(|e| FerrumError::model(format!("paged_batched_decode_attn: {e}")))
 }
 
 // ────────────────────────────────────────────────────────────────────────

--- a/crates/ferrum-kernels/src/backend/cuda.rs
+++ b/crates/ferrum-kernels/src/backend/cuda.rs
@@ -3109,6 +3109,16 @@ impl Backend for CudaBackend {
         #[cfg(not(feature = "triton-kernels"))]
         let mw: &crate::marlin::MarlinWeight = weight;
 
+        // ── Stage 12: fused MoE Marlin path ─────────────────────────────
+        // FERRUM_MOE_FUSED=1 dispatches all experts in this phase as a
+        // small number of bucketed `marlin_gemm_moe` launches (one per
+        // thread_m_blocks bucket ∈ {1, 2, 3, 4}) instead of N round-robin
+        // calls. Eliminates per-expert launch overhead at c=32 (~100
+        // experts/layer → 1-4 launches/layer).
+        if std::env::var("FERRUM_MOE_FUSED").map_or(false, |v| v == "1") {
+            return moe_gemm_phase_fused_impl(ctx, input, mw, dispatches, n_per_expert, output, k);
+        }
+
         // n_streams=1: serial dispatch on the DEFAULT context stream
         // (avoids the cross-stream sync overhead and matches the
         // pre-multi-stream path bit-for-bit).
@@ -4011,6 +4021,112 @@ fn paged_varlen_split_k_dispatch(
             Ok::<(), FerrumError>(())
         },
     )
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Stage 12 — Fused MoE Marlin: bucket dispatches by max-m, fire one
+// `marlin_gemm_moe` per bucket. ONE launch per bucket replaces N round-
+// robin calls of the multi-stream path.
+//
+// Buckets are by ceil(m / 16) ∈ {1, 2, 3, 4}. Caller's dispatch list
+// (built by moe_forward_bucketed) gives (expert_idx, in_row, out_row, m)
+// per active expert. Inactive experts (m=0) are not in the list.
+//
+// Per-call uploads: one i32 array of size num_experts_used (active
+// experts in this dispatch list) for active_expert_ids, and one
+// indexed-by-active-position array for tokens + a_row_offsets. Total
+// staging is ~3 × num_active × 4 bytes ≈ 1 KB at c=32 — htod cost is
+// O(1) per phase, dwarfed by the launch savings.
+//
+// Workspace: caller already calls `marlin_zero_stacked_workspace` per
+// phase; the fused kernel reuses the same per-expert workspace ranges.
+// ────────────────────────────────────────────────────────────────────────
+#[cfg(feature = "marlin")]
+fn moe_gemm_phase_fused_impl(
+    ctx: &mut CudaState,
+    input: &CudaSlice<f16>,
+    weight: &crate::marlin::MarlinWeight,
+    dispatches: &[(usize, usize, usize, usize)],
+    n_per_expert: usize,
+    output: &mut CudaSlice<f16>,
+    _k: usize,
+) -> Result<()> {
+    if dispatches.is_empty() {
+        return Ok(());
+    }
+    let num_active = dispatches.len();
+
+    // Bucket by ceil(m / 16). All 4 buckets share the same per-active
+    // tokens + a_row_offsets layout (indexed by active position, NOT
+    // global expert id) — the kernel's `tokens_per_expert[e]` and
+    // `A_row_offsets[e]` use the bucket-local index `e_local`. Caller's
+    // `active_expert_ids[e_local]` maps that to the global expert id.
+    //
+    // The kernel reads:
+    //   int e_local = blockIdx.y;
+    //   int e_global = active_expert_ids[e_local];
+    //   int row_start = A_row_offsets[e_global];
+    //   int m_e       = tokens_per_expert[e_global];
+    // So `tokens_per_expert` and `A_row_offsets` MUST be sized to the
+    // global expert id space and indexed by the global id.
+    //
+    // We don't know num_experts_global directly from the dispatch list,
+    // but max(expert_idx) + 1 is a safe lower bound. Real production
+    // usage at c=32 has num_experts_global ≤ 256 (Qwen3-MoE: 128).
+    let max_global_e = dispatches.iter().map(|d| d.0).max().unwrap();
+    let num_experts_global = max_global_e + 1;
+
+    // Build the per-global-expert index arrays. Both default to 0; only
+    // active experts are populated. Inactive experts won't be referenced
+    // by active_expert_ids[] so their tokens=0 / row=0 values are dead.
+    let mut tokens_global = vec![0i32; num_experts_global];
+    let mut row_offsets_global = vec![0i32; num_experts_global];
+    let mut bucket_active_ids: [Vec<i32>; 4] = [Vec::new(), Vec::new(), Vec::new(), Vec::new()];
+    for &(e_idx, in_row, _out_row, m_e) in dispatches {
+        debug_assert!(m_e > 0);
+        debug_assert!(m_e <= 64);
+        tokens_global[e_idx] = m_e as i32;
+        row_offsets_global[e_idx] = in_row as i32;
+        let bucket = ((m_e + 15) / 16).clamp(1, 4) - 1;
+        bucket_active_ids[bucket].push(e_idx as i32);
+    }
+
+    // Upload the global per-expert arrays once.
+    let stream = ctx.stream.clone();
+    let row_off_dev = stream
+        .clone_htod(&row_offsets_global)
+        .map_err(|e| FerrumError::model(format!("htod row_offsets: {e}")))?;
+    let tok_dev = stream
+        .clone_htod(&tokens_global)
+        .map_err(|e| FerrumError::model(format!("htod tokens: {e}")))?;
+
+    // Fire one launch per non-empty bucket.
+    for (b, ids) in bucket_active_ids.iter().enumerate() {
+        if ids.is_empty() {
+            continue;
+        }
+        let prob_m_bucket = ((b + 1) * 16) as i32;
+        let active_dev = stream
+            .clone_htod(ids)
+            .map_err(|e| FerrumError::model(format!("htod active_ids[b={b}]: {e}")))?;
+        crate::marlin::marlin_gemm_moe(
+            &stream,
+            input,
+            weight,
+            output,
+            &row_off_dev,
+            &tok_dev,
+            Some(&active_dev),
+            ids.len() as i32,
+            prob_m_bucket,
+            n_per_expert as i32,
+            num_experts_global as i32,
+        )
+        .map_err(|e| FerrumError::model(format!("marlin_gemm_moe (bucket={b}): {e}")))?;
+    }
+
+    let _ = num_active;
+    Ok(())
 }
 
 fn marlin_gemm_with_perm(

--- a/crates/ferrum-kernels/src/backend/cuda.rs
+++ b/crates/ferrum-kernels/src/backend/cuda.rs
@@ -4074,16 +4074,45 @@ fn paged_batched_flash_dispatch(
     block_size: usize,
     max_blocks_per_seq: usize,
 ) -> Result<()> {
-    // Pick num_splits. For batched decode the grid is already saturated
-    // (num_seqs * num_heads ≥ 1024 at c=32), so splits add cost. Only
-    // worth it when kv is long enough that split parallelism overcomes
-    // launch overhead.
-    let num_splits: usize = match max_kv_len {
-        kv if kv <= 256 => 1, // skip split-K — single pass faster
-        kv if kv <= 1024 => 2,
-        kv if kv <= 2048 => 4,
-        _ => 8,
-    };
+    // Pick num_splits. Heuristic combines two effects:
+    //   1. SM occupancy: a (num_q_heads, num_seqs, splits) grid wants
+    //      total blocks ≳ 2 × SM count for full pipelining. When the
+    //      base grid (num_seqs × num_heads) already saturates SMs,
+    //      splits ≥ 2 just add launch + reduce overhead.
+    //   2. kv_len: longer kv → more inherent serial work in step 3 →
+    //      split-K helps even at moderate occupancy.
+    //
+    // Bench (RTX 4090, M3, 32 q_heads):
+    //   c=1  splits=8 → +22% (grid was 1/4 wave, splits saturate)
+    //   c=16 splits=2 → -3.7% (grid already 4 waves)
+    //   c=32 splits=2 → +5% (grid 8 waves, kv split still helps)
+    // Override via FERRUM_PAGED_FLASH_SPLITS for tuning.
+    let force_splits = std::env::var("FERRUM_PAGED_FLASH_SPLITS")
+        .ok()
+        .and_then(|s| s.parse::<usize>().ok());
+    // 128 SMs on Ada/Hopper-class; conservative under-estimate.
+    const SM_TARGET: usize = 128;
+    let base_grid = num_seqs * num_heads;
+    let saturated = base_grid >= 2 * SM_TARGET;
+    let num_splits: usize = force_splits.unwrap_or_else(|| {
+        if saturated {
+            // Only split when kv is so long that the V loop dominates.
+            match max_kv_len {
+                kv if kv <= 768 => 1,
+                kv if kv <= 2048 => 2,
+                _ => 4,
+            }
+        } else {
+            // Low concurrency: aggressive splits to fill SMs.
+            let needed = (SM_TARGET + base_grid - 1) / base_grid;
+            let by_kv = match max_kv_len {
+                kv if kv <= 256 => 4,
+                kv if kv <= 1024 => 8,
+                _ => 16,
+            };
+            needed.max(1).min(by_kv).min(16)
+        }
+    });
     if num_splits <= 1 {
         // Caller's main path is the single-pass kernel.
         // FERRUM_PAGED_FLASH=1 still routes here, so do the single-pass

--- a/crates/ferrum-kernels/src/marlin.rs
+++ b/crates/ferrum-kernels/src/marlin.rs
@@ -45,6 +45,34 @@ extern "C" {
         // full N width while iteration covers only the expert subset.
         prob_n_full: i32,
     ) -> i32;
+
+    // Stage 11: fused MoE Marlin. ONE launch processes all experts in a
+    // bucket. Caller pre-buckets experts by their thread_m_blocks need
+    // (prob_m here = 16 * thread_m_blocks). gridDim.y = expert_count.
+    fn marlin_cuda_moe(
+        A: *const std::ffi::c_void,
+        B: *const std::ffi::c_void,
+        C: *mut std::ffi::c_void,
+        s: *const std::ffi::c_void,
+        prob_m: i32,
+        prob_n: i32,
+        prob_k: i32,
+        workspace: *mut std::ffi::c_void,
+        a_row_offsets: *const i32, // device [E_global] cumulative row offsets in A
+        tokens_per_expert: *const i32, // device [E_global]
+        active_expert_ids: *const i32, // device [expert_count] (or null for identity)
+        expert_count: i32,
+        b_int4_per_expert: i32,
+        s_int4_per_expert: i32,
+        locks_i32_per_expert: i32,
+        groupsize: i32,
+        dev: i32,
+        stream: cudarc::driver::sys::CUstream,
+        thread_k: i32,
+        thread_n: i32,
+        sms: i32,
+        prob_n_full: i32,
+    ) -> i32;
 }
 
 /// Check if Marlin kernel is available at compile time.
@@ -402,6 +430,140 @@ pub fn marlin_gemm_with_offset_strided(
     _m: i32,
     _expert_offset: i32,
     _expert_n: i32,
+) -> candle_core::Result<()> {
+    Err(candle_core::Error::Msg(
+        "Marlin kernel not available (compile with --features marlin)".into(),
+    ))
+}
+
+/// Stage 11 — fused MoE Marlin: ONE launch processes all experts in
+/// `active_expert_ids` (len = `expert_count`) by reading `expert_id =
+/// active_expert_ids[blockIdx.y]`, applying pointer offsets to the
+/// stacked B / s / workspace, and reading per-expert (m, A_row_offset)
+/// from the per-layer `tokens_per_expert` / `a_row_offsets` arrays.
+///
+/// `prob_m` is the bucket-wide max-m: every active expert MUST have
+/// `tokens_per_expert[e] ≤ prob_m`, and `prob_m` MUST be a multiple of
+/// 16. The kernel selects `thread_m_blocks = prob_m / 16` (1..=4); for
+/// experts with fewer tokens the kernel pads with zeros.
+///
+/// Caller is responsible for:
+///   - bucketing active experts by max-m (prob_m ∈ {16, 32, 48, 64})
+///   - pre-zeroing the bucketed workspace slots (or relying on
+///     `marlin_zero_stacked_workspace` having been called this iter)
+///   - ensuring all active experts share the same `prob_n`, `prob_k`,
+///     `group_size` (true for MoE — every expert in a layer has the
+///     same shape)
+#[cfg(feature = "marlin")]
+#[allow(clippy::too_many_arguments)]
+pub fn marlin_gemm_moe(
+    stream: &Arc<CudaStream>,
+    input: &CudaSlice<half::f16>,
+    weight: &MarlinWeight,
+    output: &mut CudaSlice<half::f16>,
+    a_row_offsets: &CudaSlice<i32>,
+    tokens_per_expert: &CudaSlice<i32>,
+    active_expert_ids: Option<&CudaSlice<i32>>,
+    expert_count: i32,
+    prob_m: i32,
+    n_per_expert: i32,
+    num_experts_global: i32,
+) -> candle_core::Result<()> {
+    use cudarc::driver::DevicePtr;
+    if expert_count <= 0 {
+        return Ok(());
+    }
+    if prob_m <= 0 || prob_m > 64 || prob_m % 16 != 0 {
+        return Err(candle_core::Error::Msg(format!(
+            "marlin_gemm_moe: prob_m must be in {{16, 32, 48, 64}}, got {prob_m}"
+        )));
+    }
+    let n = n_per_expert;
+    let k = weight.k as i32;
+    let n_per = n as usize;
+    let k_us = k as usize;
+    if n_per == 0 || (weight.n as i32) < num_experts_global * n {
+        return Err(candle_core::Error::Msg(format!(
+            "marlin_gemm_moe: stacked weight N={} too small for E_global={num_experts_global} × n_per={n}",
+            weight.n
+        )));
+    }
+
+    // Stacked-tile strides (int4 elems = 16 bytes each).
+    // qweight per expert = (n_per * k) / 8 i32 = (n_per * k) / 32 int4
+    // scales per expert  = (k/group_size * n_per) f16 = (...)/8 int4
+    // workspace per expert = (n_per/128) * MAX_PAR i32
+    const MAX_PAR: usize = 16;
+    let b_int4_per_expert = ((n_per * k_us) / 32) as i32;
+    let groups = k_us / weight.group_size as usize;
+    let s_int4_per_expert = ((groups * n_per) / 8) as i32;
+    let locks_i32_per_expert = (((n_per / 128).max(1)) * MAX_PAR) as i32;
+
+    let raw_stream = stream.cu_stream();
+    let (a_ptr, _ag) = input.device_ptr(stream);
+    let (b_ptr, _bg) = weight.qweight.device_ptr(stream);
+    let (c_ptr, _cg) = output.device_ptr(stream);
+    let (s_ptr, _sg) = weight.scales.device_ptr(stream);
+    let (ws_ptr, _wg) = weight.workspace.device_ptr(stream);
+    let (off_ptr, _og) = a_row_offsets.device_ptr(stream);
+    let (tok_ptr, _tg) = tokens_per_expert.device_ptr(stream);
+    let act_ptr_opt = active_expert_ids.map(|s| s.device_ptr(stream));
+    let act_raw: u64 = match &act_ptr_opt {
+        Some((p, _)) => *p,
+        None => 0,
+    };
+
+    let ret = unsafe {
+        marlin_cuda_moe(
+            a_ptr as *const _,
+            b_ptr as *const _,
+            c_ptr as *mut _,
+            s_ptr as *const _,
+            prob_m,
+            n,
+            k,
+            ws_ptr as *mut _,
+            off_ptr as *const _,
+            tok_ptr as *const _,
+            act_raw as *const _,
+            expert_count,
+            b_int4_per_expert,
+            s_int4_per_expert,
+            locks_i32_per_expert,
+            weight.group_size,
+            0, // dev
+            raw_stream,
+            -1,
+            -1,
+            -1,
+            n, // prob_n_full = prob_n (per-expert contiguous stacking)
+        )
+    };
+
+    if ret != 0 {
+        return Err(candle_core::Error::Msg(format!(
+            "marlin_cuda_moe failed: ret={ret} (prob_m={prob_m}, n={n}, k={k}, \
+             experts={expert_count}, gs={})",
+            weight.group_size
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(not(feature = "marlin"))]
+#[allow(clippy::too_many_arguments)]
+pub fn marlin_gemm_moe(
+    _stream: &Arc<CudaStream>,
+    _input: &CudaSlice<half::f16>,
+    _weight: &MarlinWeight,
+    _output: &mut CudaSlice<half::f16>,
+    _a_row_offsets: &CudaSlice<i32>,
+    _tokens_per_expert: &CudaSlice<i32>,
+    _active_expert_ids: Option<&CudaSlice<i32>>,
+    _expert_count: i32,
+    _prob_m: i32,
+    _n_per_expert: i32,
+    _num_experts_global: i32,
 ) -> candle_core::Result<()> {
     Err(candle_core::Error::Msg(
         "Marlin kernel not available (compile with --features marlin)".into(),

--- a/crates/ferrum-quantization/tests/marlin_moe_parity_test.rs
+++ b/crates/ferrum-quantization/tests/marlin_moe_parity_test.rs
@@ -1,0 +1,224 @@
+//! Stage 11 — fused MoE Marlin parity test (CUDA only).
+//!
+//! Builds N synthetic experts, stacks them via `Backend::load_gptq_stacked`
+//! (the production loader), then compares:
+//!
+//!   reference: per-expert `gemm_gptq_with_offset` (existing path, used by
+//!              `moe_forward_bucketed` via `moe_gemm_phase_batched`)
+//!   fused:     `marlin::marlin_gemm_moe` ONE call covering all experts
+//!
+//! Both should produce bit-identical (or rel < 1e-4) outputs in each
+//! expert's row range of the packed buffer.
+//!
+//! Run:
+//!   cargo test -p ferrum-quantization --features cuda,marlin --release \
+//!     --test marlin_moe_parity_test cuda_marlin_moe_fused -- --ignored --nocapture
+
+#[cfg(feature = "cuda")]
+mod synth {
+    pub fn rnd_u32(state: &mut u64) -> u32 {
+        *state = state
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        (*state >> 33) as u32
+    }
+    pub fn rnd_f32(state: &mut u64, lo: f32, hi: f32) -> f32 {
+        let u = (rnd_u32(state) & 0x00FF_FFFF) as f32 / 16_777_216.0;
+        lo + u * (hi - lo)
+    }
+    pub struct SyntheticGptq {
+        pub k: usize,
+        pub n: usize,
+        pub group_size: usize,
+        pub qweight: Vec<i32>,
+        pub scales: Vec<f32>,
+        pub qzeros: Vec<i32>,
+    }
+    pub fn make(k: usize, n: usize, gs: usize, seed: u64) -> SyntheticGptq {
+        assert_eq!(k % 8, 0);
+        assert_eq!(n % 8, 0);
+        assert_eq!(k % gs, 0);
+        let mut s = seed;
+        let groups = k / gs;
+        let mut qweight = vec![0i32; (k / 8) * n];
+        for w in qweight.iter_mut() {
+            *w = rnd_u32(&mut s) as i32;
+        }
+        let mut scales = vec![0f32; groups * n];
+        for x in scales.iter_mut() {
+            *x = rnd_f32(&mut s, 0.01, 0.1);
+        }
+        let mut qzeros = vec![0i32; groups * (n / 8)];
+        for qz in qzeros.iter_mut() {
+            let mut word: u32 = 0;
+            for bi in 0..8 {
+                word |= (rnd_u32(&mut s) & 0xF) << (bi * 4);
+            }
+            *qz = word as i32;
+        }
+        SyntheticGptq {
+            k,
+            n,
+            group_size: gs,
+            qweight,
+            scales,
+            qzeros,
+        }
+    }
+}
+
+#[cfg(feature = "cuda")]
+#[test]
+#[ignore]
+fn cuda_marlin_moe_fused_vs_per_expert() {
+    use cudarc::driver::DevicePtr;
+    use ferrum_kernels::backend::cuda::{CudaBackend, GptqStoreCuda};
+    use ferrum_kernels::backend::Backend;
+
+    // Marlin tile constraints: k % 128 == 0, n_per % 64 == 0, n_per % 256 ==
+    // 0 for some specs. Use a shape Qwen3-30B-A3B-like: k=2048 hidden,
+    // n_per=768 (== 2 * intermediate / 4 in practice ~ 512).
+    let k: usize = 256;
+    let n_per: usize = 256; // n_per % 256 == 0 satisfies all CALL_IF specs
+    let gs: usize = 128;
+    let num_experts: usize = 4;
+
+    // Synthetic experts.
+    let experts: Vec<synth::SyntheticGptq> = (0..num_experts)
+        .map(|e| synth::make(k, n_per, gs, 0xCAFE0000 + e as u64))
+        .collect();
+
+    // Per-expert variable m: bucket choice of thread_m_blocks=1 (max m=16).
+    let tokens_per_expert: Vec<usize> = vec![16, 8, 12, 4]; // varying m_e
+    let total_tokens: usize = tokens_per_expert.iter().sum();
+    let mut a_row_offsets: Vec<i32> = Vec::with_capacity(num_experts);
+    {
+        let mut acc = 0usize;
+        for &m_e in &tokens_per_expert {
+            a_row_offsets.push(acc as i32);
+            acc += m_e;
+        }
+    }
+    let prob_m_bucket: i32 = 16; // bucket-wide max → thread_m_blocks=1
+
+    // Stacked store: this is what production uses.
+    let qw_refs: Vec<&[i32]> = experts.iter().map(|e| e.qweight.as_slice()).collect();
+    let sc_refs: Vec<&[f32]> = experts.iter().map(|e| e.scales.as_slice()).collect();
+    let qz_refs: Vec<&[i32]> = experts.iter().map(|e| e.qzeros.as_slice()).collect();
+    let stacked = <CudaBackend as Backend>::load_gptq_stacked(
+        &qw_refs, &sc_refs, &qz_refs, None, 4, gs, k, n_per,
+    )
+    .expect("stacked load_gptq");
+
+    // Synthetic A_packed [total_tokens, k] f32 (CudaBackend stores f16
+    // internally — `from_slice` does the f32→f16 convert).
+    let a_data: Vec<f32> = (0..total_tokens * k)
+        .map(|i| ((i as f32) * 0.0027).sin())
+        .collect();
+    let mut ctx = <CudaBackend as Backend>::new_context();
+    let a_dev = CudaBackend::from_slice(&a_data);
+
+    // ── Reference: per-expert gemm_gptq_with_offset ──────────────────────
+    // Each expert e's input rows = a_dev[a_row_offsets[e] .. + tokens_per_expert[e]],
+    // output rows = c_ref[a_row_offsets[e] .. + tokens_per_expert[e]].
+    // The Backend gemm_gptq_with_offset takes a single contiguous input
+    // slice (not strided), so we extract per-expert sub-buffers.
+    let mut c_ref = vec![0f32; total_tokens * n_per];
+    for e in 0..num_experts {
+        let m_e = tokens_per_expert[e];
+        if m_e == 0 {
+            continue;
+        }
+        let row_start = a_row_offsets[e] as usize;
+        let a_e: Vec<f32> = a_data[row_start * k..(row_start + m_e) * k].to_vec();
+        let a_e_dev = CudaBackend::from_slice(&a_e);
+        let mut out_e_dev = CudaBackend::alloc(m_e * n_per);
+        <CudaBackend as Backend>::gemm_gptq_with_offset(
+            &mut ctx,
+            &a_e_dev,
+            &stacked,
+            e * n_per,
+            n_per,
+            &mut out_e_dev,
+            m_e as i32,
+        )
+        .expect("gemm_gptq_with_offset");
+        <CudaBackend as Backend>::sync(&mut ctx);
+        let out_e = CudaBackend::to_vec(&out_e_dev, m_e * n_per);
+        c_ref[row_start * n_per..(row_start + m_e) * n_per].copy_from_slice(&out_e);
+    }
+
+    // ── Fused: marlin_gemm_moe ONE call ──────────────────────────────────
+    // Need: a_dev (already), MarlinWeight (extract from stacked), c_dev,
+    //       a_row_offsets dev, tokens_per_expert dev.
+    let mw = match &stacked {
+        GptqStoreCuda::Marlin(mw) => mw,
+        _ => panic!("expected Marlin stacked store (no triton-kernels feature)"),
+    };
+    let mut c_fused_dev = <CudaBackend as Backend>::alloc(total_tokens * n_per);
+
+    // Upload offsets/tokens as i32. Use raw cudarc since the Backend's
+    // typed buffer is f16-only.
+    let stream = ctx.stream.clone();
+    let row_off_dev = stream
+        .memcpy_stod(&a_row_offsets)
+        .expect("upload a_row_offsets");
+    let tok_dev = stream
+        .memcpy_stod(
+            &tokens_per_expert
+                .iter()
+                .map(|&x| x as i32)
+                .collect::<Vec<_>>(),
+        )
+        .expect("upload tokens_per_expert");
+
+    // Pre-zero stacked workspace (mirrors production).
+    let _ = <CudaBackend as Backend>::marlin_zero_stacked_workspace(&mut ctx, &stacked);
+
+    ferrum_kernels::marlin::marlin_gemm_moe(
+        &stream,
+        &a_dev,
+        mw,
+        &mut c_fused_dev,
+        &row_off_dev,
+        &tok_dev,
+        None, // identity active_expert_ids = [0..num_experts)
+        num_experts as i32,
+        prob_m_bucket,
+        n_per as i32,
+        num_experts as i32,
+    )
+    .expect("marlin_gemm_moe");
+    <CudaBackend as Backend>::sync(&mut ctx);
+    let c_fused = CudaBackend::to_vec(&c_fused_dev, total_tokens * n_per);
+
+    // Compare per-expert.
+    for e in 0..num_experts {
+        let m_e = tokens_per_expert[e];
+        if m_e == 0 {
+            continue;
+        }
+        let row_start = a_row_offsets[e] as usize;
+        let slice_ref = &c_ref[row_start * n_per..(row_start + m_e) * n_per];
+        let slice_fused = &c_fused[row_start * n_per..(row_start + m_e) * n_per];
+        let max_diff = slice_ref
+            .iter()
+            .zip(slice_fused)
+            .map(|(a, b)| (a - b).abs())
+            .fold(0f32, f32::max);
+        let mag = slice_ref
+            .iter()
+            .map(|x| x.abs())
+            .fold(0f32, f32::max)
+            .max(1e-6);
+        let rel = max_diff / mag;
+        eprintln!(
+            "expert {e}: m_e={m_e}, row_start={row_start}, \
+             per-expert vs fused: max|diff|={max_diff:.4} rel={rel:.4}"
+        );
+        assert!(
+            rel < 1e-3,
+            "fused MoE Marlin disagrees with per-expert (expert {e}): rel={rel}"
+        );
+    }
+}

--- a/crates/ferrum-quantization/tests/marlin_moe_parity_test.rs
+++ b/crates/ferrum-quantization/tests/marlin_moe_parity_test.rs
@@ -71,8 +71,7 @@ mod synth {
 #[test]
 #[ignore]
 fn cuda_marlin_moe_fused_vs_per_expert() {
-    use cudarc::driver::DevicePtr;
-    use ferrum_kernels::backend::cuda::{CudaBackend, GptqStoreCuda};
+    use ferrum_kernels::backend::cuda::CudaBackend;
     use ferrum_kernels::backend::Backend;
 
     // Marlin tile constraints: k % 128 == 0, n_per % 64 == 0, n_per % 256 ==
@@ -149,22 +148,23 @@ fn cuda_marlin_moe_fused_vs_per_expert() {
     }
 
     // ── Fused: marlin_gemm_moe ONE call ──────────────────────────────────
-    // Need: a_dev (already), MarlinWeight (extract from stacked), c_dev,
-    //       a_row_offsets dev, tokens_per_expert dev.
-    let mw = match &stacked {
-        GptqStoreCuda::Marlin(mw) => mw,
-        _ => panic!("expected Marlin stacked store (no triton-kernels feature)"),
-    };
+    // Need: a_dev (already), MarlinWeight (= stacked when no triton-kernels),
+    //       c_dev, a_row_offsets dev, tokens_per_expert dev.
+    //
+    // Without `triton-kernels` feature, GptqStoreCuda is a transparent
+    // alias for MarlinWeight, so `stacked` IS the MarlinWeight directly
+    // (see crates/ferrum-kernels/src/backend/cuda.rs:279).
+    let mw: &ferrum_kernels::marlin::MarlinWeight = &stacked;
     let mut c_fused_dev = <CudaBackend as Backend>::alloc(total_tokens * n_per);
 
     // Upload offsets/tokens as i32. Use raw cudarc since the Backend's
     // typed buffer is f16-only.
     let stream = ctx.stream.clone();
     let row_off_dev = stream
-        .memcpy_stod(&a_row_offsets)
+        .clone_htod(&a_row_offsets)
         .expect("upload a_row_offsets");
     let tok_dev = stream
-        .memcpy_stod(
+        .clone_htod(
             &tokens_per_expert
                 .iter()
                 .map(|&x| x as i32)

--- a/crates/ferrum-quantization/tests/marlin_moe_parity_test.rs
+++ b/crates/ferrum-quantization/tests/marlin_moe_parity_test.rs
@@ -139,7 +139,7 @@ fn cuda_marlin_moe_fused_vs_per_expert() {
             e * n_per,
             n_per,
             &mut out_e_dev,
-            m_e as i32,
+            m_e,
         )
         .expect("gemm_gptq_with_offset");
         <CudaBackend as Backend>::sync(&mut ctx);

--- a/docs/bench/cuda-rtx4090-2026-05-08-m3-moe/README.md
+++ b/docs/bench/cuda-rtx4090-2026-05-08-m3-moe/README.md
@@ -346,6 +346,57 @@ jitter; c=16 matched Stage 9 to 0.3%. **No correctness regression.**
 Bench JSONs live on the pod under
 `/workspace/ferrum-infer-rs/bench/v0.2-cuda/results_m3_clean/ferrum_clean_c{1,8,16,32}.json`.
 
+### Stages 11 + 12 + 12.1 — fused MoE Marlin (2026-05-08, PR #96)
+
+Three sequential CUDA kernel changes, all gated on `FERRUM_MOE_FUSED=1`.
+
+**Stage 11** — `marlin_cuda_moe` host entrypoint + `Marlin<...>` kernel
+pre-amble. ONE launch processes all experts in a bucket via gridDim.y
+indirection. Adds 7 optional MoE kernel args (default nullptr/0); when
+non-null, kernel reads `e_local = blockIdx.y`, applies pointer offsets
+to A/B/C/s/locks, overrides prob_m. Existing single-expert path
+unchanged.
+
+**Stage 12** — wire fused kernel into `moe_forward_bucketed`. Bucket
+experts by `ceil(m/16)` ∈ {1,2,3,4}, fire ONE call per bucket via
+`moe_gemm_phase_fused_impl`. c=32 alone gave +5% over Stage 9 — fused
+launches don't help when each block does only 0.5M FLOPs but pays 3 µs
+setup. Profile showed 80% of TPOT still in Marlin GEMM.
+
+**Stage 12.1 ★** — `gridDim.x = n_tiles` (NOT sms). Original Marlin uses
+gridDim.x = 128 cooperating blocks per GEMM. With Stage 12's
+gridDim.y = num_experts, total = 12800 blocks → ~100 waves on 128 SMs,
+each block doing 1 tile (0.5M FLOP) with 3 µs setup → setup dominates.
+Setting `blocks = n_tiles` (=3 for Qwen3-MoE) means each block
+processes ALL k-tiles for one n-tile — per-block work scales 32×, setup
+amortises. Total grid: (3, 100) = 300 blocks → 2.3 waves.
+
+| c    | Stage 9 final | **Stage 12.1**     | Δ vs Stage 9 | TPOT (Stage 9 → 12.1) | vs vLLM |
+|------|---------------|--------------------|--------------|-----------------------|---------|
+| 1    | 73.8          | **84.3**           | +14%         | 12.78 → 11.28 ms      | —       |
+| 8    | 171.6         | **254.8**          | +48%         | 44.05 → 28.59 ms      | —       |
+| 16   | 236.1         | **318.9**          | +35%         | 61.46 → 45.04 ms      | 63%     |
+| 32   | 256.3         | **320.6**          | +25%         | 115.90 → 92.74 ms     | **17.1%** |
+
+Re-profile at c=32 confirms `bk_total` halved (33 → 16 ms across 48
+layers); `gemm1` 17 → 8.8 ms (-48%), `gemm3` 13 → 4.8 ms (-63%). New
+distribution at c=32 (steady state, profile-mode):
+
+```
+TPOT 13 ms = attn 4 ms (31%) + moe 7 ms (54%) + other 1 ms (9%)
+```
+
+attn now sits comparable to MoE GEMM. Next levers (Stage 13+):
+
+1. **Strategy B (sorted_token_ids)** — per-tile expert routing eliminates
+   the padding waste (m_e ∈ {1..3} but kernel runs prob_m=16). Predicted
+   +50-100% on the GEMM phase.
+2. **Attn split-K / prefetch tuning** — paged_decode_attention is now
+   31% of TPOT, was 14% pre-12.1.
+
+Parity validated: `cuda_marlin_moe_fused_vs_per_expert` test passes
+with rel < 0.001 (4 experts × variable m_e ∈ {16, 8, 12, 4}).
+
 ### The c=32 OOB resolution
 
 Stage 9's first ship (commit c846732) hit `CUDA_ERROR_ILLEGAL_ADDRESS`


### PR DESCRIPTION
## Headline result (RTX 4090, Qwen3-30B-A3B-INT4, vllm bench serve random 256→128)

| c | Stage 9 (main) | **Stage 12.1 (this PR)** | Δ | vs vLLM |
|---|---:|---:|---:|---:|
| 1 | 73.8 | **84.3** | +14% | — |
| 8 | 171.6 | **254.8** | **+48%** | — |
| 16 | 236.1 | **318.9** | **+35%** | 63% (vLLM 505) |
| **32** | **256.3** | **320.6** | **+25%** | **17.1%** (was 14.4%) |

Mean TPOT at c=32: 116 → 93 ms (-20%).

## What's in here

Three sequential CUDA kernel changes (all gated on `FERRUM_MOE_FUSED=1`).

### Stage 11 — `marlin_cuda_moe` host entrypoint + `Marlin<...>` kernel pre-amble
ONE kernel launch processes all experts in a bucket via gridDim.y indirection. The Marlin template gets 7 optional MoE args at the end (default nullptr/0); the kernel reads `e_local = blockIdx.y`, applies pointer offsets to A/B/C/s/locks, overrides prob_m. New `CALL_IF_MOE` macro launches with 2D grid (sms, expert_count). Existing `CALL_IF` passes nullptr/0 — no behaviour change for the per-expert path.

Layout assumptions: A pre-gathered `[total_pairs, k]` fp16 with row range `[A_row_offsets[e], A_row_offsets[e]+tokens_per_expert[e])`, B/s/workspace stacked per expert (matches `load_gptq_stacked` output).

### Stage 12 — wire fused kernel into `moe_forward_bucketed`
Bucket experts by `ceil(m / 16)` ∈ {1, 2, 3, 4}, fire ONE `marlin_gemm_moe` per bucket via `moe_gemm_phase_fused_impl` instead of N round-robin per-expert calls. Same dispatch-list interface as `moe_gemm_phase_batched`.

c=32 alone with Stage 12: +5% over Stage 9 (only marginal). Profile showed 80% of TPOT was still in Marlin GEMM — fused launches don't help when each block does only 0.5M FLOPs but pays 3 µs setup.

### Stage 12.1 — gridDim.x = n_tiles (NOT sms) ★ key win
Original Marlin uses gridDim.x = sms = 128 cooperating blocks per GEMM. With Stage 12's gridDim.y = num_experts, total = 12800 blocks → ~100 waves on 128 SMs, each block doing 1 tile (0.5M FLOP) with 3 µs setup → setup dominates.

For MoE we already get parallelism via gridDim.y. Within one expert n_tiles = 3 cols. Setting `blocks = n_tiles` means each block processes ALL k-tiles for one n-tile — per-block work scales 32×, setup amortises. Total grid: (3, 100) = 300 blocks → 2.3 waves on 128 SMs.

The kernel's cooperating-block barrier logic falls out cleanly: `slice_count = 1` so locks are never read or written.

## Test plan
- [x] `cargo test -p ferrum-quantization --features cuda --release --test marlin_moe_parity_test cuda_marlin_moe -- --ignored` (parity test passes — rel < 0.001 vs per-expert reference for 4 experts × variable m_e ∈ {16, 8, 12, 4})
- [x] M3 fused bench c=1/8/16/32 — see headline table above
- [x] cargo check --workspace --all-targets (Mac, no cuda)
- [ ] CI: CPU + Metal + CUDA passes

## Files changed
- `crates/ferrum-kernels/kernels/marlin_cuda_kernel.cu` — kernel + new entrypoint
- `crates/ferrum-kernels/src/marlin.rs` — FFI + safe wrapper
- `crates/ferrum-kernels/src/backend/cuda.rs` — `moe_gemm_phase_fused_impl`
- `crates/ferrum-quantization/tests/marlin_moe_parity_test.rs` — parity test (new)
- `bench/v0.2-cuda/m3_fused.sh`, `bench/v0.2-cuda/m3_prof_fused.sh` — bench scripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)