### PR TITLE
fix(cli/run): show loading progress for large models

### DIFF
--- a/crates/ferrum-cli/src/commands/run.rs
+++ b/crates/ferrum-cli/src/commands/run.rs
@@ -202,9 +202,25 @@ pub async fn execute(cmd: RunCommand, config: CliConfig) -> Result<()> {
     let device = select_device(&cmd.backend);
     eprintln!("{}", format!("Using {:?} backend", device).dimmed());
 
-    // Create engine
+    // Create engine. Big-model loads (15-60 GB safetensors) are slow on
+    // first run — print a hint so users don't think it's frozen. Per-
+    // layer INFO logs fire from the model loaders once parsing starts;
+    // utils::setup_logging whitelists them at INFO level.
+    eprintln!(
+        "{}",
+        "Loading weights to GPU... (30s+ for >10 GB models)".dimmed()
+    );
+    let load_start = std::time::Instant::now();
     let engine_config = ferrum_engine::simple_engine_config(model_id.clone(), device);
     let engine = ferrum_engine::create_default_engine(engine_config).await?;
+    eprintln!(
+        "{}",
+        format!(
+            "Model loaded in {:.1}s.",
+            load_start.elapsed().as_secs_f64()
+        )
+        .dimmed()
+    );
 
     // Print ready message
     eprintln!();

--- a/crates/ferrum-cli/src/utils.rs
+++ b/crates/ferrum-cli/src/utils.rs
@@ -14,13 +14,22 @@ pub fn setup_logging(verbose: bool, quiet: bool) -> Result<()> {
         tracing::Level::WARN
     };
 
-    // Build filter: suppress noisy warnings unless verbose
+    // Build filter: suppress noisy warnings unless verbose. Default level
+    // is WARN, but the model-load and weight-loader namespaces stay at
+    // INFO so users see per-layer progress during the (10-60s) load.
+    // Without this, `ferrum run /path/to/30b-moe` looks frozen between
+    // "Loading..." and the first decode token.
     let filter = if verbose {
         EnvFilter::new(log_level.to_string())
     } else {
         EnvFilter::try_from_default_env().unwrap_or_else(|_| {
             EnvFilter::new(format!(
-                "{},ferrum_engine::metal::metal_executor=error,tokenizers=error",
+                "{},\
+                 ferrum_engine::metal::metal_executor=error,\
+                 tokenizers=error,\
+                 ferrum_models=info,\
+                 ferrum_quantization=info,\
+                 ferrum_engine::registry=info",
                 log_level
             ))
         })


### PR DESCRIPTION
## Symptom
\`ferrum run /workspace/models/M3\` (Qwen3-30B-A3B, 15.8 GB weights):

\`\`\`
[auto-size] gpu=24.0 GB total / 23.5 GB free | weights=15.8 GB | ...
[auto-size] KV_MAX_BLOCKS=1241 PAGED_MAX_SEQS=2 KV_CAPACITY=8192
Loading /workspace/models/M3...
Using CUDA(0) backend
[~30s of nothing — looks frozen]
Ready. Type your message and press Enter.
\`\`\`

User reported: "加载模型过程中没有任何提示".

## Root cause
- The model loader emits per-layer \`tracing::info!\` events.
- CLI's default tracing filter is WARN, so INFO drops.

## Fix
- \`utils.rs\`: whitelist \`ferrum_models\`, \`ferrum_quantization\`, \`ferrum_engine::registry\` at INFO. Other crates stay WARN, so output isn't noisy.
- \`run.rs\`: print \"Loading weights to GPU... (30s+ for >10 GB models)\" hint before \`create_default_engine\`, and \"Model loaded in X.Ys.\" after. Users see SOMETHING during the load and how long it took, even if no per-layer logs surface.

## Test plan
- [x] cargo check --workspace
- [ ] On RTX 4090 pod: \`./target/release/ferrum run /workspace/models/M3\` — verify per-layer INFO logs show, plus the load-timing line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)