### PR TITLE
docs(bench): M3 Stage 13a final — 256 → 355 tok/s c=32 (+39%)

### DIFF
--- a/bench/v0.2-cuda/m3_tile_sweep.sh
+++ b/bench/v0.2-cuda/m3_tile_sweep.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+# Marlin tile-size sweep at c=32. After Stage 12.1 + 13a defaults ON,
+# the (1,8,8) thread tile (128x128) is what prob_m=16 auto-picks. Try
+# the other CALL_IF specs to see which actually wins for the MoE
+# shape (gate_up n=1536, k=2048; down n=2048, k=768).
+#
+# FERRUM_MARLIN_TILE accepts: 64x256, 128x128, 64x128, 128x64.
+# Only c=32, single rep — quick A/B (~2 min total).
+
+set -uo pipefail
+WORKSPACE="${WORKSPACE:-/workspace}"
+BENCH_DIR="${WORKSPACE}/ferrum-infer-rs/bench/v0.2-cuda"
+RESULTS_DIR="$BENCH_DIR/results_m3_tile_sweep"
+MODEL_DIR="${WORKSPACE}/models/M3"
+mkdir -p "$RESULTS_DIR"
+
+run_one() {
+  local tile="$1"
+  local PORT=8800
+  local SERVER_LOG="$RESULTS_DIR/server_${tile}.log"
+
+  echo "── tile=$tile ────────────────────────────────────"
+  pkill -9 -f "target/release/ferrum" 2>/dev/null
+  sleep 3
+
+  CUDA_VISIBLE_DEVICES=0 \
+  FERRUM_KV_CAPACITY=2048 \
+  FERRUM_KV_MAX_BLOCKS=4096 \
+  FERRUM_PAGED_MAX_SEQS=32 \
+  FERRUM_METAL_PAGED_KV=1 \
+  FERRUM_MIXED_BATCH=0 \
+  FERRUM_GREEDY_ARGMAX=1 \
+  FERRUM_MOE_BUCKETED=1 \
+  FERRUM_MARLIN_SKIP_WS_ZERO=1 \
+  FERRUM_MOE_STREAMS=4 \
+  FERRUM_MARLIN_TILE="$tile" \
+    "$WORKSPACE/ferrum-infer-rs/target/release/ferrum" serve \
+      --model "$MODEL_DIR" --port "$PORT" \
+      --gpu-memory-utilization 0.95 > "$SERVER_LOG" 2>&1 &
+  local PID=$!
+
+  for i in $(seq 1 600); do
+    if curl -sf "http://127.0.0.1:$PORT/v1/models" >/dev/null 2>&1; then break; fi
+    if ! kill -0 "$PID" 2>/dev/null; then echo "died (tile=$tile)"; tail -50 "$SERVER_LOG"; return 1; fi
+    sleep 1
+  done
+
+  curl -s "http://127.0.0.1:$PORT/v1/chat/completions" \
+    -H "Content-Type: application/json" \
+    -d '{"model":"x","messages":[{"role":"user","content":"hi"}],"max_tokens":4,"stream":false}' >/dev/null
+
+  vllm bench serve \
+    --backend openai-chat --base-url "http://127.0.0.1:$PORT" \
+    --endpoint /v1/chat/completions --model "$MODEL_DIR" --tokenizer "$MODEL_DIR" \
+    --dataset-name random --random-input-len 256 --random-output-len 128 \
+    --num-prompts 128 --max-concurrency 32 \
+    --save-result --result-dir "$RESULTS_DIR" \
+    --result-filename "tile_${tile}_c32.json" \
+    --percentile-metrics ttft,tpot,itl 2>&1 | tail -5
+
+  kill -INT "$PID" 2>/dev/null
+  wait "$PID" 2>/dev/null
+}
+
+for tile in 128x128 64x256 64x128 128x64; do
+  run_one "$tile"
+done
+
+echo ""
+echo "=== headlines (c=32) ==="
+for tile in 128x128 64x256 64x128 128x64; do
+  python3 -c "
+import json
+d = json.load(open('$RESULTS_DIR/tile_${tile}_c32.json'))
+print(f'tile=${tile}  out={d[\"output_throughput\"]:.1f} tok/s  tpot={d[\"mean_tpot_ms\"]:.2f} ms')
+" 2>/dev/null || echo "tile=$tile: missing data"
+done

--- a/docs/bench/cuda-rtx4090-2026-05-08-m3-moe/README.md
+++ b/docs/bench/cuda-rtx4090-2026-05-08-m3-moe/README.md
@@ -397,6 +397,62 @@ attn now sits comparable to MoE GEMM. Next levers (Stage 13+):
 Parity validated: `cuda_marlin_moe_fused_vs_per_expert` test passes
 with rel < 0.001 (4 experts × variable m_e ∈ {16, 8, 12, 4}).
 
+### Stage 13a — batched paged-decode flash split-K (PRs #96 + #98)
+
+After Stage 12.1 attn jumped to 31% of c=32 TPOT (was 14%). New batched
+flash-decode kernel: phase-1 splits each seq's KV across `num_splits`
+chunks (grid: num_q_heads × num_seqs × num_splits) + phase-2 reduce per
+(seq, head). Smart heuristic auto-tunes splits by `num_seqs × num_heads`
+saturation AND `kv_len`:
+
+- saturated grid: splits=1 if kv≤768 else 2-4
+- low concurrency: aggressive splits to fill SMs
+
+| c    | Stage 12.1 | **Stage 13a v2 (smart split-K)** | Δ vs Stage 12.1 | vs vLLM |
+|------|------------|----------------------------------|-----------------|---------|
+| 1    | 84.3       | **101.9**                        | **+21%** ★      | 63%     |
+| 8    | 254.8      | **262.5**                        | +3.0%           | —       |
+| 16   | 318.9      | **330.2**                        | +3.5%           | 65%     |
+| 32   | 320.6      | **355.1**                        | **+10.8%**      | **19.0%** |
+
+PR #98 flips `FERRUM_MOE_FUSED` and `FERRUM_PAGED_FLASH` defaults to
+ON so end-user CLI doesn't need any env var to get the fast path.
+Escape: `FERRUM_PAGED_FLASH=0` falls back to single-pass kernel;
+`FERRUM_MOE_FUSED=0` falls back to multi-stream pool.
+
+### Cumulative progress (this session, PRs #94 → #98)
+
+| Stage              | c=1   | c=8   | c=16  | c=32  | vs vLLM (c=32) |
+|--------------------|-------|-------|-------|-------|----------------|
+| pre-#94 baseline   | 9.7   | 9.7   | —     | 137.1 | 7.3%           |
+| #94 (Stages 6-10)  | 65.5  | 118.0 | 132.1 | 267.7 | 14.3%          |
+| #96 (Stages 11+12+12.1+13a) | 84.3 | 254.8 | 318.9 | 320.6 | 17.1%   |
+| **#98 (defaults ON, smart split-K)** | **101.9** | **262.5** | **330.2** | **355.1** | **19.0%** |
+
+c=32: 137 → **355 tok/s = 2.6×**. Mean TPOT 204 → **83 ms** (-59%).
+
+### Path to 80% of vLLM (~1500 tok/s)
+
+Current ratio 19% means another **4.2×** to hit 80%. Single-kernel
+tunes (tile size, gridDim shape, split-K heuristic) have been mined
+out — each remaining 5-10% gain is now diminishing. The big remaining
+levers all require larger work:
+
+- **vLLM-style fused MoE Marlin port** — sorted_token_ids + per-tile
+  expert routing. Eliminates the m=16 padding waste (m_e ∈ {1..3}
+  effective, 5-16× compute slack). ~4000 LoC port. Speculative gain
+  3-4× on the MoE GEMM phase.
+- **Marlin m<16 tile rewrite** — drop the m16n8k16 MMA, add m8n8k16
+  variants for tiny-m experts. Saves bandwidth waste (B/s tile is
+  loaded once per call regardless of actual m). Major surgery on the
+  IST-DASLab kernel internals.
+- **CUDA Graph capture for full decode iter** — vLLM uses parameterized
+  graphs (`cudaGraphExecKernelNodeSetParams`) so per-token routing
+  changes don't force re-record. ~+5-10% on launch overhead, not the
+  4× we'd need.
+
+### The c=32 OOB resolution
+
 ### The c=32 OOB resolution
 
 Stage 9's first ship (commit c846732) hit `CUDA_ERROR_ILLEGAL_ADDRESS`


### PR DESCRIPTION
Records cumulative session result for Qwen3-30B-A3B INT4 on RTX 4090.

| Stage              | c=1   | c=8   | c=16  | c=32  | vs vLLM (c=32) |
|--------------------|-------|-------|-------|-------|----------------|
| pre-#94 baseline   | 9.7   | 9.7   | —     | 137.1 | 7.3%           |
| #94 (Stages 6-10)  | 65.5  | 118.0 | 132.1 | 267.7 | 14.3%          |
| #96 (Stages 11+12+12.1+13a) | 84.3 | 254.8 | 318.9 | 320.6 | 17.1%   |
| **#98 (defaults ON)** | **101.9** | **262.5** | **330.2** | **355.1** | **19.0%** |

c=32 mean TPOT: 204 → **83 ms** (-59%).

## Next-step ROI table

Single-kernel tuning is mined out. To reach 80% of vLLM (~1500 tok/s,
4.2× more) we need:
- **vLLM-style fused MoE Marlin port** (~4000 LoC, speculative 3-4× on MoE GEMM)
- **Marlin m<16 tile rewrite** (major surgery on IST-DASLab MMA pipeline)
- **CUDA Graph capture** (5-10% on launch overhead — not the lever we need alone)

🤖 Generated with [Claude Code](https://claude.com/claude-code)