### PR TITLE
perf(attn): batched paged-attention dispatch — c=32 +26% (310→391 tok/s)

### DIFF
--- a/crates/ferrum-kernels/src/backend/cuda.rs
+++ b/crates/ferrum-kernels/src/backend/cuda.rs
@@ -126,23 +126,6 @@ pub struct CudaState {
     /// this scratch we fall back to atomic_add which is 1.3-1.5× slower.
     #[cfg(feature = "vllm-moe-marlin")]
     vllm_moe_c_tmp_f32: Option<CudaSlice<f32>>,
-    /// Persistent device-side routing buffers for vLLM marlin_moe. Moves
-    /// the per-layer `vec! + clone_htod + std::mem::forget` pattern off
-    /// the hot path: every layer reuses the same allocation, fills it
-    /// via memcpy_htod, and re-launches. This is also the foundation for
-    /// Stage 13c full-forward CUDA Graph capture — the kernel takes its
-    /// inputs from stable device pointers, so a captured graph can be
-    /// replayed many times after re-uploading routing.
-    ///
-    /// Sized to a worst-case upper bound; grow lazily.
-    #[cfg(feature = "vllm-moe-marlin")]
-    vllm_moe_sorted_token_ids: Option<CudaSlice<i32>>,
-    #[cfg(feature = "vllm-moe-marlin")]
-    vllm_moe_expert_ids: Option<CudaSlice<i32>>,
-    #[cfg(feature = "vllm-moe-marlin")]
-    vllm_moe_num_tokens_past_padded: Option<CudaSlice<i32>>,
-    #[cfg(feature = "vllm-moe-marlin")]
-    vllm_moe_routing_capacity: usize,
 }
 
 const BATCHED_SCRATCH_CAP: usize = 64;
@@ -210,55 +193,6 @@ impl CudaState {
             );
         }
         self.vllm_moe_c_tmp_f32.as_mut().unwrap()
-    }
-
-    /// Persistent vLLM moe routing buffers. Allocated ONCE at worst-case
-    /// size on first call (num_experts × block_size = 128 × 16 = 2048 i32
-    /// for Qwen3-MoE; expert_ids = 128). Caller then uploads via
-    /// cuMemcpyHtoDAsync with explicit byte count — no re-allocation
-    /// happens between calls, so there's no stream-ordered / drop-time
-    /// race between the in-flight memcpy and the new buffer allocation.
-    #[cfg(feature = "vllm-moe-marlin")]
-    pub fn vllm_moe_routing(
-        &mut self,
-    ) -> (
-        &mut CudaSlice<i32>,
-        &mut CudaSlice<i32>,
-        &mut CudaSlice<i32>,
-    ) {
-        if self.vllm_moe_sorted_token_ids.is_none() {
-            // Worst case: every expert gets at least one block at decode
-            // time. Qwen3-MoE has up to 128 experts; 16 = block_size.
-            // 2048 i32 = 8 KB; 128 i32 = 512 B; 1 i32 = 4 B. Trivial cost.
-            const WORST_SORTED_LEN: usize = 128 * 16;
-            const WORST_EID_LEN: usize = 128;
-            self.vllm_moe_sorted_token_ids = Some(
-                self.stream
-                    .alloc_zeros::<i32>(WORST_SORTED_LEN)
-                    .expect("alloc_zeros vllm_moe_sorted_token_ids"),
-            );
-            self.vllm_moe_expert_ids = Some(
-                self.stream
-                    .alloc_zeros::<i32>(WORST_EID_LEN)
-                    .expect("alloc_zeros vllm_moe_expert_ids"),
-            );
-            self.vllm_moe_num_tokens_past_padded = Some(
-                self.stream
-                    .alloc_zeros::<i32>(1)
-                    .expect("alloc_zeros vllm_moe_num_tokens_past_padded"),
-            );
-            self.vllm_moe_routing_capacity = WORST_SORTED_LEN;
-            tracing::info!(
-                "vLLM moe routing buffers allocated (worst-case): \
-                 sorted_token_ids={WORST_SORTED_LEN} i32, \
-                 expert_ids={WORST_EID_LEN} i32, num_tokens_past_padded=1 i32"
-            );
-        }
-        (
-            self.vllm_moe_sorted_token_ids.as_mut().unwrap(),
-            self.vllm_moe_expert_ids.as_mut().unwrap(),
-            self.vllm_moe_num_tokens_past_padded.as_mut().unwrap(),
-        )
     }
 
     /// Lazy-init the persistent cuEvents used by
@@ -473,14 +407,6 @@ impl Backend for CudaBackend {
             paged_attn_out_tm_capacity: 0,
             #[cfg(feature = "vllm-moe-marlin")]
             vllm_moe_c_tmp_f32: None,
-            #[cfg(feature = "vllm-moe-marlin")]
-            vllm_moe_sorted_token_ids: None,
-            #[cfg(feature = "vllm-moe-marlin")]
-            vllm_moe_expert_ids: None,
-            #[cfg(feature = "vllm-moe-marlin")]
-            vllm_moe_num_tokens_past_padded: None,
-            #[cfg(feature = "vllm-moe-marlin")]
-            vllm_moe_routing_capacity: 0,
         }
     }
 
@@ -3391,11 +3317,10 @@ impl Backend for CudaBackend {
         use cudarc::driver::CudaSlice;
         use cudarc::driver::DevicePtr;
 
-        // Per-call alloc + leak (matches Stage 14a / PR #101 behaviour
-        // that benched green at +37% c=16 / +19% c=32). Persistent
-        // routing buffers (the cleanup we wanted for graph capture) hit
-        // a CUDA_ERROR_INVALID_VALUE on subsequent memcpys that we
-        // couldn't pinpoint — revert keeps the perf wins intact.
+        // Per-call alloc + leak. Persistent buffers (one-alloc + reuse)
+        // were attempted as Stage 13c-1 but hit a CUDA driver edge case
+        // — leaving the bench-validated path in place for now.
+        // TODO(stage-13c-redo): retry with stream sync between forwards.
         let stream = ctx.stream.clone();
         let st: CudaSlice<i32> = stream
             .clone_htod(sorted_token_ids)
@@ -3412,8 +3337,7 @@ impl Backend for CudaBackend {
             let (npp_ptr, _g2) = npp.device_ptr(&stream);
             (st_ptr, eid_ptr, npp_ptr)
         };
-        let st_f16: CudaSlice<f16> =
-            unsafe { stream.upgrade_device_ptr(st_ptr as CUdeviceptr, 0) };
+        let st_f16: CudaSlice<f16> = unsafe { stream.upgrade_device_ptr(st_ptr as CUdeviceptr, 0) };
         let eid_f16: CudaSlice<f16> =
             unsafe { stream.upgrade_device_ptr(eid_ptr as CUdeviceptr, 0) };
         let npp_f16: CudaSlice<f16> =

--- a/crates/ferrum-kernels/src/backend/cuda.rs
+++ b/crates/ferrum-kernels/src/backend/cuda.rs
@@ -3432,21 +3432,6 @@ impl Backend for CudaBackend {
         std::mem::forget(eid);
         std::mem::forget(npp);
 
-        // Reinterpret the persistent i32 buffers as f16 device handles
-        // for the trait's Self::Buffer. The consumer (moe_gemm_phase_vllm)
-        // only reads device_ptr — len isn't consulted.
-        let (st_ptr, eid_ptr, npp_ptr) = {
-            let (st_ptr, _g0) = st_dev.device_ptr(&stream);
-            let (eid_ptr, _g1) = eid_dev.device_ptr(&stream);
-            let (npp_ptr, _g2) = npp_dev.device_ptr(&stream);
-            (st_ptr, eid_ptr, npp_ptr)
-        };
-        let st_f16: CudaSlice<f16> = unsafe { stream.upgrade_device_ptr(st_ptr as CUdeviceptr, 0) };
-        let eid_f16: CudaSlice<f16> =
-            unsafe { stream.upgrade_device_ptr(eid_ptr as CUdeviceptr, 0) };
-        let npp_f16: CudaSlice<f16> =
-            unsafe { stream.upgrade_device_ptr(npp_ptr as CUdeviceptr, 0) };
-
         Ok(crate::backend::traits::MoeRouting {
             sorted_token_ids: st_f16,
             expert_ids: eid_f16,

--- a/crates/ferrum-kernels/src/backend/cuda.rs
+++ b/crates/ferrum-kernels/src/backend/cuda.rs
@@ -3391,72 +3391,46 @@ impl Backend for CudaBackend {
         use cudarc::driver::CudaSlice;
         use cudarc::driver::DevicePtr;
 
-        // Clone stream FIRST (Arc clone), then take &mut ctx to get the
-        // persistent routing buffers. They're allocated worst-case once;
-        // no re-alloc happens on shape change.
+        // Per-call alloc + leak (matches Stage 14a / PR #101 behaviour
+        // that benched green at +37% c=16 / +19% c=32). Persistent
+        // routing buffers (the cleanup we wanted for graph capture) hit
+        // a CUDA_ERROR_INVALID_VALUE on subsequent memcpys that we
+        // couldn't pinpoint — revert keeps the perf wins intact.
+        use cudarc::driver::sys::CUdeviceptr;
+        use cudarc::driver::CudaSlice;
+        use cudarc::driver::DevicePtr;
         let stream = ctx.stream.clone();
-
-        // Early return for empty inputs — calling cuMemcpyHtoDAsync with
-        // byte_count=0 returns CUDA_ERROR_INVALID_VALUE on some driver
-        // versions. The kernel reads num_tokens_past_padded[0] / block
-        // entries, so an all-zero scenario should never invoke this, but
-        // guard anyway.
-        if sorted_token_ids.is_empty() || expert_ids.is_empty() {
-            return Err(FerrumError::model(format!(
-                "upload_moe_routing: empty inputs (sorted={}, eid={})",
-                sorted_token_ids.len(),
-                expert_ids.len()
-            )));
-        }
-
-        let (st_dev, eid_dev, npp_dev) = ctx.vllm_moe_routing();
-        eprintln!(
-            "DEBUG upload_moe_routing v2: sorted_len={} eid_len={} npp_len={} st_dev_len={} eid_dev_len={} npp_dev_len={}",
-            sorted_token_ids.len(),
-            expert_ids.len(),
-            num_tokens_past_padded.len(),
-            st_dev.len(),
-            eid_dev.len(),
-            npp_dev.len()
-        );
-
-        // Use raw cuMemcpyHtoDAsync_v2 with explicit byte count — host
-        // slices are smaller than the worst-case persistent buffers, so
-        // cudarc's memcpy_htod (which requires src.len() == dst.len()) is
-        // not usable. We only need to copy host_len bytes; the remaining
-        // tail of the persistent buffer is irrelevant (kernel reads
-        // exactly num_tokens_past_padded[0] / block_size entries).
-        unsafe {
-            use cudarc::driver::sys;
-            let s = stream.cu_stream();
-            let (st_ptr, _g0) = st_dev.device_ptr(&stream);
-            sys::cuMemcpyHtoDAsync_v2(
-                st_ptr,
-                sorted_token_ids.as_ptr() as *const _,
-                std::mem::size_of_val(sorted_token_ids),
-                s,
-            )
-            .result()
+        let st: CudaSlice<i32> = stream
+            .clone_htod(sorted_token_ids)
             .map_err(|e| FerrumError::model(format!("htod sorted_token_ids: {e}")))?;
-            let (eid_ptr, _g1) = eid_dev.device_ptr(&stream);
-            sys::cuMemcpyHtoDAsync_v2(
-                eid_ptr,
-                expert_ids.as_ptr() as *const _,
-                std::mem::size_of_val(expert_ids),
-                s,
-            )
-            .result()
+        let eid: CudaSlice<i32> = stream
+            .clone_htod(expert_ids)
             .map_err(|e| FerrumError::model(format!("htod expert_ids: {e}")))?;
-            let (npp_ptr, _g2) = npp_dev.device_ptr(&stream);
-            sys::cuMemcpyHtoDAsync_v2(
-                npp_ptr,
-                num_tokens_past_padded.as_ptr() as *const _,
-                std::mem::size_of_val(num_tokens_past_padded),
-                s,
-            )
-            .result()
+        let npp: CudaSlice<i32> = stream
+            .clone_htod(num_tokens_past_padded)
             .map_err(|e| FerrumError::model(format!("htod num_tokens_past_padded: {e}")))?;
-        }
+        let (st_ptr, eid_ptr, npp_ptr) = {
+            let (st_ptr, _g0) = st.device_ptr(&stream);
+            let (eid_ptr, _g1) = eid.device_ptr(&stream);
+            let (npp_ptr, _g2) = npp.device_ptr(&stream);
+            (st_ptr, eid_ptr, npp_ptr)
+        };
+        let st_f16: CudaSlice<f16> =
+            unsafe { stream.upgrade_device_ptr(st_ptr as CUdeviceptr, 0) };
+        let eid_f16: CudaSlice<f16> =
+            unsafe { stream.upgrade_device_ptr(eid_ptr as CUdeviceptr, 0) };
+        let npp_f16: CudaSlice<f16> =
+            unsafe { stream.upgrade_device_ptr(npp_ptr as CUdeviceptr, 0) };
+        // Forget the i32 owning slices so the memory survives — the f16
+        // views above point at the same allocation. Acceptable leak: a
+        // few KB per layer × 48 layers/forward × forwards/sec = ~MB/s
+        // sustained, freed only at process exit. Not ideal but works.
+        // TODO(stage-13c-redo): re-attempt persistent buffers once we
+        // understand why memcpy_htod / cuMemcpyHtoDAsync rejects the
+        // 2nd call's params under our driver version.
+        std::mem::forget(st);
+        std::mem::forget(eid);
+        std::mem::forget(npp);
 
         // Reinterpret the persistent i32 buffers as f16 device handles
         // for the trait's Self::Buffer. The consumer (moe_gemm_phase_vllm)

--- a/crates/ferrum-kernels/src/backend/cuda.rs
+++ b/crates/ferrum-kernels/src/backend/cuda.rs
@@ -3396,9 +3396,6 @@ impl Backend for CudaBackend {
         // routing buffers (the cleanup we wanted for graph capture) hit
         // a CUDA_ERROR_INVALID_VALUE on subsequent memcpys that we
         // couldn't pinpoint — revert keeps the perf wins intact.
-        use cudarc::driver::sys::CUdeviceptr;
-        use cudarc::driver::CudaSlice;
-        use cudarc::driver::DevicePtr;
         let stream = ctx.stream.clone();
         let st: CudaSlice<i32> = stream
             .clone_htod(sorted_token_ids)

--- a/crates/ferrum-kernels/src/backend/cuda.rs
+++ b/crates/ferrum-kernels/src/backend/cuda.rs
@@ -212,42 +212,47 @@ impl CudaState {
         self.vllm_moe_c_tmp_f32.as_mut().unwrap()
     }
 
-    /// Allocate exact-size persistent vLLM moe routing buffers — each
-    /// call resizes if `capacity` differs from the cached size. Caller
-    /// then memcpy_htods exactly `capacity` i32 elements into
-    /// sorted_token_ids and `capacity / block_size` (= capacity/16) i32
-    /// into expert_ids, both of which match the host slice lengths.
+    /// Persistent vLLM moe routing buffers. Allocated ONCE at worst-case
+    /// size on first call (num_experts × block_size = 128 × 16 = 2048 i32
+    /// for Qwen3-MoE; expert_ids = 128). Caller then uploads via
+    /// cuMemcpyHtoDAsync with explicit byte count — no re-allocation
+    /// happens between calls, so there's no stream-ordered / drop-time
+    /// race between the in-flight memcpy and the new buffer allocation.
     #[cfg(feature = "vllm-moe-marlin")]
     pub fn vllm_moe_routing(
         &mut self,
-        capacity: usize,
     ) -> (
         &mut CudaSlice<i32>,
         &mut CudaSlice<i32>,
         &mut CudaSlice<i32>,
     ) {
-        if self.vllm_moe_routing_capacity != capacity || self.vllm_moe_sorted_token_ids.is_none() {
+        if self.vllm_moe_sorted_token_ids.is_none() {
+            // Worst case: every expert gets at least one block at decode
+            // time. Qwen3-MoE has up to 128 experts; 16 = block_size.
+            // 2048 i32 = 8 KB; 128 i32 = 512 B; 1 i32 = 4 B. Trivial cost.
+            const WORST_SORTED_LEN: usize = 128 * 16;
+            const WORST_EID_LEN: usize = 128;
             self.vllm_moe_sorted_token_ids = Some(
                 self.stream
-                    .alloc_zeros::<i32>(capacity)
+                    .alloc_zeros::<i32>(WORST_SORTED_LEN)
                     .expect("alloc_zeros vllm_moe_sorted_token_ids"),
             );
-            // expert_ids count = capacity / block_size. block_size is 16
-            // for our Qwen3-MoE path.
-            let eid_cap = capacity / 16;
             self.vllm_moe_expert_ids = Some(
                 self.stream
-                    .alloc_zeros::<i32>(eid_cap)
+                    .alloc_zeros::<i32>(WORST_EID_LEN)
                     .expect("alloc_zeros vllm_moe_expert_ids"),
             );
-            if self.vllm_moe_num_tokens_past_padded.is_none() {
-                self.vllm_moe_num_tokens_past_padded = Some(
-                    self.stream
-                        .alloc_zeros::<i32>(1)
-                        .expect("alloc_zeros vllm_moe_num_tokens_past_padded"),
-                );
-            }
-            self.vllm_moe_routing_capacity = capacity;
+            self.vllm_moe_num_tokens_past_padded = Some(
+                self.stream
+                    .alloc_zeros::<i32>(1)
+                    .expect("alloc_zeros vllm_moe_num_tokens_past_padded"),
+            );
+            self.vllm_moe_routing_capacity = WORST_SORTED_LEN;
+            tracing::info!(
+                "vLLM moe routing buffers allocated (worst-case): \
+                 sorted_token_ids={WORST_SORTED_LEN} i32, \
+                 expert_ids={WORST_EID_LEN} i32, num_tokens_past_padded=1 i32"
+            );
         }
         (
             self.vllm_moe_sorted_token_ids.as_mut().unwrap(),
@@ -3386,30 +3391,49 @@ impl Backend for CudaBackend {
         use cudarc::driver::CudaSlice;
         use cudarc::driver::DevicePtr;
 
-        // Clone stream FIRST (Arc clone, no borrow on ctx), then take
-        // &mut ctx to grow/get persistent routing buffers.
+        // Clone stream FIRST (Arc clone), then take &mut ctx to get the
+        // persistent routing buffers. They're allocated worst-case once;
+        // no re-alloc happens on shape change.
         let stream = ctx.stream.clone();
-        let cap = sorted_token_ids.len();
-        let eid_host_len = expert_ids.len();
-        let npp_host_len = num_tokens_past_padded.len();
-        let (st_dev, eid_dev, npp_dev) = ctx.vllm_moe_routing(cap);
+        let (st_dev, eid_dev, npp_dev) = ctx.vllm_moe_routing();
 
-        eprintln!(
-            "DEBUG upload_moe_routing: cap={cap} eid_host={eid_host_len} npp_host={npp_host_len} st_dev_len={} eid_dev_len={} npp_dev_len={}",
-            st_dev.len(), eid_dev.len(), npp_dev.len()
-        );
-
-        // Persistent buffers now sized exactly to the host slices — use
-        // cudarc's memcpy_htod which validates src.len() == dst.len().
-        stream
-            .memcpy_htod(sorted_token_ids, st_dev)
-            .map_err(|e| FerrumError::model(format!("htod sorted_token_ids (cap={cap} dev_len={}): {e}", st_dev.len())))?;
-        stream
-            .memcpy_htod(expert_ids, eid_dev)
-            .map_err(|e| FerrumError::model(format!("htod expert_ids (host_len={eid_host_len} dev_len={}): {e}", eid_dev.len())))?;
-        stream
-            .memcpy_htod(num_tokens_past_padded, npp_dev)
+        // Use raw cuMemcpyHtoDAsync_v2 with explicit byte count — host
+        // slices are smaller than the worst-case persistent buffers, so
+        // cudarc's memcpy_htod (which requires src.len() == dst.len()) is
+        // not usable. We only need to copy host_len bytes; the remaining
+        // tail of the persistent buffer is irrelevant (kernel reads
+        // exactly num_tokens_past_padded[0] / block_size entries).
+        unsafe {
+            use cudarc::driver::sys;
+            let s = stream.cu_stream();
+            let (st_ptr, _g0) = st_dev.device_ptr(&stream);
+            sys::cuMemcpyHtoDAsync_v2(
+                st_ptr,
+                sorted_token_ids.as_ptr() as *const _,
+                std::mem::size_of_val(sorted_token_ids),
+                s,
+            )
+            .result()
+            .map_err(|e| FerrumError::model(format!("htod sorted_token_ids: {e}")))?;
+            let (eid_ptr, _g1) = eid_dev.device_ptr(&stream);
+            sys::cuMemcpyHtoDAsync_v2(
+                eid_ptr,
+                expert_ids.as_ptr() as *const _,
+                std::mem::size_of_val(expert_ids),
+                s,
+            )
+            .result()
+            .map_err(|e| FerrumError::model(format!("htod expert_ids: {e}")))?;
+            let (npp_ptr, _g2) = npp_dev.device_ptr(&stream);
+            sys::cuMemcpyHtoDAsync_v2(
+                npp_ptr,
+                num_tokens_past_padded.as_ptr() as *const _,
+                std::mem::size_of_val(num_tokens_past_padded),
+                s,
+            )
+            .result()
             .map_err(|e| FerrumError::model(format!("htod num_tokens_past_padded: {e}")))?;
+        }
 
         // Reinterpret the persistent i32 buffers as f16 device handles
         // for the trait's Self::Buffer. The consumer (moe_gemm_phase_vllm)

--- a/crates/ferrum-kernels/src/backend/cuda.rs
+++ b/crates/ferrum-kernels/src/backend/cuda.rs
@@ -3390,16 +3390,23 @@ impl Backend for CudaBackend {
         // &mut ctx to grow/get persistent routing buffers.
         let stream = ctx.stream.clone();
         let cap = sorted_token_ids.len();
+        let eid_host_len = expert_ids.len();
+        let npp_host_len = num_tokens_past_padded.len();
         let (st_dev, eid_dev, npp_dev) = ctx.vllm_moe_routing(cap);
+
+        eprintln!(
+            "DEBUG upload_moe_routing: cap={cap} eid_host={eid_host_len} npp_host={npp_host_len} st_dev_len={} eid_dev_len={} npp_dev_len={}",
+            st_dev.len(), eid_dev.len(), npp_dev.len()
+        );
 
         // Persistent buffers now sized exactly to the host slices — use
         // cudarc's memcpy_htod which validates src.len() == dst.len().
         stream
             .memcpy_htod(sorted_token_ids, st_dev)
-            .map_err(|e| FerrumError::model(format!("htod sorted_token_ids: {e}")))?;
+            .map_err(|e| FerrumError::model(format!("htod sorted_token_ids (cap={cap} dev_len={}): {e}", st_dev.len())))?;
         stream
             .memcpy_htod(expert_ids, eid_dev)
-            .map_err(|e| FerrumError::model(format!("htod expert_ids: {e}")))?;
+            .map_err(|e| FerrumError::model(format!("htod expert_ids (host_len={eid_host_len} dev_len={}): {e}", eid_dev.len())))?;
         stream
             .memcpy_htod(num_tokens_past_padded, npp_dev)
             .map_err(|e| FerrumError::model(format!("htod num_tokens_past_padded: {e}")))?;

--- a/crates/ferrum-kernels/src/backend/cuda.rs
+++ b/crates/ferrum-kernels/src/backend/cuda.rs
@@ -3393,20 +3393,46 @@ impl Backend for CudaBackend {
         use cudarc::driver::DevicePtr;
 
         // Clone stream FIRST (Arc clone, no borrow on ctx), then take
-        // &mut ctx to grow/get persistent routing buffers — keeps the
-        // borrow checker happy.
+        // &mut ctx to grow/get persistent routing buffers.
         let stream = ctx.stream.clone();
         let cap = sorted_token_ids.len();
         let (st_dev, eid_dev, npp_dev) = ctx.vllm_moe_routing(cap);
-        stream
-            .memcpy_htod(sorted_token_ids, st_dev)
+
+        // Use raw cuMemcpyHtoDAsync_v2 with explicit byte count — the
+        // persistent buffers are sized to a rounded capacity ≥ the host
+        // slice, so cudarc's memcpy_htod (which requires src.len() ==
+        // dst.len()) fails. We only need to copy `host.len()` bytes.
+        unsafe {
+            use cudarc::driver::sys;
+            let s = stream.cu_stream();
+            let (st_ptr, _g0) = st_dev.device_ptr(&stream);
+            sys::cuMemcpyHtoDAsync_v2(
+                st_ptr,
+                sorted_token_ids.as_ptr() as *const _,
+                std::mem::size_of_val(sorted_token_ids),
+                s,
+            )
+            .result()
             .map_err(|e| FerrumError::model(format!("htod sorted_token_ids: {e}")))?;
-        stream
-            .memcpy_htod(expert_ids, eid_dev)
+            let (eid_ptr, _g1) = eid_dev.device_ptr(&stream);
+            sys::cuMemcpyHtoDAsync_v2(
+                eid_ptr,
+                expert_ids.as_ptr() as *const _,
+                std::mem::size_of_val(expert_ids),
+                s,
+            )
+            .result()
             .map_err(|e| FerrumError::model(format!("htod expert_ids: {e}")))?;
-        stream
-            .memcpy_htod(num_tokens_past_padded, npp_dev)
+            let (npp_ptr, _g2) = npp_dev.device_ptr(&stream);
+            sys::cuMemcpyHtoDAsync_v2(
+                npp_ptr,
+                num_tokens_past_padded.as_ptr() as *const _,
+                std::mem::size_of_val(num_tokens_past_padded),
+                s,
+            )
+            .result()
             .map_err(|e| FerrumError::model(format!("htod num_tokens_past_padded: {e}")))?;
+        }
 
         // Reinterpret the persistent i32 buffers as f16 device handles
         // for the trait's Self::Buffer. The consumer (moe_gemm_phase_vllm)

--- a/crates/ferrum-kernels/src/backend/cuda.rs
+++ b/crates/ferrum-kernels/src/backend/cuda.rs
@@ -3395,7 +3395,30 @@ impl Backend for CudaBackend {
         // persistent routing buffers. They're allocated worst-case once;
         // no re-alloc happens on shape change.
         let stream = ctx.stream.clone();
+
+        // Early return for empty inputs — calling cuMemcpyHtoDAsync with
+        // byte_count=0 returns CUDA_ERROR_INVALID_VALUE on some driver
+        // versions. The kernel reads num_tokens_past_padded[0] / block
+        // entries, so an all-zero scenario should never invoke this, but
+        // guard anyway.
+        if sorted_token_ids.is_empty() || expert_ids.is_empty() {
+            return Err(FerrumError::model(format!(
+                "upload_moe_routing: empty inputs (sorted={}, eid={})",
+                sorted_token_ids.len(),
+                expert_ids.len()
+            )));
+        }
+
         let (st_dev, eid_dev, npp_dev) = ctx.vllm_moe_routing();
+        eprintln!(
+            "DEBUG upload_moe_routing v2: sorted_len={} eid_len={} npp_len={} st_dev_len={} eid_dev_len={} npp_dev_len={}",
+            sorted_token_ids.len(),
+            expert_ids.len(),
+            num_tokens_past_padded.len(),
+            st_dev.len(),
+            eid_dev.len(),
+            npp_dev.len()
+        );
 
         // Use raw cuMemcpyHtoDAsync_v2 with explicit byte count — host
         // slices are smaller than the worst-case persistent buffers, so

--- a/crates/ferrum-kernels/src/backend/cuda.rs
+++ b/crates/ferrum-kernels/src/backend/cuda.rs
@@ -212,11 +212,11 @@ impl CudaState {
         self.vllm_moe_c_tmp_f32.as_mut().unwrap()
     }
 
-    /// Get or grow the persistent vLLM moe routing buffers. `capacity`
-    /// is the upper bound on `total_padded` (= sum of per-expert padded
-    /// rows, ≤ num_experts * moe_block_size when each expert holds at
-    /// least one row). Returns `&mut` to all three buffers + the
-    /// num_tokens_past_padded[1] buffer. Grow re-allocates and zeros.
+    /// Allocate exact-size persistent vLLM moe routing buffers — each
+    /// call resizes if `capacity` differs from the cached size. Caller
+    /// then memcpy_htods exactly `capacity` i32 elements into
+    /// sorted_token_ids and `capacity / block_size` (= capacity/16) i32
+    /// into expert_ids, both of which match the host slice lengths.
     #[cfg(feature = "vllm-moe-marlin")]
     pub fn vllm_moe_routing(
         &mut self,
@@ -226,20 +226,20 @@ impl CudaState {
         &mut CudaSlice<i32>,
         &mut CudaSlice<i32>,
     ) {
-        if self.vllm_moe_routing_capacity < capacity {
-            // Round up to next 256 to amortise growth.
-            let new_cap = ((capacity + 255) / 256) * 256;
+        if self.vllm_moe_routing_capacity != capacity || self.vllm_moe_sorted_token_ids.is_none() {
             self.vllm_moe_sorted_token_ids = Some(
                 self.stream
-                    .alloc_zeros::<i32>(new_cap)
+                    .alloc_zeros::<i32>(capacity)
                     .expect("alloc_zeros vllm_moe_sorted_token_ids"),
             );
+            // expert_ids count = capacity / block_size. block_size is 16
+            // for our Qwen3-MoE path.
+            let eid_cap = capacity / 16;
             self.vllm_moe_expert_ids = Some(
                 self.stream
-                    .alloc_zeros::<i32>(new_cap / 16) // n_blocks = capacity / block_size; block_size=16 max
+                    .alloc_zeros::<i32>(eid_cap)
                     .expect("alloc_zeros vllm_moe_expert_ids"),
             );
-            // num_tokens_past_padded is just a single i32 — alloc once.
             if self.vllm_moe_num_tokens_past_padded.is_none() {
                 self.vllm_moe_num_tokens_past_padded = Some(
                     self.stream
@@ -247,13 +247,7 @@ impl CudaState {
                         .expect("alloc_zeros vllm_moe_num_tokens_past_padded"),
                 );
             }
-            self.vllm_moe_routing_capacity = new_cap;
-            tracing::info!(
-                "vLLM moe routing buffers grown to capacity {} (sorted_token_ids: {} i32, expert_ids: {} i32)",
-                new_cap,
-                new_cap,
-                new_cap / 16,
-            );
+            self.vllm_moe_routing_capacity = capacity;
         }
         (
             self.vllm_moe_sorted_token_ids.as_mut().unwrap(),
@@ -3398,41 +3392,17 @@ impl Backend for CudaBackend {
         let cap = sorted_token_ids.len();
         let (st_dev, eid_dev, npp_dev) = ctx.vllm_moe_routing(cap);
 
-        // Use raw cuMemcpyHtoDAsync_v2 with explicit byte count — the
-        // persistent buffers are sized to a rounded capacity ≥ the host
-        // slice, so cudarc's memcpy_htod (which requires src.len() ==
-        // dst.len()) fails. We only need to copy `host.len()` bytes.
-        unsafe {
-            use cudarc::driver::sys;
-            let s = stream.cu_stream();
-            let (st_ptr, _g0) = st_dev.device_ptr(&stream);
-            sys::cuMemcpyHtoDAsync_v2(
-                st_ptr,
-                sorted_token_ids.as_ptr() as *const _,
-                std::mem::size_of_val(sorted_token_ids),
-                s,
-            )
-            .result()
+        // Persistent buffers now sized exactly to the host slices — use
+        // cudarc's memcpy_htod which validates src.len() == dst.len().
+        stream
+            .memcpy_htod(sorted_token_ids, st_dev)
             .map_err(|e| FerrumError::model(format!("htod sorted_token_ids: {e}")))?;
-            let (eid_ptr, _g1) = eid_dev.device_ptr(&stream);
-            sys::cuMemcpyHtoDAsync_v2(
-                eid_ptr,
-                expert_ids.as_ptr() as *const _,
-                std::mem::size_of_val(expert_ids),
-                s,
-            )
-            .result()
+        stream
+            .memcpy_htod(expert_ids, eid_dev)
             .map_err(|e| FerrumError::model(format!("htod expert_ids: {e}")))?;
-            let (npp_ptr, _g2) = npp_dev.device_ptr(&stream);
-            sys::cuMemcpyHtoDAsync_v2(
-                npp_ptr,
-                num_tokens_past_padded.as_ptr() as *const _,
-                std::mem::size_of_val(num_tokens_past_padded),
-                s,
-            )
-            .result()
+        stream
+            .memcpy_htod(num_tokens_past_padded, npp_dev)
             .map_err(|e| FerrumError::model(format!("htod num_tokens_past_padded: {e}")))?;
-        }
 
         // Reinterpret the persistent i32 buffers as f16 device handles
         // for the trait's Self::Buffer. The consumer (moe_gemm_phase_vllm)

--- a/crates/ferrum-kernels/tests/paged_decode_attn_bench.rs
+++ b/crates/ferrum-kernels/tests/paged_decode_attn_bench.rs
@@ -1,0 +1,171 @@
+//! Paged decode attention microbench at Qwen3-MoE / RTX 4090 shape.
+//!
+//! Reports per-launch GPU time (us) + achieved DRAM bandwidth (% of peak).
+//! Used to decide between (A) tightening the current kernel, (B) porting
+//! vLLM PagedAttn V2, or (C) FlashAttention-2 production decode.
+//!
+//! Run on RTX 4090:
+//!   cargo test -p ferrum-kernels --features cuda --release \
+//!     --test paged_decode_attn_bench bench_paged_decode_attn \
+//!     -- --ignored --nocapture
+
+#![cfg(feature = "cuda")]
+
+use cudarc::driver::CudaContext;
+use ferrum_kernels::backend::cuda::CudaBackend;
+use ferrum_kernels::backend::Backend;
+use std::time::Instant;
+
+#[test]
+#[ignore]
+fn bench_paged_decode_attn() {
+    // Qwen3-MoE / -30B-A3B
+    const NUM_HEADS: usize = 16;
+    const NUM_KV_HEADS: usize = 4;
+    const HEAD_DIM: usize = 128;
+    const BLOCK_SIZE: usize = 16;
+
+    // Decode parameters: c=32, kv_len=256 (typical mid-conversation).
+    const NUM_SEQS: usize = 32;
+    const KV_LEN: usize = 256;
+    const MAX_BLOCKS_PER_SEQ: usize = 32; // covers up to 512 tokens; we fill 256
+    const N_ITERS: usize = 200;
+    const N_WARMUP: usize = 20;
+
+    let ctx_handle = CudaContext::new(0).expect("CUDA context");
+    let stream = ctx_handle.default_stream();
+
+    // Q: [num_seqs, num_heads, head_dim] (q_len=1)
+    let q_n = NUM_SEQS * NUM_HEADS * HEAD_DIM;
+    let q_data: Vec<f32> = (0..q_n).map(|i| ((i as f32) * 0.0017).sin()).collect();
+    let q = CudaBackend::from_slice(&q_data);
+
+    // KV pool: [total_blocks, num_kv_heads, block_size, head_dim] f16
+    // total_blocks = num_seqs * max_blocks_per_seq (over-alloc)
+    let total_blocks = NUM_SEQS * MAX_BLOCKS_PER_SEQ;
+    let kv_n = total_blocks * NUM_KV_HEADS * BLOCK_SIZE * HEAD_DIM;
+    let k_data: Vec<f32> = (0..kv_n).map(|i| ((i as f32) * 0.0011).cos()).collect();
+    let v_data: Vec<f32> = (0..kv_n).map(|i| ((i as f32) * 0.0009).sin()).collect();
+    let k_pool = CudaBackend::from_slice(&k_data);
+    let v_pool = CudaBackend::from_slice(&v_data);
+
+    // block_tables: [num_seqs, max_blocks_per_seq] i32
+    let mut bt_host: Vec<i32> = Vec::with_capacity(NUM_SEQS * MAX_BLOCKS_PER_SEQ);
+    for s in 0..NUM_SEQS {
+        for b in 0..MAX_BLOCKS_PER_SEQ {
+            bt_host.push((s * MAX_BLOCKS_PER_SEQ + b) as i32);
+        }
+    }
+    let block_tables_i32 = stream.clone_htod(&bt_host).unwrap();
+
+    // valid_kv_lens: [num_seqs] i32, all = KV_LEN
+    let kvl_host = vec![KV_LEN as i32; NUM_SEQS];
+    let valid_kv_lens_i32 = stream.clone_htod(&kvl_host).unwrap();
+
+    // Reinterpret i32 device buffers as f16 (Self::Buffer) for the trait API.
+    use cudarc::driver::sys::CUdeviceptr;
+    use cudarc::driver::CudaSlice;
+    use cudarc::driver::DevicePtr;
+    use half::f16;
+    let (bt_ptr, _g0) = block_tables_i32.device_ptr(&stream);
+    let (kvl_ptr, _g1) = valid_kv_lens_i32.device_ptr(&stream);
+    let bt_f16: CudaSlice<f16> = unsafe { stream.upgrade_device_ptr(bt_ptr as CUdeviceptr, 0) };
+    let kvl_f16: CudaSlice<f16> = unsafe { stream.upgrade_device_ptr(kvl_ptr as CUdeviceptr, 0) };
+
+    let mut out_dev = CudaBackend::alloc(NUM_SEQS * NUM_HEADS * HEAD_DIM);
+    let mut ctx = <CudaBackend as Backend>::new_context();
+
+    // Warmup
+    for _ in 0..N_WARMUP {
+        <CudaBackend as Backend>::paged_decode_attention(
+            &mut ctx,
+            &q,
+            &k_pool,
+            &v_pool,
+            &mut out_dev,
+            &bt_f16,
+            &kvl_f16,
+            NUM_SEQS,
+            NUM_HEADS,
+            NUM_KV_HEADS,
+            HEAD_DIM,
+            BLOCK_SIZE,
+            MAX_BLOCKS_PER_SEQ,
+            1, // q_len = 1
+        )
+        .unwrap();
+    }
+    <CudaBackend as Backend>::sync(&mut ctx);
+
+    // Measured run
+    let t0 = Instant::now();
+    for _ in 0..N_ITERS {
+        <CudaBackend as Backend>::paged_decode_attention(
+            &mut ctx,
+            &q,
+            &k_pool,
+            &v_pool,
+            &mut out_dev,
+            &bt_f16,
+            &kvl_f16,
+            NUM_SEQS,
+            NUM_HEADS,
+            NUM_KV_HEADS,
+            HEAD_DIM,
+            BLOCK_SIZE,
+            MAX_BLOCKS_PER_SEQ,
+            1,
+        )
+        .unwrap();
+    }
+    <CudaBackend as Backend>::sync(&mut ctx);
+    let elapsed = t0.elapsed();
+    let per_iter_us = elapsed.as_micros() as f64 / N_ITERS as f64;
+
+    // KV bytes per iter: each query attends to KV_LEN tokens of K + V.
+    // GQA — kv heads are shared across query heads, so each kv head's
+    // (K, V) block range is read num_q_heads/num_kv_heads times. We bound
+    // by the read-once layout (best case) and amplified (worst case).
+    let kv_bytes_optimal: u64 = (NUM_SEQS * NUM_KV_HEADS * 2 * KV_LEN * HEAD_DIM * 2) as u64;
+    let kv_bytes_amplified: u64 = (NUM_SEQS * NUM_HEADS * 2 * KV_LEN * HEAD_DIM * 2) as u64;
+    let bw_optimal_gbs = kv_bytes_optimal as f64 / (per_iter_us * 1e3);
+    let bw_amplified_gbs = kv_bytes_amplified as f64 / (per_iter_us * 1e3);
+    // RTX 4090 peak DRAM: 1008 GB/s
+    const PEAK_GBS: f64 = 1008.0;
+
+    eprintln!(
+        "── paged_decode_attn @ Qwen3-MoE c={NUM_SEQS} kv_len={KV_LEN} ──"
+    );
+    eprintln!(
+        "  shape: heads={NUM_HEADS} kv_heads={NUM_KV_HEADS} dim={HEAD_DIM} block={BLOCK_SIZE}"
+    );
+    eprintln!(
+        "  per-launch: {per_iter_us:.1} µs ({} iters in {:.1} ms)",
+        N_ITERS,
+        elapsed.as_secs_f64() * 1000.0
+    );
+    eprintln!(
+        "  KV bytes optimal:    {:.1} MB  → BW {:.0} GB/s  ({:.1}% of {:.0} peak)",
+        kv_bytes_optimal as f64 / 1e6,
+        bw_optimal_gbs,
+        bw_optimal_gbs / PEAK_GBS * 100.0,
+        PEAK_GBS,
+    );
+    eprintln!(
+        "  KV bytes amplified:  {:.1} MB  → BW {:.0} GB/s  ({:.1}% of {:.0} peak)",
+        kv_bytes_amplified as f64 / 1e6,
+        bw_amplified_gbs,
+        bw_amplified_gbs / PEAK_GBS * 100.0,
+        PEAK_GBS,
+    );
+
+    // Per-forward attention budget at 48 layers:
+    let attn_per_forward_us = per_iter_us * 48.0;
+    eprintln!(
+        "  per-forward (48 layers): {:.2} ms",
+        attn_per_forward_us / 1e3
+    );
+
+    std::mem::forget(bt_f16);
+    std::mem::forget(kvl_f16);
+}

--- a/crates/ferrum-kernels/tests/paged_decode_attn_bench.rs
+++ b/crates/ferrum-kernels/tests/paged_decode_attn_bench.rs
@@ -133,9 +133,7 @@ fn bench_paged_decode_attn() {
     // RTX 4090 peak DRAM: 1008 GB/s
     const PEAK_GBS: f64 = 1008.0;
 
-    eprintln!(
-        "── paged_decode_attn @ Qwen3-MoE c={NUM_SEQS} kv_len={KV_LEN} ──"
-    );
+    eprintln!("── paged_decode_attn @ Qwen3-MoE c={NUM_SEQS} kv_len={KV_LEN} ──");
     eprintln!(
         "  shape: heads={NUM_HEADS} kv_heads={NUM_KV_HEADS} dim={HEAD_DIM} block={BLOCK_SIZE}"
     );

--- a/crates/ferrum-models/src/models/qwen3_moe.rs
+++ b/crates/ferrum-models/src/models/qwen3_moe.rs
@@ -239,6 +239,14 @@ pub struct Qwen3MoeScratch<B: Backend> {
     pub paged_batch_o: Option<B::Buffer>,
     pub paged_batch_block_tables: Option<B::Buffer>,
     pub paged_batch_context_lens: Option<B::Buffer>,
+    /// Per-seq pos_offset buffer for the batched
+    /// `split_qkv_norm_rope_into_paged_cache_varlen` path. Eliminates the
+    /// per-item dispatch loop in `forward_layer_batched_decode`.
+    pub paged_batch_pos_offsets: Option<B::Buffer>,
+    /// `[0, 1, 2, ..., max_seqs]` — pre-filled cumulative seq-len array
+    /// for batched decode where every seq contributes q_len=1. Constant
+    /// across the lifetime of the scratch.
+    pub paged_batch_cu_seqlens_q: Option<B::Buffer>,
     pub paged_max_blocks_per_seq: usize,
 
     pub max_tokens: usize,
@@ -317,6 +325,8 @@ impl<B: Backend> Qwen3MoeScratch<B> {
             paged_batch_o: None,
             paged_batch_block_tables: None,
             paged_batch_context_lens: None,
+            paged_batch_pos_offsets: None,
+            paged_batch_cu_seqlens_q: None,
             paged_max_blocks_per_seq: 0,
             max_tokens: t,
             moe_route_scratch: crate::moe::MoeRouteScratch::new(),
@@ -339,6 +349,12 @@ impl<B: Backend> Qwen3MoeScratch<B> {
         self.paged_batch_o = Some(B::alloc(max_seqs * q_dim));
         self.paged_batch_block_tables = Some(B::alloc_u32(max_seqs * max_blocks_per_seq));
         self.paged_batch_context_lens = Some(B::alloc_u32(max_seqs));
+        self.paged_batch_pos_offsets = Some(B::alloc_u32(max_seqs));
+        // cu_seqlens_q is constant [0, 1, 2, ..., max_seqs] for batched
+        // decode (q_len=1 per seq) — pre-fill once via a "context" we can
+        // borrow temporarily; if the writer needs ctx, we lazy-init at
+        // first call instead.
+        self.paged_batch_cu_seqlens_q = Some(B::alloc_u32(max_seqs + 1));
         self.paged_max_blocks_per_seq = max_blocks_per_seq;
     }
 
@@ -2029,12 +2045,12 @@ impl<B: Backend> Qwen3MoeModel<B> {
             let block_size = 16; // matches PAGED_BLOCK_SIZE in ensure_kv
             let qkv_stride = q_dim + 2 * kv_dim;
 
-            // Step 1: per-item paged write. Read each item's qkv out of
-            // the batched qkv_out buffer; write its head-major Q into
-            // paged_batch_q[i*q_dim ..]; write its K/V into the pool at
-            // its allocated blocks via block_table.
+            // Step 1: gather per-seq metadata on host (cache.len before
+            // append, full block_tables stack, post-append context_lens),
+            // bump cache.len, build cu_seqlens_q.
             let q_head_major_size_bytes = (q_dim * std::mem::size_of::<f32>()) as u64;
-            let qkv_stride_bytes = (qkv_stride * std::mem::size_of::<f32>()) as u64;
+            let _qkv_stride_bytes = (qkv_stride * std::mem::size_of::<f32>()) as u64;
+            let _ = q_head_major_size_bytes; // unused in batched path
             let pool_ptr = {
                 let pools = self.paged_pools.as_mut().unwrap();
                 (
@@ -2044,71 +2060,30 @@ impl<B: Backend> Qwen3MoeModel<B> {
             };
             // SAFETY: pools allocated-once, see paged_pools field comment.
             let (pool_k, pool_v) = unsafe { (&mut *pool_ptr.0, &mut *pool_ptr.1) };
-            for (i, (cache_id, _token, pos)) in batch.iter().enumerate() {
-                let pos_i = *pos as usize;
-                let caches = self
-                    .kv_caches
-                    .get(cache_id)
-                    .expect("paged batched: cache not present");
-                let cache = &caches[li];
-                let bt = cache
-                    .block_table
-                    .as_ref()
-                    .expect("paged batched: block_table missing");
-                let cache_len_before = cache.len;
-                let bt_ptr = bt as *const B::Buffer;
-                // SAFETY: bt is read-only during the dispatch; we don't
-                // touch self.kv_caches between this raw deref and the
-                // call below.
-                let bt_safe: &B::Buffer = unsafe { &*bt_ptr };
-                B::split_qkv_norm_rope_into_paged_cache(
-                    ctx,
-                    &self.scratch.qkv_out,
-                    (i as u64) * qkv_stride_bytes,
-                    q_norm_w,
-                    k_norm_w,
-                    &self.rope.cos,
-                    &self.rope.sin,
-                    self.scratch
-                        .paged_batch_q
-                        .as_mut()
-                        .expect("paged_batch_q missing"),
-                    (i as u64) * q_head_major_size_bytes,
-                    pool_k,
-                    pool_v,
-                    bt_safe,
-                    1,
-                    nh,
-                    nkv,
-                    hd,
-                    pos_i,
-                    eps,
-                    qk_mode,
-                    cache_len_before,
-                    block_size,
-                    max_blocks_per_seq,
-                )
-                .expect("split_qkv_norm_rope_into_paged_cache (batched)");
-            }
 
-            // Step 2: bump cache.len and stack block_tables + context_lens
-            // host-side, then upload to device scratch.
             let mut stacked_bt: Vec<u32> = vec![0u32; m * max_blocks_per_seq];
             let mut stacked_cl: Vec<u32> = vec![0u32; m];
+            let mut pos_offsets_host: Vec<u32> = vec![0u32; m];
+            let mut cu_seqlens_host: Vec<u32> = vec![0u32; m + 1];
+            for i in 0..=m {
+                cu_seqlens_host[i] = i as u32;
+            }
             for (i, (cache_id, _, _)) in batch.iter().enumerate() {
                 let caches = self
                     .kv_caches
                     .get_mut(cache_id)
                     .expect("paged batched: cache not present");
                 let cache = &mut caches[li];
-                cache.len += 1;
-                let len = cache.len as u32;
-                stacked_cl[i] = len;
+                pos_offsets_host[i] = cache.len as u32; // RoPE position = pre-append cache len
                 let blocks = &cache.paged_block_indices;
                 let n_to_copy = blocks.len().min(max_blocks_per_seq);
                 stacked_bt[i * max_blocks_per_seq..i * max_blocks_per_seq + n_to_copy]
                     .copy_from_slice(&blocks[..n_to_copy]);
+                cache.len += 1;
+                stacked_cl[i] = cache.len as u32;
             }
+
+            // Step 2: upload all per-seq metadata.
             let bt_buf = self
                 .scratch
                 .paged_batch_block_tables
@@ -2121,6 +2096,59 @@ impl<B: Backend> Qwen3MoeModel<B> {
                 .as_mut()
                 .expect("paged_batch_context_lens missing");
             B::write_u32(ctx, cl_buf, &stacked_cl);
+            let pos_buf = self
+                .scratch
+                .paged_batch_pos_offsets
+                .as_mut()
+                .expect("paged_batch_pos_offsets missing");
+            B::write_u32(ctx, pos_buf, &pos_offsets_host);
+            let cu_buf = self
+                .scratch
+                .paged_batch_cu_seqlens_q
+                .as_mut()
+                .expect("paged_batch_cu_seqlens_q missing");
+            B::write_u32(ctx, cu_buf, &cu_seqlens_host);
+
+            // Step 3: ONE batched split_qkv_norm_rope_into_paged_cache_varlen
+            // dispatch — replaces the m=batch per-seq loop. Saves
+            // (m-1) × launch_overhead per layer × num_layers.
+            let bt_ptr_raw =
+                self.scratch.paged_batch_block_tables.as_ref().unwrap() as *const B::Buffer;
+            let pos_ptr_raw =
+                self.scratch.paged_batch_pos_offsets.as_ref().unwrap() as *const B::Buffer;
+            let cu_ptr_raw =
+                self.scratch.paged_batch_cu_seqlens_q.as_ref().unwrap() as *const B::Buffer;
+            let q_buf_ptr_raw = self.scratch.paged_batch_q.as_mut().unwrap() as *mut B::Buffer;
+            // SAFETY: scratch buffers are independent of qkv_out / norm
+            // weights / rope and are not re-borrowed by the called fn.
+            let bt_safe: &B::Buffer = unsafe { &*bt_ptr_raw };
+            let pos_safe: &B::Buffer = unsafe { &*pos_ptr_raw };
+            let cu_safe: &B::Buffer = unsafe { &*cu_ptr_raw };
+            let q_buf_safe: &mut B::Buffer = unsafe { &mut *q_buf_ptr_raw };
+            B::split_qkv_norm_rope_into_paged_cache_varlen(
+                ctx,
+                &self.scratch.qkv_out,
+                q_norm_w,
+                k_norm_w,
+                &self.rope.cos,
+                &self.rope.sin,
+                q_buf_safe,
+                pool_k,
+                pool_v,
+                cu_safe,
+                pos_safe,
+                bt_safe,
+                m, // num_seqs
+                m, // m_total — q_len=1 each, so m_total = m
+                nh,
+                nkv,
+                hd,
+                eps,
+                qk_mode,
+                block_size,
+                max_blocks_per_seq,
+            )
+            .expect("split_qkv_norm_rope_into_paged_cache_varlen (batched)");
 
             // Step 3: one batched paged_decode_attention(num_seqs=m).
             let bt_ptr =
@@ -2153,17 +2181,18 @@ impl<B: Backend> Qwen3MoeModel<B> {
             )
             .expect("paged batched decode");
 
-            // Step 4: per-item copy paged_batch_o[i] → attn_flat[i*q_dim].
-            for i in 0..m {
-                B::copy_slice(
-                    ctx,
-                    self.scratch.paged_batch_o.as_ref().unwrap(),
-                    i * q_dim,
-                    &mut self.scratch.attn_flat,
-                    i * q_dim,
-                    q_dim,
-                );
-            }
+            // Step 4: ONE batched copy paged_batch_o[0..m*q_dim] →
+            // attn_flat[0..m*q_dim]. Layouts match (both head-major,
+            // contiguous m × q_dim), so a single copy replaces the m
+            // per-item launches.
+            B::copy_slice(
+                ctx,
+                self.scratch.paged_batch_o.as_ref().unwrap(),
+                0,
+                &mut self.scratch.attn_flat,
+                0,
+                m * q_dim,
+            );
 
             stage_end(attn_t0, ctx, &BD_ATTN_PERITEM_US);
         } else {


### PR DESCRIPTION
## Summary

Collapses the per-item attention loop in `forward_layer_batched_decode` into a single batched dispatch. Microbench revealed paged_decode_attn itself is only 14% of `attn_peritem` time — the bulk was launch overhead from 32 sequential `split_qkv_norm_rope_into_paged_cache` calls + 32 `copy_slice` calls × 48 layers.

## Bench results (Qwen3-30B-A3B GPTQ-Int4, RTX 4090, FERRUM_VLLM_MOE=1)

| c  | Stage 12.1 | PR #101 (14b) | **this PR** | Δ vs PR #101 | Δ vs 12.1 |
|----|-----------|---------------|-------------|--------------|-----------|
| 1  | —         | 103.6         | 104.5       | +1%          | —         |
| 8  | —         | 263.6         | **295.6**   | **+12%**     | —         |
| 16 | 235.5     | 321.9         | **374.6**   | **+16%**     | **+59%**  |
| 32 | 267.7     | 310.0         | **391.1**   | **+26%**     | **+46%**  |

**c=32 TPOT: 97.28 → 75.67 ms (-22%)**.
**vs vLLM ~1500 tok/s: 26% (was 21% pre-merge)**.

## Microbench data

`bench_paged_decode_attn` test at Qwen3-MoE shape (c=32, kv_len=256):
- per-launch: 45.5 µs
- 36% of RTX 4090 peak DRAM bandwidth (1008 GB/s)
- per-forward (48 layers): 2.2 ms

But profile reports `attn_peritem = 15 ms / forward`. So 87% of attn time was outside the actual attention kernel — in the per-seq dispatch loop.

## Changes

1. `forward_layer_batched_decode` paged path:
   - Step 1+2: build host-side `pos_offsets[m]`, `cu_seqlens_q[m+1] = [0..m+1]`, `block_tables[m, max_blocks]`, `context_lens[m]` in one loop, upload to scratch.
   - Step 3: ONE `split_qkv_norm_rope_into_paged_cache_varlen` replacing the m-iteration loop.
   - Step 4: ONE `copy_slice(0, 0, m * q_dim)` replacing the m-iteration copy loop.
2. New scratch buffers: `paged_batch_pos_offsets`, `paged_batch_cu_seqlens_q` (allocated once via `enable_paged_batch`).
3. `crates/ferrum-kernels/tests/paged_decode_attn_bench.rs` — Qwen3-MoE shape microbench reporting per-launch us + DRAM utilisation.
4. Reverted Stage 13c-1 persistent routing buffers — they hit a CUDA driver edge case I couldn't pinpoint (CUDA_ERROR_INVALID_VALUE on the 2nd memcpy regardless of allocation strategy: rounded-cap, exact-cap, worst-case-once). Per-call clone_htod + mem::forget is back, matching Stage 14a path that benched green at +37%.

## Test plan

- [x] Local Mac `cargo check --workspace --all-targets`
- [x] CUDA `cargo test -p ferrum-kernels --features cuda --release --test paged_decode_attn_bench bench_paged_decode_attn -- --ignored` → 45.5 µs/iter, 36% BW
- [x] Bench c=1/8/16/32 — see numbers above
- [x] Smoke: server starts, prefill+decode runs without panic

## Known limits

- The Stage 13c-1 persistent buffer regression in PR #101 (introduced but never bench-verified — Monitor pre-fired on stale logs, hiding the bug) is reverted here. Anyone running FERRUM_VLLM_MOE=1 against `main` between PR #101 merge and this PR would have hit the panic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)