### PR TITLE
fix(metal): cap-gate unified path + alias --prompt one-shot + BERT prefix detection

### DIFF
--- a/crates/ferrum-cli/src/commands/run.rs
+++ b/crates/ferrum-cli/src/commands/run.rs
@@ -222,6 +222,74 @@ pub async fn execute(cmd: RunCommand, config: CliConfig) -> Result<()> {
         .dimmed()
     );
 
+    // One-shot mode: --prompt supplied → run a single request and exit.
+    // Matches the GGUF run_gguf_one_shot UX. Previously cmd.prompt was
+    // documented as "one-shot for non-interactive runs" but the alias
+    // path ignored it and dropped into REPL, which exits silently when
+    // stdin is not a TTY.
+    if let Some(one_shot) = cmd.prompt.clone() {
+        let chat_prompt = build_chat_prompt(&[], &one_shot, cmd.system.as_deref(), &model_id);
+        let model_lower = model_id.to_lowercase();
+        let (default_top_p, default_top_k) = if model_lower.contains("qwen3") {
+            (0.8, Some(20))
+        } else {
+            (0.9, None)
+        };
+        let request = InferenceRequest {
+            id: RequestId(Uuid::new_v4()),
+            model_id: ferrum_types::ModelId(model_id.clone()),
+            prompt: chat_prompt,
+            sampling_params: SamplingParams {
+                max_tokens: cmd.max_tokens as usize,
+                temperature: cmd.temperature,
+                top_p: default_top_p,
+                top_k: default_top_k,
+                repetition_penalty: 1.1,
+                stop_sequences: vec![
+                    "<|im_end|>".to_string(),
+                    "</s>".to_string(),
+                    "<|endoftext|>".to_string(),
+                ],
+                ..Default::default()
+            },
+            stream: true,
+            priority: Priority::Normal,
+            client_id: None,
+            session_id: None,
+            created_at: Utc::now(),
+            metadata: HashMap::new(),
+        };
+        let mut stream = engine.infer_stream(request).await?;
+        let start = std::time::Instant::now();
+        let mut tokens = 0usize;
+        while let Some(chunk) = stream.next().await {
+            if let Ok(c) = chunk {
+                if !cmd.bench_mode {
+                    print!("{}", c.text);
+                    io::stdout().flush().ok();
+                }
+                tokens += 1;
+                if c.finish_reason.is_some() {
+                    break;
+                }
+            }
+        }
+        let elapsed = start.elapsed().as_secs_f64();
+        let tps = if elapsed > 0.0 {
+            tokens as f64 / elapsed
+        } else {
+            0.0
+        };
+        if !cmd.bench_mode {
+            println!();
+        }
+        eprintln!(
+            "{}",
+            format!("[{tokens} tokens, {tps:.1} tok/s, {elapsed:.1}s]").dimmed()
+        );
+        return Ok(());
+    }
+
     // Print ready message
     eprintln!();
     eprintln!("{}", "Ready. Type your message and press Enter.".green());

--- a/crates/ferrum-cli/src/commands/run_gguf.rs
+++ b/crates/ferrum-cli/src/commands/run_gguf.rs
@@ -64,6 +64,10 @@ pub async fn run_gguf_one_shot(cmd: RunCommand, _config: CliConfig) -> Result<()
         // Paged-KV's win is multi-seq batching at the attention kernel.
         // m=1 single-user run sees zero benefit and pays pool-allocation
         // overhead. Force off here.
+        //
+        // KNOWN: Qwen3-MoE GGUF on Metal at m=1 currently outputs garbage
+        // + ~0.1 tok/s under both paged-KV ON and OFF (separate bug,
+        // tracked in TODO). Switching the default doesn't fix it.
         std::env::set_var("FERRUM_METAL_PAGED_KV", "0");
     }
 

--- a/crates/ferrum-kernels/src/backend/cuda.rs
+++ b/crates/ferrum-kernels/src/backend/cuda.rs
@@ -349,6 +349,10 @@ impl Backend for CudaBackend {
         true
     }
 
+    fn supports_varlen_qkv() -> bool {
+        true
+    }
+
     fn new_context() -> Self::Context {
         // Reuse the process-global stream populated by `default_stream()`.
         // Model constructors call `B::from_slice` thousands of times to

--- a/crates/ferrum-kernels/src/backend/traits.rs
+++ b/crates/ferrum-kernels/src/backend/traits.rs
@@ -1642,6 +1642,15 @@ pub trait Backend: Send + Sync + Sized + 'static {
         ))
     }
 
+    /// Capability: does this backend implement
+    /// `split_qkv_norm_rope_into_paged_cache_varlen` and
+    /// `paged_varlen_attention`? Required by the unified mixed-batch
+    /// forward path used by `LlamaFamilyModel::unified_forward`. Default
+    /// false; backends that ship the varlen kernels override.
+    fn supports_varlen_qkv() -> bool {
+        false
+    }
+
     /// Varlen variant of [`Self::split_qkv_norm_rope_into_paged_cache`].
     ///
     /// Single launch covering ALL sequences in the batch. Reads

--- a/crates/ferrum-models/src/executor/bert_executor.rs
+++ b/crates/ferrum-models/src/executor/bert_executor.rs
@@ -100,9 +100,24 @@ impl BertModelExecutor {
                 .map_err(|e| FerrumError::model(format!("Failed to load weights: {}", e)))?
         };
 
+        // Some BERT checkpoints prefix every tensor with `bert.` (the
+        // canonical google-bert / bert-base-chinese layout); others
+        // (sentence-transformers, MiniLM, etc.) drop the prefix. Probe
+        // and hand candle's BertModel::load the correct `pp(...)` view.
+        //
+        // KNOWN: google-bert / bert-base-chinese also uses TF-style
+        // `LayerNorm.gamma` / `.beta` instead of PyTorch's `weight` /
+        // `bias` — candle BertModel::load doesn't auto-rename them, so
+        // those checkpoints still error after this prefix fix. Tracked
+        // separately; sentence-transformers / MiniLM-style checkpoints
+        // (no prefix, weight/bias names) work end-to-end.
+        let vb = if vb.contains_tensor("bert.embeddings.word_embeddings.weight") {
+            vb.pp("bert")
+        } else {
+            vb
+        };
+
         // Create model from config.json
-        // Note: Some models have "bert." prefix, some don't.
-        // sentence-transformers models typically don't have the prefix.
         let config_path = path.join("config.json");
         let model = BertModelWrapper::from_config_json(vb, &config_path, device.clone(), dtype)?;
 

--- a/crates/ferrum-models/src/models/llama_family.rs
+++ b/crates/ferrum-models/src/models/llama_family.rs
@@ -4153,6 +4153,16 @@ impl<B: Backend> DecoderOnlyLLM for LlamaFamilyModel<B> {
         if items.is_empty() {
             return Ok(Vec::new());
         }
+        // Backend capability gate: unified path requires varlen QKV +
+        // paged_varlen_attention. Backends without them (Metal as of
+        // 2026-05-09, CPU) should drop back to per-item dispatch via
+        // forward_layer / decode_batch_internal.
+        if !B::supports_varlen_qkv() {
+            return Err(ferrum_types::FerrumError::unsupported(
+                "LlamaFamilyModel::unified_forward: backend lacks varlen \
+                 QKV kernels. Engine will fall back to per-item dispatch.",
+            ));
+        }
         // Touch the first item's KV cache so `ensure_kv` lazily allocates
         // `paged_pools` when paged is enabled (env or backend default).
         self.ensure_kv(&items[0].0);


### PR DESCRIPTION
## Summary

Three Metal-default UX bugs surfaced during local Mac regression testing of the v0.7.3 build (commit `bb59e6f`). All three are reproducible with no env vars set; CI didn't catch them because Metal CI is compile-only.

## Bugs fixed

### 1. Dense Qwen3 / TinyLlama crash on Metal default

```
thread 'tokio-runtime-worker' panicked at qwen3_moe.rs:1513:18:
forward_layer: Model { message: "split_qkv_norm_rope_into_paged_cache_varlen: Unsupported"
                                 / "not implemented for this backend" }
```

Introduced in PR #92 (chunked-prefill path). `LlamaFamilyModel::unified_forward` requires the varlen QKV + paged_varlen attention kernels which only CUDA implements; Metal returns `supports_paged_kv() = true` so paged path is enabled, then crashes inside the layer loop.

**Fix:** add `Backend::supports_varlen_qkv()` capability (default `false`, CUDA overrides `true`). `unified_forward` early-returns Unsupported when false; engine already has a per-item fallback via `forward_layer` / `decode_batch_internal`.

### 2. `ferrum run <alias> --prompt …` ignored, dropped into REPL

The alias path read `cmd.prompt` only via the GGUF branch (`run_gguf_one_shot`). For HF aliases / safetensors paths the prompt was discarded and the REPL was entered, which exits silently when stdin is not a TTY — `echo X | ferrum run qwen3:0.6b --prompt …` produced no output and looked like a hang.

**Fix:** mirror the GGUF one-shot flow at the top of `commands::run::execute` — if `cmd.prompt.is_some()`, build one InferenceRequest, stream the response, print `[N tokens, X tok/s, Y.Ys]`, and exit.

### 3. BERT embed: `cannot find tensor embeddings.word_embeddings.weight`

google-bert / bert-base-chinese (and friends) prefix every tensor with `bert.`; sentence-transformers / MiniLM-style checkpoints don't. candle's `BertModel::load` expects un-prefixed names and errors otherwise.

**Fix:** in `bert_executor`, probe `vb.contains_tensor("bert.embeddings.word_embeddings.weight")` and hand `BertModel::load` the right `pp(...)` view.

**Caveat:** google-bert / chinese-bert also use TF1-style `LayerNorm.gamma` / `.beta` instead of PyTorch's `weight` / `bias`; candle's BertModel doesn't auto-rename them. So those checkpoints get past the prefix error but hit a separate "cannot find tensor `bert.embeddings.LayerNorm.weight`". sentence-transformers / MiniLM-style checkpoints (no prefix, weight/bias names) load successfully — they then run into `Metal error no metal implementation for layer-norm` which is a separate kernel gap, also tracked.

## Bugs surfaced but NOT fixed in this PR

- **Qwen3-30B-A3B GGUF on Metal at m=1: garbage output + ~0.1 tok/s** (regardless of `FERRUM_METAL_PAGED_KV`). Reproduced under both paged-KV ON and OFF after building from `bb59e6f`. memo claims PR #50 hit 27.6 tok/s here — that came from a config we no longer have. Deeper than a one-line env switch; worth a follow-up.
- **Metal layer-norm kernel** missing. Sentence-transformers BERT loads fine but `model.forward` panics with `no metal implementation for layer-norm`. Cross-cutting kernel gap, not a regression.

## Local verification

```
qwen3:0.6b BF16  Metal default →  25 tok/s, coherent output ✓
qwen3:4b BF16    Metal default →  ~10 tok/s (candle path) ✓
tinyllama BF16   Metal default →  24 tok/s, coherent output ✓
Qwen3-0.6B-Q8_0  GGUF Metal    →  83 tok/s decode ✓
Qwen3-8B-Q4_K_M  GGUF Metal    →  31 tok/s decode ✓
Llama-3.1-8B Q4  GGUF Metal    →  32 tok/s decode ✓
sentence-transformers/all-MiniLM-L6-v2 → loads, hits unrelated layer-norm kernel gap
```

CLI sanity (`--version`, `--help`, `list`) all work.

## Test plan

- [x] `cargo check --workspace --all-targets`
- [x] `cargo build -p ferrum-cli --features metal --release`
- [x] Smoke run on Mac M-series with no env vars

🤖 Generated with [Claude Code](https://claude.com/claude-code)