### PR TITLE
perf(moe-cuda): flip MOE_FUSED + PAGED_FLASH defaults to ON

### DIFF
--- a/crates/ferrum-kernels/src/backend/cuda.rs
+++ b/crates/ferrum-kernels/src/backend/cuda.rs
@@ -1645,11 +1645,13 @@ impl Backend for CudaBackend {
             return Ok(());
         }
 
-        // Stage 13a: optional split-K path for batched paged decode. With
-        // num_seqs * num_q_heads ≥ sms (saturated grid), splitting kv adds
-        // launch overhead but improves pipelining at long kv_len. Default
-        // OFF (FERRUM_PAGED_FLASH unset) so existing path stays.
-        if std::env::var("FERRUM_PAGED_FLASH").map_or(false, |v| v == "1") {
+        // Stage 13a: split-K path for batched paged decode. Default ON;
+        // smart heuristic auto-tunes splits based on (num_seqs × num_heads)
+        // and kv_len, so it falls back to single-pass when grid already
+        // saturates SMs at low kv. Bench M3 c=1/8/16/32 across +21% / +3% /
+        // +3.5% / +10.8% over the single-pass kernel — every concurrency
+        // wins. Set FERRUM_PAGED_FLASH=0 to opt out.
+        if std::env::var("FERRUM_PAGED_FLASH").map_or(true, |v| v != "0") {
             return paged_batched_flash_dispatch(
                 ctx,
                 q,
@@ -3133,13 +3135,15 @@ impl Backend for CudaBackend {
         #[cfg(not(feature = "triton-kernels"))]
         let mw: &crate::marlin::MarlinWeight = weight;
 
-        // ── Stage 12: fused MoE Marlin path ─────────────────────────────
-        // FERRUM_MOE_FUSED=1 dispatches all experts in this phase as a
-        // small number of bucketed `marlin_gemm_moe` launches (one per
-        // thread_m_blocks bucket ∈ {1, 2, 3, 4}) instead of N round-robin
-        // calls. Eliminates per-expert launch overhead at c=32 (~100
-        // experts/layer → 1-4 launches/layer).
-        if std::env::var("FERRUM_MOE_FUSED").map_or(false, |v| v == "1") {
+        // ── Stage 12.1: fused MoE Marlin path (default ON) ──────────────
+        // Dispatches all experts in this phase as a small number of
+        // bucketed `marlin_gemm_moe` launches (one per thread_m_blocks
+        // bucket ∈ {1, 2, 3, 4}) instead of N round-robin calls. At c=32
+        // with ~100 active experts/layer this is 1-4 launches/layer
+        // instead of 100. Bench: +25% c=32, +35% c=16, +48% c=8 over
+        // the multi-stream per-expert path. Set FERRUM_MOE_FUSED=0 to
+        // opt out (fall back to multi-stream pool).
+        if std::env::var("FERRUM_MOE_FUSED").map_or(true, |v| v != "0") {
             return moe_gemm_phase_fused_impl(ctx, input, mw, dispatches, n_per_expert, output, k);
         }
 


### PR DESCRIPTION
## Summary
After merging PR #96 (Stages 11+12+12.1+13a) the new fused-MoE + paged-flash split-K paths sit behind \`FERRUM_MOE_FUSED=1\` / \`FERRUM_PAGED_FLASH=1\`. Both showed pure wins at every concurrency on M3 Qwen3-30B-A3B (RTX 4090). End-user CLI shouldn't require internal env vars (per feedback) — promote both to ON.

## Headline (with both default ON, smart heuristics auto-tune)

| c | PR #94 baseline | This PR | Δ |
|---|---:|---:|---:|
| 1 | 73.8 | 101.9 | +38% |
| 8 | 171.6 | 262.5 | +53% |
| 16 | 236.1 | 330.2 | +40% |
| 32 | 256.3 | 355.1 | **+39%** |

c=32 vLLM ratio 14.4% → **19.0%**.

## Escape hatches
- \`FERRUM_MOE_FUSED=0\` — fall back to multi-stream per-expert pool
- \`FERRUM_PAGED_FLASH=0\` — fall back to single-pass paged decode kernel

The smart paged-flash heuristic also accepts \`FERRUM_PAGED_FLASH_SPLITS=N\` to force a fixed split count for tuning.

## Test plan
- [x] cargo check --workspace
- [x] M3 c=1/8/16/32 sweep on RTX 4090 — all up
- [ ] CI (CPU + Metal + CUDA)

🤖 Generated with [Claude Code](https://claude.com/claude-code)