### PR TITLE
refactor(backend): extract BackendQuantMarlin + BackendQuantGguf supertraits (Phase 2.3)

### DIFF
--- a/crates/ferrum-kernels/src/backend/cpu.rs
+++ b/crates/ferrum-kernels/src/backend/cpu.rs
@@ -122,140 +122,6 @@ impl Backend for CpuBackend {
     fn new_context() -> Self::Context {}
     fn sync(_ctx: &mut Self::Context) {}
 
-    fn load_gptq(
-        qweight: &[i32],
-        scales: &[f32],
-        qzeros: &[i32],
-        _g_idx: Option<&[i32]>,
-        bits: u32,
-        group_size: usize,
-        k: usize,
-        n: usize,
-    ) -> Result<Self::GptqStore> {
-        if bits != 4 {
-            return Err(FerrumError::unsupported(format!(
-                "CPU GPTQ: only bits=4 supported (got {bits})"
-            )));
-        }
-        let num_groups = k / group_size;
-        // Unpack GPTQ [K/8, N] i32 → int4 values, dequantize per-group:
-        //   w_f16 = (q - zero) * scale
-        // Write to [n, k] row-major (matches DenseLinear convention).
-        let mut w = vec![0.0f32; n * k];
-        let packed_rows = k / 8;
-        for pr in 0..packed_rows {
-            for col in 0..n {
-                let packed = qweight[pr * n + col] as u32;
-                for bi in 0..8 {
-                    let ki = pr * 8 + bi;
-                    let q = ((packed >> (bi * 4)) & 0xF) as i32;
-                    let grp = ki / group_size;
-                    let scale = scales[grp * n + col];
-                    // qzeros [num_groups, N/8] i32 packs 8 zero-values per int32
-                    let z_packed = qzeros[grp * (n / 8) + (col / 8)] as u32;
-                    let zero = (((z_packed >> ((col % 8) * 4)) & 0xF) as i32) + 1;
-                    let val = (q - zero) as f32 * scale;
-                    w[col * k + ki] = val;
-                }
-            }
-        }
-        let _ = num_groups; // informational only
-        Ok(CpuGptqStore {
-            weight_f32: w,
-            k,
-            n,
-        })
-    }
-
-    fn gemm_gptq(
-        ctx: &mut Self::Context,
-        a: &Self::Buffer,
-        weight: &Self::GptqStore,
-        out: &mut Self::Buffer,
-        m: usize,
-    ) -> Result<()> {
-        // Just run normal GEMM with dequantized weights.
-        // out[m, n] = a[m, k] @ w[n, k]^T — same contract as B::gemm.
-        Self::gemm(ctx, a, &weight.weight_f32, out, m, weight.n, weight.k);
-        Ok(())
-    }
-
-    fn gemm_gptq_with_offset(
-        ctx: &mut Self::Context,
-        a: &Self::Buffer,
-        weight: &Self::GptqStore,
-        expert_offset: usize,
-        expert_n: usize,
-        out: &mut Self::Buffer,
-        m: usize,
-    ) -> Result<()> {
-        if expert_offset + expert_n > weight.n {
-            return Err(FerrumError::model(format!(
-                "gemm_gptq_with_offset OOB: offset {expert_offset} + n {expert_n} > stacked_n {}",
-                weight.n
-            )));
-        }
-        // weight_f32 layout is [N, K] row-major; copy the
-        // [expert_offset .. expert_offset + expert_n) row range into
-        // a Vec (CPU path isn't perf-critical for MoE — Marlin owns
-        // that on CUDA).
-        let k = weight.k;
-        let row_start = expert_offset * k;
-        let row_end = (expert_offset + expert_n) * k;
-        let slice = weight.weight_f32[row_start..row_end].to_vec();
-        Self::gemm(ctx, a, &slice, out, m, expert_n, k);
-        Ok(())
-    }
-
-    fn gemm_gptq_with_offset_strided(
-        _ctx: &mut Self::Context,
-        input: &Self::Buffer,
-        in_row_offset: usize,
-        weight: &Self::GptqStore,
-        expert_offset: usize,
-        expert_n: usize,
-        output: &mut Self::Buffer,
-        out_row_offset: usize,
-        m: usize,
-        k: usize,
-    ) -> Result<()> {
-        if expert_offset + expert_n > weight.n {
-            return Err(FerrumError::model(format!(
-                "gemm_gptq_with_offset_strided OOB: offset {expert_offset} + n {expert_n} > stacked_n {}",
-                weight.n
-            )));
-        }
-        if k != weight.k {
-            return Err(FerrumError::model(format!(
-                "gemm_gptq_with_offset_strided k mismatch: arg {k} vs weight.k {}",
-                weight.k
-            )));
-        }
-        // [m, K] input slice and [m, expert_n] output slice; weight
-        // [expert_n, K] taken from the column-slice of weight_f32.
-        let in_start = in_row_offset * k;
-        let in_end = (in_row_offset + m) * k;
-        let out_start = out_row_offset * expert_n;
-        let out_end = (out_row_offset + m) * expert_n;
-        let row_start = expert_offset * k;
-        let row_end = (expert_offset + expert_n) * k;
-        let weight_slice = weight.weight_f32[row_start..row_end].to_vec();
-        let in_slice = input[in_start..in_end].to_vec();
-        let mut out_slice = vec![0.0f32; m * expert_n];
-        let mut ctx_local = ();
-        Self::gemm(
-            &mut ctx_local,
-            &in_slice,
-            &weight_slice,
-            &mut out_slice,
-            m,
-            expert_n,
-            k,
-        );
-        output[out_start..out_end].copy_from_slice(&out_slice);
-        Ok(())
-    }
-
     fn fused_silu_mul_split_strided(
         _ctx: &mut Self::Context,
         gate_up: &Self::Buffer,
@@ -274,61 +140,6 @@ impl Backend for CpuBackend {
                 let u = gate_up[in_start + r * in_per_row + intermediate + c];
                 let silu = g / (1.0 + (-g).exp());
                 out[out_start + r * intermediate + c] = silu * u;
-            }
-        }
-    }
-
-    fn load_quant(
-        kind: super::GgufQuantType,
-        bytes: &[u8],
-        n_rows: usize,
-        n_cols: usize,
-    ) -> Result<Self::QuantStore> {
-        use super::GgufQuantType;
-        match kind {
-            GgufQuantType::Q4K => {
-                let total_elems = n_rows * n_cols;
-                if total_elems % Q4_K_QK != 0 {
-                    return Err(FerrumError::model(format!(
-                        "load_quant Q4K: elements {total_elems} not a multiple of {Q4_K_QK}"
-                    )));
-                }
-                let n_blocks = total_elems / Q4_K_QK;
-                let expected = n_blocks * Q4_K_BLOCK_BYTES;
-                if bytes.len() != expected {
-                    return Err(FerrumError::model(format!(
-                        "load_quant Q4K: bytes {} != expected {} ({n_blocks} × {Q4_K_BLOCK_BYTES})",
-                        bytes.len(),
-                        expected
-                    )));
-                }
-                Ok(CpuQuantStore::Q4K {
-                    weights: dequant_q4_k_cpu(bytes, n_blocks),
-                    n_rows,
-                    n_cols,
-                })
-            }
-            other => Err(FerrumError::unsupported(format!(
-                "CPU load_quant: {other:?} not yet implemented"
-            ))),
-        }
-    }
-
-    fn gemm_quant(
-        ctx: &mut Self::Context,
-        a: &Self::Buffer,
-        weight: &Self::QuantStore,
-        out: &mut Self::Buffer,
-        m: usize,
-    ) -> Result<()> {
-        match weight {
-            CpuQuantStore::Q4K {
-                weights,
-                n_rows,
-                n_cols,
-            } => {
-                Self::gemm(ctx, a, weights, out, m, *n_rows, *n_cols);
-                Ok(())
             }
         }
     }
@@ -866,3 +677,192 @@ impl crate::backend::BackendGraph for CpuBackend {}
 
 // CPU has no multi-rank collectives; inherit BackendCollective defaults.
 impl crate::backend::BackendCollective for CpuBackend {}
+
+impl crate::backend::BackendQuantMarlin for CpuBackend {
+    fn load_gptq(
+        qweight: &[i32],
+        scales: &[f32],
+        qzeros: &[i32],
+        _g_idx: Option<&[i32]>,
+        bits: u32,
+        group_size: usize,
+        k: usize,
+        n: usize,
+    ) -> Result<Self::GptqStore> {
+        if bits != 4 {
+            return Err(FerrumError::unsupported(format!(
+                "CPU GPTQ: only bits=4 supported (got {bits})"
+            )));
+        }
+        let num_groups = k / group_size;
+        // Unpack GPTQ [K/8, N] i32 → int4 values, dequantize per-group:
+        //   w_f16 = (q - zero) * scale
+        // Write to [n, k] row-major (matches DenseLinear convention).
+        let mut w = vec![0.0f32; n * k];
+        let packed_rows = k / 8;
+        for pr in 0..packed_rows {
+            for col in 0..n {
+                let packed = qweight[pr * n + col] as u32;
+                for bi in 0..8 {
+                    let ki = pr * 8 + bi;
+                    let q = ((packed >> (bi * 4)) & 0xF) as i32;
+                    let grp = ki / group_size;
+                    let scale = scales[grp * n + col];
+                    // qzeros [num_groups, N/8] i32 packs 8 zero-values per int32
+                    let z_packed = qzeros[grp * (n / 8) + (col / 8)] as u32;
+                    let zero = (((z_packed >> ((col % 8) * 4)) & 0xF) as i32) + 1;
+                    let val = (q - zero) as f32 * scale;
+                    w[col * k + ki] = val;
+                }
+            }
+        }
+        let _ = num_groups; // informational only
+        Ok(CpuGptqStore {
+            weight_f32: w,
+            k,
+            n,
+        })
+    }
+    fn gemm_gptq(
+        ctx: &mut Self::Context,
+        a: &Self::Buffer,
+        weight: &Self::GptqStore,
+        out: &mut Self::Buffer,
+        m: usize,
+    ) -> Result<()> {
+        // Just run normal GEMM with dequantized weights.
+        // out[m, n] = a[m, k] @ w[n, k]^T — same contract as B::gemm.
+        Self::gemm(ctx, a, &weight.weight_f32, out, m, weight.n, weight.k);
+        Ok(())
+    }
+    fn gemm_gptq_with_offset(
+        ctx: &mut Self::Context,
+        a: &Self::Buffer,
+        weight: &Self::GptqStore,
+        expert_offset: usize,
+        expert_n: usize,
+        out: &mut Self::Buffer,
+        m: usize,
+    ) -> Result<()> {
+        if expert_offset + expert_n > weight.n {
+            return Err(FerrumError::model(format!(
+                "gemm_gptq_with_offset OOB: offset {expert_offset} + n {expert_n} > stacked_n {}",
+                weight.n
+            )));
+        }
+        // weight_f32 layout is [N, K] row-major; copy the
+        // [expert_offset .. expert_offset + expert_n) row range into
+        // a Vec (CPU path isn't perf-critical for MoE — Marlin owns
+        // that on CUDA).
+        let k = weight.k;
+        let row_start = expert_offset * k;
+        let row_end = (expert_offset + expert_n) * k;
+        let slice = weight.weight_f32[row_start..row_end].to_vec();
+        Self::gemm(ctx, a, &slice, out, m, expert_n, k);
+        Ok(())
+    }
+    fn gemm_gptq_with_offset_strided(
+        _ctx: &mut Self::Context,
+        input: &Self::Buffer,
+        in_row_offset: usize,
+        weight: &Self::GptqStore,
+        expert_offset: usize,
+        expert_n: usize,
+        output: &mut Self::Buffer,
+        out_row_offset: usize,
+        m: usize,
+        k: usize,
+    ) -> Result<()> {
+        if expert_offset + expert_n > weight.n {
+            return Err(FerrumError::model(format!(
+                "gemm_gptq_with_offset_strided OOB: offset {expert_offset} + n {expert_n} > stacked_n {}",
+                weight.n
+            )));
+        }
+        if k != weight.k {
+            return Err(FerrumError::model(format!(
+                "gemm_gptq_with_offset_strided k mismatch: arg {k} vs weight.k {}",
+                weight.k
+            )));
+        }
+        // [m, K] input slice and [m, expert_n] output slice; weight
+        // [expert_n, K] taken from the column-slice of weight_f32.
+        let in_start = in_row_offset * k;
+        let in_end = (in_row_offset + m) * k;
+        let out_start = out_row_offset * expert_n;
+        let out_end = (out_row_offset + m) * expert_n;
+        let row_start = expert_offset * k;
+        let row_end = (expert_offset + expert_n) * k;
+        let weight_slice = weight.weight_f32[row_start..row_end].to_vec();
+        let in_slice = input[in_start..in_end].to_vec();
+        let mut out_slice = vec![0.0f32; m * expert_n];
+        let mut ctx_local = ();
+        Self::gemm(
+            &mut ctx_local,
+            &in_slice,
+            &weight_slice,
+            &mut out_slice,
+            m,
+            expert_n,
+            k,
+        );
+        output[out_start..out_end].copy_from_slice(&out_slice);
+        Ok(())
+    }
+}
+
+impl crate::backend::BackendQuantGguf for CpuBackend {
+    fn load_quant(
+        kind: super::GgufQuantType,
+        bytes: &[u8],
+        n_rows: usize,
+        n_cols: usize,
+    ) -> Result<Self::QuantStore> {
+        use super::GgufQuantType;
+        match kind {
+            GgufQuantType::Q4K => {
+                let total_elems = n_rows * n_cols;
+                if total_elems % Q4_K_QK != 0 {
+                    return Err(FerrumError::model(format!(
+                        "load_quant Q4K: elements {total_elems} not a multiple of {Q4_K_QK}"
+                    )));
+                }
+                let n_blocks = total_elems / Q4_K_QK;
+                let expected = n_blocks * Q4_K_BLOCK_BYTES;
+                if bytes.len() != expected {
+                    return Err(FerrumError::model(format!(
+                        "load_quant Q4K: bytes {} != expected {} ({n_blocks} × {Q4_K_BLOCK_BYTES})",
+                        bytes.len(),
+                        expected
+                    )));
+                }
+                Ok(CpuQuantStore::Q4K {
+                    weights: dequant_q4_k_cpu(bytes, n_blocks),
+                    n_rows,
+                    n_cols,
+                })
+            }
+            other => Err(FerrumError::unsupported(format!(
+                "CPU load_quant: {other:?} not yet implemented"
+            ))),
+        }
+    }
+    fn gemm_quant(
+        ctx: &mut Self::Context,
+        a: &Self::Buffer,
+        weight: &Self::QuantStore,
+        out: &mut Self::Buffer,
+        m: usize,
+    ) -> Result<()> {
+        match weight {
+            CpuQuantStore::Q4K {
+                weights,
+                n_rows,
+                n_cols,
+            } => {
+                Self::gemm(ctx, a, weights, out, m, *n_rows, *n_cols);
+                Ok(())
+            }
+        }
+    }
+}

--- a/crates/ferrum-kernels/src/backend/cuda.rs
+++ b/crates/ferrum-kernels/src/backend/cuda.rs
@@ -474,18 +474,6 @@ impl Backend for CudaBackend {
         with_stream(|stream| unsafe { stream.alloc::<f16>(len) }.expect("cuda alloc"))
     }
 
-    fn pregrow_marlin_gather_scratch(ctx: &mut Self::Context, required: usize) {
-        #[cfg(feature = "marlin")]
-        {
-            let stream = ctx.stream.clone();
-            pregrow_marlin_gather_scratch(&stream, required);
-        }
-        #[cfg(not(feature = "marlin"))]
-        {
-            let _ = (ctx, required);
-        }
-    }
-
     fn from_slice(data: &[f32]) -> Self::Buffer {
         let host: Vec<f16> = data.iter().map(|&x| f16::from_f32(x)).collect();
         with_stream(|stream| stream.clone_htod(&host).expect("cuda htod"))
@@ -2123,46 +2111,6 @@ impl Backend for CudaBackend {
         .expect("add_inplace (residual_add_inplace) launch");
     }
 
-    #[cfg(feature = "marlin")]
-    fn gemm_gptq_with_offset_strided(
-        ctx: &mut Self::Context,
-        input: &Self::Buffer,
-        in_row_offset: usize,
-        weight: &Self::GptqStore,
-        expert_offset: usize,
-        expert_n: usize,
-        output: &mut Self::Buffer,
-        out_row_offset: usize,
-        m: usize,
-        _k: usize,
-    ) -> Result<()> {
-        #[cfg(feature = "triton-kernels")]
-        let mw = match weight {
-            GptqStoreCuda::Marlin(mw) => mw,
-            GptqStoreCuda::Triton(_) => {
-                return Err(FerrumError::unsupported(
-                    "gemm_gptq_with_offset_strided: Triton w4a16 store has no \
-                     stride-aware variant; load MoE via Marlin (default)",
-                ));
-            }
-        };
-        #[cfg(not(feature = "triton-kernels"))]
-        let mw: &crate::marlin::MarlinWeight = weight;
-        let stream = ctx.stream.clone();
-        crate::marlin::marlin_gemm_with_offset_strided(
-            &stream,
-            input,
-            in_row_offset as i32,
-            mw,
-            output,
-            out_row_offset as i32,
-            m as i32,
-            expert_offset as i32,
-            expert_n as i32,
-        )
-        .map_err(|e| FerrumError::model(format!("marlin offset_strided gemm: {e}")))
-    }
-
     fn fused_silu_mul_split_strided(
         ctx: &mut Self::Context,
         gate_up: &Self::Buffer,
@@ -2580,549 +2528,6 @@ impl Backend for CudaBackend {
 
     // ── GPTQ INT4 dispatch (Marlin default; Triton-rs alt via env) ──────
 
-    fn load_gptq(
-        qweight: &[i32],
-        scales: &[f32],
-        qzeros: &[i32],
-        g_idx: Option<&[i32]>,
-        bits: u32,
-        group_size: usize,
-        k: usize,
-        n: usize,
-    ) -> Result<Self::GptqStore> {
-        if bits != 4 {
-            return Err(FerrumError::unsupported(format!(
-                "CUDA GPTQ: only bits=4 supported (got {bits})"
-            )));
-        }
-        let _ = qzeros; // qzeros baked into Marlin scales path; unused for Marlin store
-
-        // Path B: triton-rs w4a16 GPTQ kernel — operates on the on-disk
-        // GPTQ tensor layout directly. Just upload the three tensors and
-        // tag the store as Triton. No CPU-side repack.
-        #[cfg(feature = "triton-kernels")]
-        if use_triton_int4() {
-            let stream = default_stream();
-            let scales_f16: Vec<f16> = scales.iter().map(|&x| f16::from_f32(x)).collect();
-            let qweight_dev = stream
-                .clone_htod(qweight)
-                .map_err(|e| FerrumError::model(format!("triton qweight htod: {e}")))?;
-            let scales_dev = stream
-                .clone_htod(&scales_f16)
-                .map_err(|e| FerrumError::model(format!("triton scales htod: {e}")))?;
-            let qzeros_dev = stream
-                .clone_htod(qzeros)
-                .map_err(|e| FerrumError::model(format!("triton qzeros htod: {e}")))?;
-            tracing::info!("GPTQ load (triton-rs w4a16): K={k}, N={n}, gs={group_size}");
-            return Ok(GptqStoreCuda::Triton(
-                crate::triton_w4a16::TritonGptqWeight {
-                    qweight: qweight_dev,
-                    scales: scales_dev,
-                    qzeros: qzeros_dev,
-                    k,
-                    n,
-                    group_size: group_size as i32,
-                },
-            ));
-        }
-
-        // Detect desc_act=true (act-order GPTQ): g_idx is non-trivial.
-        // AutoGPTQ writes g_idx[k] = k/group_size for desc_act=false; any
-        // deviation = act-order. Build perm = argsort(g_idx) and permute
-        // qweight rows so that group_idx = i / group_size after the perm
-        // (matches Marlin's sequential group access). Standard scales/zeros
-        // layout works because they're already indexed by group, not by k.
-        let (qweight_for_repack, perm_dev_opt): (Vec<i32>, Option<CudaSlice<i32>>) =
-            if let Some(gx) = g_idx {
-                let is_desc_act = gx
-                    .iter()
-                    .enumerate()
-                    .any(|(i, &g)| g != (i as i32) / group_size as i32);
-                if is_desc_act {
-                    // perm[i] = disk row whose g_idx is the i-th smallest.
-                    let mut perm: Vec<usize> = (0..k).collect();
-                    perm.sort_by_key(|&i| gx[i]);
-                    let permuted_qweight =
-                        crate::marlin::permute_gptq_qweight_rows(qweight, &perm, k, n);
-                    let perm_i32: Vec<i32> = perm.iter().map(|&p| p as i32).collect();
-                    let stream = default_stream();
-                    let perm_dev = stream
-                        .clone_htod(&perm_i32)
-                        .map_err(|e| FerrumError::model(format!("perm htod: {e}")))?;
-                    tracing::info!(
-                        "GPTQ load (Marlin + desc_act perm-aware): K={k} N={n} gs={group_size}"
-                    );
-                    (permuted_qweight, Some(perm_dev))
-                } else {
-                    (qweight.to_vec(), None)
-                }
-            } else {
-                (qweight.to_vec(), None)
-            };
-
-        // Path A (default): Marlin. Repack on CPU, then upload. Matches
-        // IST-DASLab/marlin Layer.pack().
-        let marlin_qweight_i32 = crate::marlin::repack_gptq_to_marlin(&qweight_for_repack, k, n);
-        // Scales arrive as f32 but Marlin expects f16. Convert + permute.
-        let scales_f16: Vec<f16> = scales.iter().map(|&x| f16::from_f32(x)).collect();
-        let marlin_scales_f16 =
-            crate::marlin::repack_scales_to_marlin(&scales_f16, k, n, group_size);
-
-        // Upload on the global stream (same one inference uses).
-        let stream = default_stream();
-        let qweight_dev = stream
-            .clone_htod(&marlin_qweight_i32)
-            .map_err(|e| FerrumError::model(format!("qweight htod: {e}")))?;
-        let scales_dev = stream
-            .clone_htod(&marlin_scales_f16)
-            .map_err(|e| FerrumError::model(format!("scales htod: {e}")))?;
-
-        // Workspace: Marlin uses int32 atomic locks, [N/128 * max_par] zeroed.
-        // max_par hardcoded to 16 per kernel launch; allocate + zero here.
-        let max_par = 16usize;
-        let ws_len = (n / 128).max(1) * max_par;
-        let workspace_dev = stream
-            .alloc_zeros::<i32>(ws_len)
-            .map_err(|e| FerrumError::model(format!("ws alloc: {e}")))?;
-
-        let marlin_weight = crate::marlin::MarlinWeight {
-            qweight: qweight_dev,
-            scales: scales_dev,
-            workspace: workspace_dev,
-            k,
-            n,
-            group_size: group_size as i32,
-            perm: perm_dev_opt,
-        };
-
-        // Wrap in the Marlin variant (or pass through, depending on cfg).
-        #[cfg(feature = "triton-kernels")]
-        {
-            Ok(GptqStoreCuda::Marlin(marlin_weight))
-        }
-        #[cfg(not(feature = "triton-kernels"))]
-        {
-            Ok(marlin_weight)
-        }
-    }
-
-    fn load_gptq_stacked(
-        qweights: &[&[i32]],
-        scales: &[&[f32]],
-        qzeros: &[&[i32]],
-        g_idx: Option<&[i32]>,
-        bits: u32,
-        group_size: usize,
-        k: usize,
-        n_per_expert: usize,
-    ) -> Result<Self::GptqStore> {
-        if bits != 4 {
-            return Err(FerrumError::unsupported(format!(
-                "CUDA GPTQ stacked: only bits=4 supported (got {bits})"
-            )));
-        }
-        let num_experts = qweights.len();
-        if num_experts == 0 {
-            return Err(FerrumError::model("load_gptq_stacked: 0 experts"));
-        }
-        if scales.len() != num_experts || qzeros.len() != num_experts {
-            return Err(FerrumError::model(format!(
-                "load_gptq_stacked length mismatch: qw={} sc={} qz={}",
-                num_experts,
-                scales.len(),
-                qzeros.len()
-            )));
-        }
-        let _ = qzeros; // Marlin doesn't read qzeros (sym=true)
-
-        // vLLM marlin_moe_wna16 path: stacked weight in vLLM Marlin tile
-        // format (NOT IST-DASLab). Run gptq_marlin_repack per expert,
-        // permute scales with the same _scale_perm IST-DASLab uses.
-        // Opt-in via FERRUM_VLLM_MOE=1 — paired with the dispatch-side
-        // switch in moe_forward_bucketed.
-        #[cfg(feature = "vllm-moe-marlin")]
-        if use_vllm_moe() {
-            let stream = default_stream();
-            let store = crate::vllm_marlin::load_stacked_gptq_vllm_marlin(
-                &stream,
-                qweights,
-                scales,
-                bits,
-                group_size,
-                k,
-                n_per_expert,
-            )
-            .map_err(|e| FerrumError::model(format!("load_stacked_gptq_vllm_marlin: {e}")))?;
-            tracing::info!(
-                "GPTQ stacked load (vLLM marlin path): {num_experts} experts × N={n_per_expert} × K={k} (gs={group_size})",
-            );
-            return Ok(store);
-        }
-
-        // Triton path: would need a stacked variant — not implemented.
-        // Fall through to Marlin.
-        #[cfg(feature = "triton-kernels")]
-        if use_triton_int4() {
-            return Err(FerrumError::unsupported(
-                "load_gptq_stacked: Triton w4a16 path not implemented; \
-                 unset FERRUM_TRITON_INT4 to use Marlin",
-            ));
-        }
-
-        // desc_act perm-aware path: sample expert 0's g_idx (all experts
-        // share K-axis quantization, so g_idx is identical across experts).
-        let (perm_dev_opt, perm_for_repack): (Option<CudaSlice<i32>>, Option<Vec<usize>>) =
-            if let Some(gx) = g_idx {
-                let is_desc_act = gx
-                    .iter()
-                    .enumerate()
-                    .any(|(i, &g)| g != (i as i32) / group_size as i32);
-                if is_desc_act {
-                    let mut perm: Vec<usize> = (0..k).collect();
-                    perm.sort_by_key(|&i| gx[i]);
-                    let perm_i32: Vec<i32> = perm.iter().map(|&p| p as i32).collect();
-                    let stream = default_stream();
-                    let perm_dev = stream
-                        .clone_htod(&perm_i32)
-                        .map_err(|e| FerrumError::model(format!("perm htod: {e}")))?;
-                    (Some(perm_dev), Some(perm))
-                } else {
-                    (None, None)
-                }
-            } else {
-                (None, None)
-            };
-
-        // Per-expert repack in parallel via rayon. Each produces its
-        // own packed qweight + permuted scales tile. Concat in expert
-        // order — each expert's bytes are CONTIGUOUS in the output
-        // buffer, so an offset GEMM with prob_n=n_per_expert just
-        // walks the right slice.
-        use rayon::prelude::*;
-        let qw_per_expert_i32 = (n_per_expert * k) / 8;
-        let sc_per_expert_f16 = (k / group_size) * n_per_expert;
-
-        let mut packed_qw: Vec<i32> = vec![0i32; num_experts * qw_per_expert_i32];
-        let mut packed_sc: Vec<f16> = vec![f16::ZERO; num_experts * sc_per_expert_f16];
-
-        // Parallelize across experts: each writes to a disjoint output
-        // slice. Per-expert repack runs the inner-rayon-parallel
-        // 4-pass kernel — at num_experts > num_cores, outer parallelism
-        // wins; at smaller num_experts, inner parallelism wins. Rayon
-        // nests fine.
-        packed_qw
-            .par_chunks_mut(qw_per_expert_i32)
-            .zip(packed_sc.par_chunks_mut(sc_per_expert_f16))
-            .enumerate()
-            .for_each(|(e, (qw_out, sc_out))| {
-                let qw_in: Vec<i32> = if let Some(perm) = &perm_for_repack {
-                    crate::marlin::permute_gptq_qweight_rows(qweights[e], perm, k, n_per_expert)
-                } else {
-                    qweights[e].to_vec()
-                };
-                let qw_packed = crate::marlin::repack_gptq_to_marlin(&qw_in, k, n_per_expert);
-                qw_out.copy_from_slice(&qw_packed);
-
-                let sc_f16: Vec<f16> = scales[e].iter().map(|&x| f16::from_f32(x)).collect();
-                let sc_packed =
-                    crate::marlin::repack_scales_to_marlin(&sc_f16, k, n_per_expert, group_size);
-                sc_out.copy_from_slice(&sc_packed);
-            });
-
-        // Single htod upload of the concatenated packed buffer.
-        let stream = default_stream();
-        let qweight_dev = stream
-            .clone_htod(&packed_qw)
-            .map_err(|e| FerrumError::model(format!("stacked qweight htod: {e}")))?;
-        let scales_dev = stream
-            .clone_htod(&packed_sc)
-            .map_err(|e| FerrumError::model(format!("stacked scales htod: {e}")))?;
-
-        // Workspace: per-expert range concatenated. Each expert owns
-        // (n_per_expert/128) × max_par i32 mutex slots starting at
-        // its expert_idx * that_size.
-        let max_par = 16usize;
-        let ws_per_expert = (n_per_expert / 128).max(1) * max_par;
-        let ws_len = num_experts * ws_per_expert;
-        let workspace_dev = stream
-            .alloc_zeros::<i32>(ws_len)
-            .map_err(|e| FerrumError::model(format!("stacked ws alloc: {e}")))?;
-
-        // Total stacked N for downstream offset arithmetic. We store
-        // total_n in MarlinWeight.n so byte_per_col-style helpers see
-        // the full width; the offset GEMM uses per-expert stride
-        // (= n_per_expert) regardless of weight.n.
-        let total_n = num_experts * n_per_expert;
-        let marlin_weight = crate::marlin::MarlinWeight {
-            qweight: qweight_dev,
-            scales: scales_dev,
-            workspace: workspace_dev,
-            k,
-            n: total_n,
-            group_size: group_size as i32,
-            perm: perm_dev_opt,
-        };
-
-        tracing::info!(
-            "GPTQ stacked load: {} experts × N={n_per_expert} × K={k} (gs={group_size})",
-            num_experts
-        );
-
-        #[cfg(feature = "triton-kernels")]
-        {
-            Ok(GptqStoreCuda::Marlin(marlin_weight))
-        }
-        #[cfg(not(feature = "triton-kernels"))]
-        {
-            Ok(marlin_weight)
-        }
-    }
-
-    #[cfg(feature = "marlin")]
-    fn gemm_gptq(
-        ctx: &mut Self::Context,
-        a: &Self::Buffer,
-        weight: &Self::GptqStore,
-        out: &mut Self::Buffer,
-        m: usize,
-    ) -> Result<()> {
-        // Branch on store variant (only present when triton-kernels is on).
-        #[cfg(feature = "triton-kernels")]
-        match weight {
-            GptqStoreCuda::Marlin(mw) => marlin_gemm_with_perm(ctx, a, mw, out, m),
-            GptqStoreCuda::Triton(tw) => {
-                // Pre-load (and cache) the CudaFunction once per CudaState.
-                // Subsequent calls hit the HashMap and skip the PTX parse.
-                let func = ctx.func(
-                    "triton_w4a16_gptq",
-                    crate::triton_ptx::w4a16_gptq_f16::PTX,
-                    crate::triton_w4a16::fn_name(),
-                );
-                let stream = ctx.stream.clone();
-                crate::triton_w4a16::launch_w4a16_gptq_triton(&stream, &func, a, tw, out, m as i32)
-                    .map_err(|e| FerrumError::model(format!("triton w4a16: {e}")))
-            }
-        }
-        #[cfg(not(feature = "triton-kernels"))]
-        {
-            marlin_gemm_with_perm(ctx, a, weight, out, m)
-        }
-    }
-
-    #[cfg(all(not(feature = "marlin"), feature = "triton-kernels"))]
-    fn gemm_gptq(
-        ctx: &mut Self::Context,
-        a: &Self::Buffer,
-        weight: &Self::GptqStore,
-        out: &mut Self::Buffer,
-        m: usize,
-    ) -> Result<()> {
-        // Marlin compiled out → only Triton path is callable. The Marlin
-        // variant should never be constructed in this configuration
-        // (load_gptq currently still builds a MarlinWeight even with
-        // triton-kernels — but its `gemm_gptq` would have nothing to call,
-        // so we error explicitly for traceability instead of silently
-        // failing inside the FFI stub).
-        match weight {
-            GptqStoreCuda::Marlin(_) => Err(FerrumError::unsupported(
-                "cargo feature `marlin` disabled — Marlin variant unusable; \
-                 set FERRUM_TRITON_INT4=1 to force the triton path",
-            )),
-            GptqStoreCuda::Triton(tw) => {
-                let func = ctx.func(
-                    "triton_w4a16_gptq",
-                    crate::triton_ptx::w4a16_gptq_f16::PTX,
-                    crate::triton_w4a16::fn_name(),
-                );
-                let stream = ctx.stream.clone();
-                crate::triton_w4a16::launch_w4a16_gptq_triton(&stream, &func, a, tw, out, m as i32)
-                    .map_err(|e| FerrumError::model(format!("triton w4a16: {e}")))
-            }
-        }
-    }
-
-    #[cfg(all(not(feature = "marlin"), not(feature = "triton-kernels")))]
-    fn gemm_gptq(
-        _ctx: &mut Self::Context,
-        _a: &Self::Buffer,
-        _weight: &Self::GptqStore,
-        _out: &mut Self::Buffer,
-        _m: usize,
-    ) -> Result<()> {
-        Err(FerrumError::unsupported(
-            "cargo features `marlin` and `triton-kernels` both disabled — \
-             GPTQ not available",
-        ))
-    }
-
-    /// MoE expert dispatch: GEMM over a column-slice of a stacked Marlin
-    /// store. Lets all 128 experts share one Marlin repack; the runtime
-    /// dispatch picks one expert by `expert_offset`.
-    ///
-    /// Currently Marlin-only (the Triton w4a16 variant doesn't support
-    /// strided access on the on-disk layout). When triton-kernels is on
-    /// and the store is Triton, returns Unsupported — caller should ensure
-    /// MoE models load through the Marlin path (default).
-    #[cfg(feature = "marlin")]
-    fn gemm_gptq_with_offset(
-        ctx: &mut Self::Context,
-        a: &Self::Buffer,
-        weight: &Self::GptqStore,
-        expert_offset: usize,
-        expert_n: usize,
-        out: &mut Self::Buffer,
-        m: usize,
-    ) -> Result<()> {
-        #[cfg(feature = "triton-kernels")]
-        let mw = match weight {
-            GptqStoreCuda::Marlin(mw) => mw,
-            GptqStoreCuda::Triton(_) => {
-                return Err(FerrumError::unsupported(
-                    "gemm_gptq_with_offset: Triton w4a16 store has no \
-                     stride-aware variant; load MoE via Marlin (default)",
-                ));
-            }
-        };
-        #[cfg(not(feature = "triton-kernels"))]
-        let mw: &crate::marlin::MarlinWeight = weight;
-        let stream = ctx.stream.clone();
-        crate::marlin::marlin_gemm_with_offset(
-            &stream,
-            a,
-            mw,
-            out,
-            m as i32,
-            expert_offset as i32,
-            expert_n as i32,
-        )
-        .map_err(|e| FerrumError::model(format!("marlin offset gemm: {e}")))
-    }
-
-    #[cfg(feature = "marlin")]
-    fn moe_gemm_phase_batched(
-        ctx: &mut Self::Context,
-        input: &Self::Buffer,
-        weight: &Self::GptqStore,
-        dispatches: &[(usize, usize, usize, usize)],
-        n_per_expert: usize,
-        output: &mut Self::Buffer,
-        k: usize,
-    ) -> Result<()> {
-        #[cfg(feature = "triton-kernels")]
-        let mw = match weight {
-            GptqStoreCuda::Marlin(mw) => mw,
-            GptqStoreCuda::Triton(_) => {
-                return Err(FerrumError::unsupported(
-                    "moe_gemm_phase_batched: Triton w4a16 not supported",
-                ));
-            }
-        };
-        #[cfg(not(feature = "triton-kernels"))]
-        let mw: &crate::marlin::MarlinWeight = weight;
-
-        // ── Stage 12.1: fused MoE Marlin path (default ON) ──────────────
-        // Dispatches all experts in this phase as a small number of
-        // bucketed `marlin_gemm_moe` launches (one per thread_m_blocks
-        // bucket ∈ {1, 2, 3, 4}) instead of N round-robin calls. At c=32
-        // with ~100 active experts/layer this is 1-4 launches/layer
-        // instead of 100. Bench: +25% c=32, +35% c=16, +48% c=8 over
-        // the multi-stream per-expert path. Set FERRUM_MOE_FUSED=0 to
-        // opt out (fall back to multi-stream pool).
-        if std::env::var("FERRUM_MOE_FUSED").map_or(true, |v| v != "0") {
-            return moe_gemm_phase_fused_impl(ctx, input, mw, dispatches, n_per_expert, output, k);
-        }
-
-        // n_streams=1: serial dispatch on the DEFAULT context stream
-        // (avoids the cross-stream sync overhead and matches the
-        // pre-multi-stream path bit-for-bit).
-        let n_streams = std::env::var("FERRUM_MOE_STREAMS")
-            .ok()
-            .and_then(|s| s.parse::<usize>().ok())
-            .unwrap_or(4)
-            .max(1);
-        if n_streams == 1 {
-            let default_stream = ctx.stream.clone();
-            for (expert_idx, in_row_offset, out_row_offset, m) in dispatches {
-                crate::marlin::marlin_gemm_with_offset_strided(
-                    &default_stream,
-                    input,
-                    *in_row_offset as i32,
-                    mw,
-                    output,
-                    *out_row_offset as i32,
-                    *m as i32,
-                    (expert_idx * n_per_expert) as i32,
-                    n_per_expert as i32,
-                )
-                .map_err(|e| FerrumError::model(format!("marlin offset_strided: {e}")))?;
-            }
-            let _ = k;
-            return Ok(());
-        }
-
-        // n_streams ≥ 2: round-robin across the pool, then ALL streams
-        // wait for the default's prior work (cuStreamWaitEvent on an
-        // event recorded into default), and the default waits for ALL
-        // pool streams before returning. Without this cross-stream
-        // sync, silu_mul on default may run before pool GEMMs commit
-        // → races → junk output.
-        //
-        // The 1 + N events are persistent on `CudaState` — re-recording
-        // an event silently overwrites the prior recording, so per-call
-        // create+destroy is replaced with record+wait only. At c=32 /
-        // 48 layers / 2 phases that's ~960 driver calls saved per token.
-        let (entry_event, exit_events) = ctx.moe_sync_events();
-        let pool: Vec<Arc<CudaStream>> = ctx.moe_stream_pool().to_vec();
-        let default_stream = ctx.stream.clone();
-        use cudarc::driver::sys as cu;
-        // Default → pool: record on default, each pool waits.
-        unsafe {
-            cu::cuEventRecord(entry_event, default_stream.cu_stream());
-        }
-        for stream in &pool {
-            unsafe {
-                cu::cuStreamWaitEvent(stream.cu_stream(), entry_event, 0);
-            }
-        }
-
-        for (i, (expert_idx, in_row_offset, out_row_offset, m)) in dispatches.iter().enumerate() {
-            let stream = &pool[i % n_streams];
-            crate::marlin::marlin_gemm_with_offset_strided(
-                stream,
-                input,
-                *in_row_offset as i32,
-                mw,
-                output,
-                *out_row_offset as i32,
-                *m as i32,
-                (expert_idx * n_per_expert) as i32,
-                n_per_expert as i32,
-            )
-            .map_err(|e| FerrumError::model(format!("marlin offset_strided: {e}")))?;
-        }
-
-        // pool → default: each pool stream records its exit event;
-        // default waits for all of them. After return, default's next
-        // op (silu) will see all GEMM outputs committed.
-        let _ = k;
-        debug_assert_eq!(
-            exit_events.len(),
-            pool.len(),
-            "moe_sync_events exit count != pool size"
-        );
-        for (i, stream) in pool.iter().enumerate() {
-            unsafe {
-                cu::cuEventRecord(exit_events[i], stream.cu_stream());
-            }
-        }
-        for ev in &exit_events {
-            unsafe {
-                cu::cuStreamWaitEvent(default_stream.cu_stream(), *ev, 0);
-            }
-        }
-        Ok(())
-    }
-
     #[cfg(feature = "vllm-moe-marlin")]
     fn upload_moe_routing(
         ctx: &mut Self::Context,
@@ -3191,115 +2596,6 @@ impl Backend for CudaBackend {
         }
         .result()
         .map_err(|e| FerrumError::model(format!("cuMemsetD16Async: {e}")))?;
-        Ok(())
-    }
-
-    #[cfg(feature = "vllm-moe-marlin")]
-    fn moe_gemm_phase_vllm(
-        ctx: &mut Self::Context,
-        input: &Self::Buffer,
-        weight: &Self::GptqStore,
-        sorted_token_ids: &Self::Buffer,
-        expert_ids: &Self::Buffer,
-        num_tokens_past_padded: &Self::Buffer,
-        output: &mut Self::Buffer,
-        prob_m: usize,
-        n_per_expert: usize,
-        k: usize,
-        moe_block_size: usize,
-        top_k: usize,
-    ) -> Result<()> {
-        #[cfg(feature = "triton-kernels")]
-        let mw = match weight {
-            GptqStoreCuda::Marlin(mw) => mw,
-            GptqStoreCuda::Triton(_) => {
-                return Err(FerrumError::unsupported(
-                    "moe_gemm_phase_vllm: Triton store unsupported",
-                ));
-            }
-        };
-        #[cfg(not(feature = "triton-kernels"))]
-        let mw: &crate::marlin::MarlinWeight = weight;
-
-        // sorted_token_ids / expert_ids / num_tokens_past_padded are i32
-        // device buffers handed in as Self::Buffer (= CudaSlice<f16>).
-        // The marlin_gemm_moe_vllm wrapper uses CudaSlice<i32>, so we
-        // reinterpret each view via upgrade_device_ptr. The view length
-        // is irrelevant — the kernel reads via raw device pointers — so
-        // we hand it `0` to make the leakage cost explicit.
-        use cudarc::driver::sys::CUdeviceptr;
-        use cudarc::driver::CudaSlice;
-        use cudarc::driver::DevicePtr;
-
-        // Stream is Arc<CudaStream>, so cloning it doesn't borrow ctx and
-        // we can subsequently take &mut for the c_tmp helper.
-        let stream = ctx.stream.clone();
-        // Resolve c_tmp scratch (lazy-allocates 8 MB on first call). The
-        // wrapper takes &mut so it can forward the device pointer; the
-        // kernel uses c_tmp as a global fp32 reduce scratch
-        // (use_fp32_reduce=1 path, ~1.3-1.5× faster than atomic_add).
-        let c_tmp_mut: &mut CudaSlice<f32> = ctx.vllm_moe_c_tmp();
-
-        let (st_ptr, _g0) = sorted_token_ids.device_ptr(&stream);
-        let (eid_ptr, _g1) = expert_ids.device_ptr(&stream);
-        let (npp_ptr, _g2) = num_tokens_past_padded.device_ptr(&stream);
-        let st_view: CudaSlice<i32> =
-            unsafe { stream.upgrade_device_ptr(st_ptr as CUdeviceptr, 0) };
-        let eid_view: CudaSlice<i32> =
-            unsafe { stream.upgrade_device_ptr(eid_ptr as CUdeviceptr, 0) };
-        let npp_view: CudaSlice<i32> =
-            unsafe { stream.upgrade_device_ptr(npp_ptr as CUdeviceptr, 0) };
-
-        let r = crate::marlin::marlin_gemm_moe_vllm(
-            &stream,
-            input,
-            mw,
-            output,
-            Some(c_tmp_mut), // fp32_reduce path (atomic_add fallback if None)
-            &st_view,
-            &eid_view,
-            &npp_view,
-            None, // topk_weights
-            moe_block_size as i32,
-            top_k as i32,
-            false, // mul_topk_weights
-            false, // is_ep
-            prob_m as i32,
-            n_per_expert as i32,
-            k as i32,
-        );
-        // Views borrow the original device allocations; forgetting prevents
-        // double-free at scope end.
-        std::mem::forget(st_view);
-        std::mem::forget(eid_view);
-        std::mem::forget(npp_view);
-        r.map_err(|e| FerrumError::model(format!("marlin_gemm_moe_vllm: {e}")))
-    }
-
-    #[cfg(feature = "marlin")]
-    fn marlin_zero_stacked_workspace(
-        ctx: &mut Self::Context,
-        weight: &Self::GptqStore,
-    ) -> Result<()> {
-        use cudarc::driver::DevicePtr;
-        #[cfg(feature = "triton-kernels")]
-        let mw = match weight {
-            GptqStoreCuda::Marlin(mw) => mw,
-            GptqStoreCuda::Triton(_) => {
-                return Err(FerrumError::unsupported(
-                    "marlin_zero_stacked_workspace: not applicable to Triton store",
-                ));
-            }
-        };
-        #[cfg(not(feature = "triton-kernels"))]
-        let mw: &crate::marlin::MarlinWeight = weight;
-        let stream = ctx.stream.clone();
-        let raw_stream = stream.cu_stream();
-        let (ws_ptr, _g) = mw.workspace.device_ptr(&stream);
-        let ws_len = mw.workspace.len();
-        unsafe {
-            cudarc::driver::sys::cuMemsetD32Async(ws_ptr, 0, ws_len, raw_stream);
-        }
         Ok(())
     }
 }
@@ -4795,3 +4091,702 @@ fn ensure_module(ctx: &Arc<CudaContext>, key: &'static str, ptx_src: &str) -> Ar
     g.insert(key, m.clone());
     m
 }
+
+impl BackendQuantMarlin for CudaBackend {
+    fn pregrow_marlin_gather_scratch(ctx: &mut Self::Context, required: usize) {
+        #[cfg(feature = "marlin")]
+        {
+            let stream = ctx.stream.clone();
+            pregrow_marlin_gather_scratch(&stream, required);
+        }
+        #[cfg(not(feature = "marlin"))]
+        {
+            let _ = (ctx, required);
+        }
+    }
+    #[cfg(feature = "marlin")]
+    fn gemm_gptq_with_offset_strided(
+        ctx: &mut Self::Context,
+        input: &Self::Buffer,
+        in_row_offset: usize,
+        weight: &Self::GptqStore,
+        expert_offset: usize,
+        expert_n: usize,
+        output: &mut Self::Buffer,
+        out_row_offset: usize,
+        m: usize,
+        _k: usize,
+    ) -> Result<()> {
+        #[cfg(feature = "triton-kernels")]
+        let mw = match weight {
+            GptqStoreCuda::Marlin(mw) => mw,
+            GptqStoreCuda::Triton(_) => {
+                return Err(FerrumError::unsupported(
+                    "gemm_gptq_with_offset_strided: Triton w4a16 store has no \
+                     stride-aware variant; load MoE via Marlin (default)",
+                ));
+            }
+        };
+        #[cfg(not(feature = "triton-kernels"))]
+        let mw: &crate::marlin::MarlinWeight = weight;
+        let stream = ctx.stream.clone();
+        crate::marlin::marlin_gemm_with_offset_strided(
+            &stream,
+            input,
+            in_row_offset as i32,
+            mw,
+            output,
+            out_row_offset as i32,
+            m as i32,
+            expert_offset as i32,
+            expert_n as i32,
+        )
+        .map_err(|e| FerrumError::model(format!("marlin offset_strided gemm: {e}")))
+    }
+    fn load_gptq(
+        qweight: &[i32],
+        scales: &[f32],
+        qzeros: &[i32],
+        g_idx: Option<&[i32]>,
+        bits: u32,
+        group_size: usize,
+        k: usize,
+        n: usize,
+    ) -> Result<Self::GptqStore> {
+        if bits != 4 {
+            return Err(FerrumError::unsupported(format!(
+                "CUDA GPTQ: only bits=4 supported (got {bits})"
+            )));
+        }
+        let _ = qzeros; // qzeros baked into Marlin scales path; unused for Marlin store
+
+        // Path B: triton-rs w4a16 GPTQ kernel — operates on the on-disk
+        // GPTQ tensor layout directly. Just upload the three tensors and
+        // tag the store as Triton. No CPU-side repack.
+        #[cfg(feature = "triton-kernels")]
+        if use_triton_int4() {
+            let stream = default_stream();
+            let scales_f16: Vec<f16> = scales.iter().map(|&x| f16::from_f32(x)).collect();
+            let qweight_dev = stream
+                .clone_htod(qweight)
+                .map_err(|e| FerrumError::model(format!("triton qweight htod: {e}")))?;
+            let scales_dev = stream
+                .clone_htod(&scales_f16)
+                .map_err(|e| FerrumError::model(format!("triton scales htod: {e}")))?;
+            let qzeros_dev = stream
+                .clone_htod(qzeros)
+                .map_err(|e| FerrumError::model(format!("triton qzeros htod: {e}")))?;
+            tracing::info!("GPTQ load (triton-rs w4a16): K={k}, N={n}, gs={group_size}");
+            return Ok(GptqStoreCuda::Triton(
+                crate::triton_w4a16::TritonGptqWeight {
+                    qweight: qweight_dev,
+                    scales: scales_dev,
+                    qzeros: qzeros_dev,
+                    k,
+                    n,
+                    group_size: group_size as i32,
+                },
+            ));
+        }
+
+        // Detect desc_act=true (act-order GPTQ): g_idx is non-trivial.
+        // AutoGPTQ writes g_idx[k] = k/group_size for desc_act=false; any
+        // deviation = act-order. Build perm = argsort(g_idx) and permute
+        // qweight rows so that group_idx = i / group_size after the perm
+        // (matches Marlin's sequential group access). Standard scales/zeros
+        // layout works because they're already indexed by group, not by k.
+        let (qweight_for_repack, perm_dev_opt): (Vec<i32>, Option<CudaSlice<i32>>) =
+            if let Some(gx) = g_idx {
+                let is_desc_act = gx
+                    .iter()
+                    .enumerate()
+                    .any(|(i, &g)| g != (i as i32) / group_size as i32);
+                if is_desc_act {
+                    // perm[i] = disk row whose g_idx is the i-th smallest.
+                    let mut perm: Vec<usize> = (0..k).collect();
+                    perm.sort_by_key(|&i| gx[i]);
+                    let permuted_qweight =
+                        crate::marlin::permute_gptq_qweight_rows(qweight, &perm, k, n);
+                    let perm_i32: Vec<i32> = perm.iter().map(|&p| p as i32).collect();
+                    let stream = default_stream();
+                    let perm_dev = stream
+                        .clone_htod(&perm_i32)
+                        .map_err(|e| FerrumError::model(format!("perm htod: {e}")))?;
+                    tracing::info!(
+                        "GPTQ load (Marlin + desc_act perm-aware): K={k} N={n} gs={group_size}"
+                    );
+                    (permuted_qweight, Some(perm_dev))
+                } else {
+                    (qweight.to_vec(), None)
+                }
+            } else {
+                (qweight.to_vec(), None)
+            };
+
+        // Path A (default): Marlin. Repack on CPU, then upload. Matches
+        // IST-DASLab/marlin Layer.pack().
+        let marlin_qweight_i32 = crate::marlin::repack_gptq_to_marlin(&qweight_for_repack, k, n);
+        // Scales arrive as f32 but Marlin expects f16. Convert + permute.
+        let scales_f16: Vec<f16> = scales.iter().map(|&x| f16::from_f32(x)).collect();
+        let marlin_scales_f16 =
+            crate::marlin::repack_scales_to_marlin(&scales_f16, k, n, group_size);
+
+        // Upload on the global stream (same one inference uses).
+        let stream = default_stream();
+        let qweight_dev = stream
+            .clone_htod(&marlin_qweight_i32)
+            .map_err(|e| FerrumError::model(format!("qweight htod: {e}")))?;
+        let scales_dev = stream
+            .clone_htod(&marlin_scales_f16)
+            .map_err(|e| FerrumError::model(format!("scales htod: {e}")))?;
+
+        // Workspace: Marlin uses int32 atomic locks, [N/128 * max_par] zeroed.
+        // max_par hardcoded to 16 per kernel launch; allocate + zero here.
+        let max_par = 16usize;
+        let ws_len = (n / 128).max(1) * max_par;
+        let workspace_dev = stream
+            .alloc_zeros::<i32>(ws_len)
+            .map_err(|e| FerrumError::model(format!("ws alloc: {e}")))?;
+
+        let marlin_weight = crate::marlin::MarlinWeight {
+            qweight: qweight_dev,
+            scales: scales_dev,
+            workspace: workspace_dev,
+            k,
+            n,
+            group_size: group_size as i32,
+            perm: perm_dev_opt,
+        };
+
+        // Wrap in the Marlin variant (or pass through, depending on cfg).
+        #[cfg(feature = "triton-kernels")]
+        {
+            Ok(GptqStoreCuda::Marlin(marlin_weight))
+        }
+        #[cfg(not(feature = "triton-kernels"))]
+        {
+            Ok(marlin_weight)
+        }
+    }
+    fn load_gptq_stacked(
+        qweights: &[&[i32]],
+        scales: &[&[f32]],
+        qzeros: &[&[i32]],
+        g_idx: Option<&[i32]>,
+        bits: u32,
+        group_size: usize,
+        k: usize,
+        n_per_expert: usize,
+    ) -> Result<Self::GptqStore> {
+        if bits != 4 {
+            return Err(FerrumError::unsupported(format!(
+                "CUDA GPTQ stacked: only bits=4 supported (got {bits})"
+            )));
+        }
+        let num_experts = qweights.len();
+        if num_experts == 0 {
+            return Err(FerrumError::model("load_gptq_stacked: 0 experts"));
+        }
+        if scales.len() != num_experts || qzeros.len() != num_experts {
+            return Err(FerrumError::model(format!(
+                "load_gptq_stacked length mismatch: qw={} sc={} qz={}",
+                num_experts,
+                scales.len(),
+                qzeros.len()
+            )));
+        }
+        let _ = qzeros; // Marlin doesn't read qzeros (sym=true)
+
+        // vLLM marlin_moe_wna16 path: stacked weight in vLLM Marlin tile
+        // format (NOT IST-DASLab). Run gptq_marlin_repack per expert,
+        // permute scales with the same _scale_perm IST-DASLab uses.
+        // Opt-in via FERRUM_VLLM_MOE=1 — paired with the dispatch-side
+        // switch in moe_forward_bucketed.
+        #[cfg(feature = "vllm-moe-marlin")]
+        if use_vllm_moe() {
+            let stream = default_stream();
+            let store = crate::vllm_marlin::load_stacked_gptq_vllm_marlin(
+                &stream,
+                qweights,
+                scales,
+                bits,
+                group_size,
+                k,
+                n_per_expert,
+            )
+            .map_err(|e| FerrumError::model(format!("load_stacked_gptq_vllm_marlin: {e}")))?;
+            tracing::info!(
+                "GPTQ stacked load (vLLM marlin path): {num_experts} experts × N={n_per_expert} × K={k} (gs={group_size})",
+            );
+            return Ok(store);
+        }
+
+        // Triton path: would need a stacked variant — not implemented.
+        // Fall through to Marlin.
+        #[cfg(feature = "triton-kernels")]
+        if use_triton_int4() {
+            return Err(FerrumError::unsupported(
+                "load_gptq_stacked: Triton w4a16 path not implemented; \
+                 unset FERRUM_TRITON_INT4 to use Marlin",
+            ));
+        }
+
+        // desc_act perm-aware path: sample expert 0's g_idx (all experts
+        // share K-axis quantization, so g_idx is identical across experts).
+        let (perm_dev_opt, perm_for_repack): (Option<CudaSlice<i32>>, Option<Vec<usize>>) =
+            if let Some(gx) = g_idx {
+                let is_desc_act = gx
+                    .iter()
+                    .enumerate()
+                    .any(|(i, &g)| g != (i as i32) / group_size as i32);
+                if is_desc_act {
+                    let mut perm: Vec<usize> = (0..k).collect();
+                    perm.sort_by_key(|&i| gx[i]);
+                    let perm_i32: Vec<i32> = perm.iter().map(|&p| p as i32).collect();
+                    let stream = default_stream();
+                    let perm_dev = stream
+                        .clone_htod(&perm_i32)
+                        .map_err(|e| FerrumError::model(format!("perm htod: {e}")))?;
+                    (Some(perm_dev), Some(perm))
+                } else {
+                    (None, None)
+                }
+            } else {
+                (None, None)
+            };
+
+        // Per-expert repack in parallel via rayon. Each produces its
+        // own packed qweight + permuted scales tile. Concat in expert
+        // order — each expert's bytes are CONTIGUOUS in the output
+        // buffer, so an offset GEMM with prob_n=n_per_expert just
+        // walks the right slice.
+        use rayon::prelude::*;
+        let qw_per_expert_i32 = (n_per_expert * k) / 8;
+        let sc_per_expert_f16 = (k / group_size) * n_per_expert;
+
+        let mut packed_qw: Vec<i32> = vec![0i32; num_experts * qw_per_expert_i32];
+        let mut packed_sc: Vec<f16> = vec![f16::ZERO; num_experts * sc_per_expert_f16];
+
+        // Parallelize across experts: each writes to a disjoint output
+        // slice. Per-expert repack runs the inner-rayon-parallel
+        // 4-pass kernel — at num_experts > num_cores, outer parallelism
+        // wins; at smaller num_experts, inner parallelism wins. Rayon
+        // nests fine.
+        packed_qw
+            .par_chunks_mut(qw_per_expert_i32)
+            .zip(packed_sc.par_chunks_mut(sc_per_expert_f16))
+            .enumerate()
+            .for_each(|(e, (qw_out, sc_out))| {
+                let qw_in: Vec<i32> = if let Some(perm) = &perm_for_repack {
+                    crate::marlin::permute_gptq_qweight_rows(qweights[e], perm, k, n_per_expert)
+                } else {
+                    qweights[e].to_vec()
+                };
+                let qw_packed = crate::marlin::repack_gptq_to_marlin(&qw_in, k, n_per_expert);
+                qw_out.copy_from_slice(&qw_packed);
+
+                let sc_f16: Vec<f16> = scales[e].iter().map(|&x| f16::from_f32(x)).collect();
+                let sc_packed =
+                    crate::marlin::repack_scales_to_marlin(&sc_f16, k, n_per_expert, group_size);
+                sc_out.copy_from_slice(&sc_packed);
+            });
+
+        // Single htod upload of the concatenated packed buffer.
+        let stream = default_stream();
+        let qweight_dev = stream
+            .clone_htod(&packed_qw)
+            .map_err(|e| FerrumError::model(format!("stacked qweight htod: {e}")))?;
+        let scales_dev = stream
+            .clone_htod(&packed_sc)
+            .map_err(|e| FerrumError::model(format!("stacked scales htod: {e}")))?;
+
+        // Workspace: per-expert range concatenated. Each expert owns
+        // (n_per_expert/128) × max_par i32 mutex slots starting at
+        // its expert_idx * that_size.
+        let max_par = 16usize;
+        let ws_per_expert = (n_per_expert / 128).max(1) * max_par;
+        let ws_len = num_experts * ws_per_expert;
+        let workspace_dev = stream
+            .alloc_zeros::<i32>(ws_len)
+            .map_err(|e| FerrumError::model(format!("stacked ws alloc: {e}")))?;
+
+        // Total stacked N for downstream offset arithmetic. We store
+        // total_n in MarlinWeight.n so byte_per_col-style helpers see
+        // the full width; the offset GEMM uses per-expert stride
+        // (= n_per_expert) regardless of weight.n.
+        let total_n = num_experts * n_per_expert;
+        let marlin_weight = crate::marlin::MarlinWeight {
+            qweight: qweight_dev,
+            scales: scales_dev,
+            workspace: workspace_dev,
+            k,
+            n: total_n,
+            group_size: group_size as i32,
+            perm: perm_dev_opt,
+        };
+
+        tracing::info!(
+            "GPTQ stacked load: {} experts × N={n_per_expert} × K={k} (gs={group_size})",
+            num_experts
+        );
+
+        #[cfg(feature = "triton-kernels")]
+        {
+            Ok(GptqStoreCuda::Marlin(marlin_weight))
+        }
+        #[cfg(not(feature = "triton-kernels"))]
+        {
+            Ok(marlin_weight)
+        }
+    }
+    #[cfg(feature = "marlin")]
+    fn gemm_gptq(
+        ctx: &mut Self::Context,
+        a: &Self::Buffer,
+        weight: &Self::GptqStore,
+        out: &mut Self::Buffer,
+        m: usize,
+    ) -> Result<()> {
+        // Branch on store variant (only present when triton-kernels is on).
+        #[cfg(feature = "triton-kernels")]
+        match weight {
+            GptqStoreCuda::Marlin(mw) => marlin_gemm_with_perm(ctx, a, mw, out, m),
+            GptqStoreCuda::Triton(tw) => {
+                // Pre-load (and cache) the CudaFunction once per CudaState.
+                // Subsequent calls hit the HashMap and skip the PTX parse.
+                let func = ctx.func(
+                    "triton_w4a16_gptq",
+                    crate::triton_ptx::w4a16_gptq_f16::PTX,
+                    crate::triton_w4a16::fn_name(),
+                );
+                let stream = ctx.stream.clone();
+                crate::triton_w4a16::launch_w4a16_gptq_triton(&stream, &func, a, tw, out, m as i32)
+                    .map_err(|e| FerrumError::model(format!("triton w4a16: {e}")))
+            }
+        }
+        #[cfg(not(feature = "triton-kernels"))]
+        {
+            marlin_gemm_with_perm(ctx, a, weight, out, m)
+        }
+    }
+    #[cfg(all(not(feature = "marlin"), feature = "triton-kernels"))]
+    fn gemm_gptq(
+        ctx: &mut Self::Context,
+        a: &Self::Buffer,
+        weight: &Self::GptqStore,
+        out: &mut Self::Buffer,
+        m: usize,
+    ) -> Result<()> {
+        // Marlin compiled out → only Triton path is callable. The Marlin
+        // variant should never be constructed in this configuration
+        // (load_gptq currently still builds a MarlinWeight even with
+        // triton-kernels — but its `gemm_gptq` would have nothing to call,
+        // so we error explicitly for traceability instead of silently
+        // failing inside the FFI stub).
+        match weight {
+            GptqStoreCuda::Marlin(_) => Err(FerrumError::unsupported(
+                "cargo feature `marlin` disabled — Marlin variant unusable; \
+                 set FERRUM_TRITON_INT4=1 to force the triton path",
+            )),
+            GptqStoreCuda::Triton(tw) => {
+                let func = ctx.func(
+                    "triton_w4a16_gptq",
+                    crate::triton_ptx::w4a16_gptq_f16::PTX,
+                    crate::triton_w4a16::fn_name(),
+                );
+                let stream = ctx.stream.clone();
+                crate::triton_w4a16::launch_w4a16_gptq_triton(&stream, &func, a, tw, out, m as i32)
+                    .map_err(|e| FerrumError::model(format!("triton w4a16: {e}")))
+            }
+        }
+    }
+    #[cfg(all(not(feature = "marlin"), not(feature = "triton-kernels")))]
+    fn gemm_gptq(
+        _ctx: &mut Self::Context,
+        _a: &Self::Buffer,
+        _weight: &Self::GptqStore,
+        _out: &mut Self::Buffer,
+        _m: usize,
+    ) -> Result<()> {
+        Err(FerrumError::unsupported(
+            "cargo features `marlin` and `triton-kernels` both disabled — \
+             GPTQ not available",
+        ))
+    }
+    /// MoE expert dispatch: GEMM over a column-slice of a stacked Marlin
+    /// store. Lets all 128 experts share one Marlin repack; the runtime
+    /// dispatch picks one expert by `expert_offset`.
+    ///
+    /// Currently Marlin-only (the Triton w4a16 variant doesn't support
+    /// strided access on the on-disk layout). When triton-kernels is on
+    /// and the store is Triton, returns Unsupported — caller should ensure
+    /// MoE models load through the Marlin path (default).
+    #[cfg(feature = "marlin")]
+    fn gemm_gptq_with_offset(
+        ctx: &mut Self::Context,
+        a: &Self::Buffer,
+        weight: &Self::GptqStore,
+        expert_offset: usize,
+        expert_n: usize,
+        out: &mut Self::Buffer,
+        m: usize,
+    ) -> Result<()> {
+        #[cfg(feature = "triton-kernels")]
+        let mw = match weight {
+            GptqStoreCuda::Marlin(mw) => mw,
+            GptqStoreCuda::Triton(_) => {
+                return Err(FerrumError::unsupported(
+                    "gemm_gptq_with_offset: Triton w4a16 store has no \
+                     stride-aware variant; load MoE via Marlin (default)",
+                ));
+            }
+        };
+        #[cfg(not(feature = "triton-kernels"))]
+        let mw: &crate::marlin::MarlinWeight = weight;
+        let stream = ctx.stream.clone();
+        crate::marlin::marlin_gemm_with_offset(
+            &stream,
+            a,
+            mw,
+            out,
+            m as i32,
+            expert_offset as i32,
+            expert_n as i32,
+        )
+        .map_err(|e| FerrumError::model(format!("marlin offset gemm: {e}")))
+    }
+    #[cfg(feature = "marlin")]
+    fn moe_gemm_phase_batched(
+        ctx: &mut Self::Context,
+        input: &Self::Buffer,
+        weight: &Self::GptqStore,
+        dispatches: &[(usize, usize, usize, usize)],
+        n_per_expert: usize,
+        output: &mut Self::Buffer,
+        k: usize,
+    ) -> Result<()> {
+        #[cfg(feature = "triton-kernels")]
+        let mw = match weight {
+            GptqStoreCuda::Marlin(mw) => mw,
+            GptqStoreCuda::Triton(_) => {
+                return Err(FerrumError::unsupported(
+                    "moe_gemm_phase_batched: Triton w4a16 not supported",
+                ));
+            }
+        };
+        #[cfg(not(feature = "triton-kernels"))]
+        let mw: &crate::marlin::MarlinWeight = weight;
+
+        // ── Stage 12.1: fused MoE Marlin path (default ON) ──────────────
+        // Dispatches all experts in this phase as a small number of
+        // bucketed `marlin_gemm_moe` launches (one per thread_m_blocks
+        // bucket ∈ {1, 2, 3, 4}) instead of N round-robin calls. At c=32
+        // with ~100 active experts/layer this is 1-4 launches/layer
+        // instead of 100. Bench: +25% c=32, +35% c=16, +48% c=8 over
+        // the multi-stream per-expert path. Set FERRUM_MOE_FUSED=0 to
+        // opt out (fall back to multi-stream pool).
+        if std::env::var("FERRUM_MOE_FUSED").map_or(true, |v| v != "0") {
+            return moe_gemm_phase_fused_impl(ctx, input, mw, dispatches, n_per_expert, output, k);
+        }
+
+        // n_streams=1: serial dispatch on the DEFAULT context stream
+        // (avoids the cross-stream sync overhead and matches the
+        // pre-multi-stream path bit-for-bit).
+        let n_streams = std::env::var("FERRUM_MOE_STREAMS")
+            .ok()
+            .and_then(|s| s.parse::<usize>().ok())
+            .unwrap_or(4)
+            .max(1);
+        if n_streams == 1 {
+            let default_stream = ctx.stream.clone();
+            for (expert_idx, in_row_offset, out_row_offset, m) in dispatches {
+                crate::marlin::marlin_gemm_with_offset_strided(
+                    &default_stream,
+                    input,
+                    *in_row_offset as i32,
+                    mw,
+                    output,
+                    *out_row_offset as i32,
+                    *m as i32,
+                    (expert_idx * n_per_expert) as i32,
+                    n_per_expert as i32,
+                )
+                .map_err(|e| FerrumError::model(format!("marlin offset_strided: {e}")))?;
+            }
+            let _ = k;
+            return Ok(());
+        }
+
+        // n_streams ≥ 2: round-robin across the pool, then ALL streams
+        // wait for the default's prior work (cuStreamWaitEvent on an
+        // event recorded into default), and the default waits for ALL
+        // pool streams before returning. Without this cross-stream
+        // sync, silu_mul on default may run before pool GEMMs commit
+        // → races → junk output.
+        //
+        // The 1 + N events are persistent on `CudaState` — re-recording
+        // an event silently overwrites the prior recording, so per-call
+        // create+destroy is replaced with record+wait only. At c=32 /
+        // 48 layers / 2 phases that's ~960 driver calls saved per token.
+        let (entry_event, exit_events) = ctx.moe_sync_events();
+        let pool: Vec<Arc<CudaStream>> = ctx.moe_stream_pool().to_vec();
+        let default_stream = ctx.stream.clone();
+        use cudarc::driver::sys as cu;
+        // Default → pool: record on default, each pool waits.
+        unsafe {
+            cu::cuEventRecord(entry_event, default_stream.cu_stream());
+        }
+        for stream in &pool {
+            unsafe {
+                cu::cuStreamWaitEvent(stream.cu_stream(), entry_event, 0);
+            }
+        }
+
+        for (i, (expert_idx, in_row_offset, out_row_offset, m)) in dispatches.iter().enumerate() {
+            let stream = &pool[i % n_streams];
+            crate::marlin::marlin_gemm_with_offset_strided(
+                stream,
+                input,
+                *in_row_offset as i32,
+                mw,
+                output,
+                *out_row_offset as i32,
+                *m as i32,
+                (expert_idx * n_per_expert) as i32,
+                n_per_expert as i32,
+            )
+            .map_err(|e| FerrumError::model(format!("marlin offset_strided: {e}")))?;
+        }
+
+        // pool → default: each pool stream records its exit event;
+        // default waits for all of them. After return, default's next
+        // op (silu) will see all GEMM outputs committed.
+        let _ = k;
+        debug_assert_eq!(
+            exit_events.len(),
+            pool.len(),
+            "moe_sync_events exit count != pool size"
+        );
+        for (i, stream) in pool.iter().enumerate() {
+            unsafe {
+                cu::cuEventRecord(exit_events[i], stream.cu_stream());
+            }
+        }
+        for ev in &exit_events {
+            unsafe {
+                cu::cuStreamWaitEvent(default_stream.cu_stream(), *ev, 0);
+            }
+        }
+        Ok(())
+    }
+    #[cfg(feature = "vllm-moe-marlin")]
+    fn moe_gemm_phase_vllm(
+        ctx: &mut Self::Context,
+        input: &Self::Buffer,
+        weight: &Self::GptqStore,
+        sorted_token_ids: &Self::Buffer,
+        expert_ids: &Self::Buffer,
+        num_tokens_past_padded: &Self::Buffer,
+        output: &mut Self::Buffer,
+        prob_m: usize,
+        n_per_expert: usize,
+        k: usize,
+        moe_block_size: usize,
+        top_k: usize,
+    ) -> Result<()> {
+        #[cfg(feature = "triton-kernels")]
+        let mw = match weight {
+            GptqStoreCuda::Marlin(mw) => mw,
+            GptqStoreCuda::Triton(_) => {
+                return Err(FerrumError::unsupported(
+                    "moe_gemm_phase_vllm: Triton store unsupported",
+                ));
+            }
+        };
+        #[cfg(not(feature = "triton-kernels"))]
+        let mw: &crate::marlin::MarlinWeight = weight;
+
+        // sorted_token_ids / expert_ids / num_tokens_past_padded are i32
+        // device buffers handed in as Self::Buffer (= CudaSlice<f16>).
+        // The marlin_gemm_moe_vllm wrapper uses CudaSlice<i32>, so we
+        // reinterpret each view via upgrade_device_ptr. The view length
+        // is irrelevant — the kernel reads via raw device pointers — so
+        // we hand it `0` to make the leakage cost explicit.
+        use cudarc::driver::sys::CUdeviceptr;
+        use cudarc::driver::CudaSlice;
+        use cudarc::driver::DevicePtr;
+
+        // Stream is Arc<CudaStream>, so cloning it doesn't borrow ctx and
+        // we can subsequently take &mut for the c_tmp helper.
+        let stream = ctx.stream.clone();
+        // Resolve c_tmp scratch (lazy-allocates 8 MB on first call). The
+        // wrapper takes &mut so it can forward the device pointer; the
+        // kernel uses c_tmp as a global fp32 reduce scratch
+        // (use_fp32_reduce=1 path, ~1.3-1.5× faster than atomic_add).
+        let c_tmp_mut: &mut CudaSlice<f32> = ctx.vllm_moe_c_tmp();
+
+        let (st_ptr, _g0) = sorted_token_ids.device_ptr(&stream);
+        let (eid_ptr, _g1) = expert_ids.device_ptr(&stream);
+        let (npp_ptr, _g2) = num_tokens_past_padded.device_ptr(&stream);
+        let st_view: CudaSlice<i32> =
+            unsafe { stream.upgrade_device_ptr(st_ptr as CUdeviceptr, 0) };
+        let eid_view: CudaSlice<i32> =
+            unsafe { stream.upgrade_device_ptr(eid_ptr as CUdeviceptr, 0) };
+        let npp_view: CudaSlice<i32> =
+            unsafe { stream.upgrade_device_ptr(npp_ptr as CUdeviceptr, 0) };
+
+        let r = crate::marlin::marlin_gemm_moe_vllm(
+            &stream,
+            input,
+            mw,
+            output,
+            Some(c_tmp_mut), // fp32_reduce path (atomic_add fallback if None)
+            &st_view,
+            &eid_view,
+            &npp_view,
+            None, // topk_weights
+            moe_block_size as i32,
+            top_k as i32,
+            false, // mul_topk_weights
+            false, // is_ep
+            prob_m as i32,
+            n_per_expert as i32,
+            k as i32,
+        );
+        // Views borrow the original device allocations; forgetting prevents
+        // double-free at scope end.
+        std::mem::forget(st_view);
+        std::mem::forget(eid_view);
+        std::mem::forget(npp_view);
+        r.map_err(|e| FerrumError::model(format!("marlin_gemm_moe_vllm: {e}")))
+    }
+    #[cfg(feature = "marlin")]
+    fn marlin_zero_stacked_workspace(
+        ctx: &mut Self::Context,
+        weight: &Self::GptqStore,
+    ) -> Result<()> {
+        use cudarc::driver::DevicePtr;
+        #[cfg(feature = "triton-kernels")]
+        let mw = match weight {
+            GptqStoreCuda::Marlin(mw) => mw,
+            GptqStoreCuda::Triton(_) => {
+                return Err(FerrumError::unsupported(
+                    "marlin_zero_stacked_workspace: not applicable to Triton store",
+                ));
+            }
+        };
+        #[cfg(not(feature = "triton-kernels"))]
+        let mw: &crate::marlin::MarlinWeight = weight;
+        let stream = ctx.stream.clone();
+        let raw_stream = stream.cu_stream();
+        let (ws_ptr, _g) = mw.workspace.device_ptr(&stream);
+        let ws_len = mw.workspace.len();
+        unsafe {
+            cudarc::driver::sys::cuMemsetD32Async(ws_ptr, 0, ws_len, raw_stream);
+        }
+        Ok(())
+    }
+}
+
+// CUDA does not ship GGUF k-quant kernels; inherit unsupported defaults.
+impl BackendQuantGguf for CudaBackend {}

--- a/crates/ferrum-kernels/src/backend/cuda.rs
+++ b/crates/ferrum-kernels/src/backend/cuda.rs
@@ -21,7 +21,10 @@
 
 #![allow(unused_variables, dead_code, unused_imports, unused_mut)]
 
-use super::{AttnConfig, Backend, QuantKind, QuantWeights, ReduceOp};
+use super::{
+    AttnConfig, Backend, BackendCollective, BackendGraph, BackendQuantGguf, BackendQuantMarlin,
+    QuantKind, QuantWeights, ReduceOp,
+};
 use crate::ptx;
 use cudarc::cublas::CudaBlas;
 use cudarc::driver::{
@@ -2509,24 +2512,11 @@ impl Backend for CudaBackend {
     // is already production-grade (112 tok/s on RTX PRO 6000 per pre-v2
     // benchmarks); wiring is a structural concern, not a kernel concern.
 
-    // Trait signature was tightened (`Self::QuantStore` instead of the
-    // historical 8-param `QuantWeights` shape). The CUDA path no longer
-    // dispatches through this entry — INT4 goes through `gemm_gptq +
-    // GptqStore`, k-quants stay on Metal/CPU. Stub kept so the trait
-    // is satisfied and the cuda feature builds on Linux.
-    fn gemm_quant(
-        _ctx: &mut Self::Context,
-        _a: &Self::Buffer,
-        _weight: &Self::QuantStore,
-        _out: &mut Self::Buffer,
-        _m: usize,
-    ) -> Result<()> {
-        Err(FerrumError::unsupported(
-            "CudaBackend::gemm_quant deprecated — use gemm_gptq + GptqStore",
-        ))
-    }
-
     // ── GPTQ INT4 dispatch (Marlin default; Triton-rs alt via env) ──────
+    //
+    // gemm_quant moved to `impl BackendQuantGguf for CudaBackend {}`
+    // (empty — CUDA inherits the unsupported default; INT4 goes through
+    // gemm_gptq + GptqStore).
 
     #[cfg(feature = "vllm-moe-marlin")]
     fn upload_moe_routing(

--- a/crates/ferrum-kernels/src/backend/metal.rs
+++ b/crates/ferrum-kernels/src/backend/metal.rs
@@ -957,114 +957,6 @@ impl Backend for MetalBackend {
 
     // ── Q4_K_M ────────────────────────────────────────────────────────
 
-    fn load_quant(
-        kind: super::GgufQuantType,
-        bytes: &[u8],
-        n_rows: usize,
-        n_cols: usize,
-    ) -> Result<Self::QuantStore> {
-        use super::GgufQuantType;
-        const QK_K: usize = 256;
-        match kind {
-            GgufQuantType::Q4K => {
-                const BLOCK_BYTES: usize = 144;
-                let total_elems = n_rows * n_cols;
-                if total_elems % QK_K != 0 {
-                    return Err(FerrumError::model(format!(
-                        "load_quant Q4K: elements {total_elems} not multiple of {QK_K}"
-                    )));
-                }
-                let n_blocks = total_elems / QK_K;
-                let expected = n_blocks * BLOCK_BYTES;
-                if bytes.len() != expected {
-                    return Err(FerrumError::model(format!(
-                        "load_quant Q4K: bytes {} != expected {} ({n_blocks} blocks)",
-                        bytes.len(),
-                        expected
-                    )));
-                }
-                let (blocks, byte_offset) = buffer_for_quant_bytes(bytes);
-                Ok(MetalQuantStore::Q4K {
-                    blocks,
-                    byte_offset,
-                    n_rows,
-                    n_cols,
-                    n_blocks,
-                })
-            }
-            GgufQuantType::Q6K => {
-                const BLOCK_BYTES: usize = crate::q6_k_gemv::Q6_K_BLOCK_BYTES; // 210
-                let total_elems = n_rows * n_cols;
-                if total_elems % QK_K != 0 {
-                    return Err(FerrumError::model(format!(
-                        "load_quant Q6K: elements {total_elems} not multiple of {QK_K}"
-                    )));
-                }
-                let n_blocks = total_elems / QK_K;
-                let expected = n_blocks * BLOCK_BYTES;
-                if bytes.len() != expected {
-                    return Err(FerrumError::model(format!(
-                        "load_quant Q6K: bytes {} != expected {} ({n_blocks} blocks)",
-                        bytes.len(),
-                        expected
-                    )));
-                }
-                let (blocks, byte_offset) = buffer_for_quant_bytes(bytes);
-                Ok(MetalQuantStore::Q6K {
-                    blocks,
-                    byte_offset,
-                    n_rows,
-                    n_cols,
-                    n_blocks,
-                })
-            }
-            other => Err(FerrumError::unsupported(format!(
-                "Metal load_quant: {other:?} not yet implemented"
-            ))),
-        }
-    }
-
-    fn load_quant_experts(
-        kind: super::GgufQuantType,
-        bytes: &[u8],
-        num_experts: usize,
-        n_rows: usize,
-        n_cols: usize,
-    ) -> Result<Self::QuantStore> {
-        use super::GgufQuantType;
-        match kind {
-            GgufQuantType::Q4K => load_q4k_experts(bytes, num_experts, n_rows, n_cols),
-            GgufQuantType::Q6K => load_q6k_experts(bytes, num_experts, n_rows, n_cols),
-            other => Err(FerrumError::unsupported(format!(
-                "Metal load_quant_experts: {other:?} not implemented (only Q4K / Q6K)"
-            ))),
-        }
-    }
-
-    fn gemv_quant_moe_id(
-        ctx: &mut Self::Context,
-        a: &Self::Buffer,
-        weight: &Self::QuantStore,
-        ids: &Self::Buffer,
-        out: &mut Self::Buffer,
-        n_selected: usize,
-        src1_stride: usize,
-    ) -> Result<()> {
-        let a_buf = a.expect_f32("gemv_quant_moe_id a");
-        let ids_buf = &ids.raw;
-        let out_buf = out.expect_f32_mut("gemv_quant_moe_id out");
-        let enc = ctx.compute_encoder();
-        dispatch_gemv_moe_id(
-            enc,
-            a_buf,
-            weight,
-            ids_buf,
-            out_buf,
-            n_selected,
-            src1_stride,
-        )
-    }
-
     fn supports_batched_moe_gemv() -> bool {
         true
     }
@@ -1075,179 +967,6 @@ impl Backend for MetalBackend {
 
     fn supports_paged_kv() -> bool {
         true
-    }
-
-    fn gemv_quant_moe_id_gate_up_silu_batched(
-        ctx: &mut Self::Context,
-        a: &Self::Buffer,
-        gate_w: &Self::QuantStore,
-        up_w: &Self::QuantStore,
-        ids: &Self::Buffer,
-        silu_out: &mut Self::Buffer,
-        m: usize,
-        top_k: usize,
-        src1_outer_stride: usize,
-        src1_inner_stride: usize,
-    ) -> Result<()> {
-        let (gate_blocks, gate_byte_offset, gate_n_rows, gate_n_cols) = match gate_w {
-            MetalQuantStore::Q4KExperts {
-                blocks,
-                byte_offset,
-                n_rows,
-                n_cols,
-                ..
-            } => (blocks, *byte_offset, *n_rows, *n_cols),
-            _ => {
-                return Err(FerrumError::model(
-                    "gemv_quant_moe_id_gate_up_silu_batched: gate_w must be Q4KExperts".to_string(),
-                ));
-            }
-        };
-        let (up_blocks, up_byte_offset, up_n_rows, up_n_cols) = match up_w {
-            MetalQuantStore::Q4KExperts {
-                blocks,
-                byte_offset,
-                n_rows,
-                n_cols,
-                ..
-            } => (blocks, *byte_offset, *n_rows, *n_cols),
-            _ => {
-                return Err(FerrumError::model(
-                    "gemv_quant_moe_id_gate_up_silu_batched: up_w must be Q4KExperts".to_string(),
-                ));
-            }
-        };
-        if gate_n_rows != up_n_rows || gate_n_cols != up_n_cols {
-            return Err(FerrumError::model(format!(
-                "gemv_quant_moe_id_gate_up_silu_batched: gate/up shape mismatch — \
-                 gate=({gate_n_rows}, {gate_n_cols}) up=({up_n_rows}, {up_n_cols})"
-            )));
-        }
-
-        let a_buf = a.expect_f32("gemv_quant_moe_id_gate_up_silu_batched a");
-        let ids_buf = &ids.raw;
-        let out_buf = silu_out.expect_f32_mut("gemv_quant_moe_id_gate_up_silu_batched silu_out");
-        let enc = ctx.compute_encoder();
-        crate::q4_k_moe_id_gate_up_silu_batched::dispatch_gemv_q4k_moe_id_gate_up_silu_batched_on_encoder(
-            &st().pipes.device,
-            enc,
-            a_buf,
-            gate_blocks,
-            gate_byte_offset,
-            up_blocks,
-            up_byte_offset,
-            ids_buf,
-            out_buf,
-            gate_n_rows,
-            gate_n_cols,
-            m,
-            top_k,
-            src1_outer_stride,
-            src1_inner_stride,
-        );
-        Ok(())
-    }
-
-    fn gemv_quant_moe_id_batched(
-        ctx: &mut Self::Context,
-        a: &Self::Buffer,
-        weight: &Self::QuantStore,
-        ids: &Self::Buffer,
-        out: &mut Self::Buffer,
-        m: usize,
-        top_k: usize,
-        src1_outer_stride: usize,
-        src1_inner_stride: usize,
-    ) -> Result<()> {
-        let a_buf = a.expect_f32("gemv_quant_moe_id_batched a");
-        let ids_buf = &ids.raw;
-        let out_buf = out.expect_f32_mut("gemv_quant_moe_id_batched out");
-        let enc = ctx.compute_encoder();
-        match weight {
-            MetalQuantStore::Q4KExperts {
-                blocks,
-                byte_offset,
-                n_rows,
-                n_cols,
-                ..
-            } => {
-                crate::q4_k_moe_id_gemv_batched::dispatch_gemv_q4k_moe_id_batched_on_encoder(
-                    &st().pipes.device,
-                    enc,
-                    a_buf,
-                    blocks,
-                    *byte_offset,
-                    ids_buf,
-                    out_buf,
-                    *n_rows,
-                    *n_cols,
-                    m,
-                    top_k,
-                    src1_outer_stride,
-                    src1_inner_stride,
-                );
-                Ok(())
-            }
-            MetalQuantStore::Q6KExperts {
-                blocks,
-                byte_offset,
-                n_rows,
-                n_cols,
-                ..
-            } => {
-                crate::q6_k_moe_id_gemv_batched::dispatch_gemv_q6k_moe_id_batched_on_encoder(
-                    &st().pipes.device,
-                    enc,
-                    a_buf,
-                    blocks,
-                    *byte_offset,
-                    ids_buf,
-                    out_buf,
-                    *n_rows,
-                    *n_cols,
-                    m,
-                    top_k,
-                    src1_outer_stride,
-                    src1_inner_stride,
-                );
-                Ok(())
-            }
-            _ => Err(FerrumError::model(
-                "gemv_quant_moe_id_batched: weight must be Q4KExperts or Q6KExperts".to_string(),
-            )),
-        }
-    }
-
-    fn gemv_quant_moe_id_offset(
-        ctx: &mut Self::Context,
-        a: &Self::Buffer,
-        a_offset: usize,
-        weight: &Self::QuantStore,
-        ids: &Self::Buffer,
-        ids_offset: usize,
-        out: &mut Self::Buffer,
-        n_selected: usize,
-        src1_stride: usize,
-    ) -> Result<()> {
-        let a_buf = a.expect_f32("gemv_quant_moe_id_offset a");
-        let ids_buf = &ids.raw;
-        let out_buf = out.expect_f32_mut("gemv_quant_moe_id_offset out");
-        let enc = ctx.compute_encoder();
-        // a_offset is in floats (a is f32), ids_offset in i32s (ids is i32).
-        // Both kernels read with 4-byte stride, so byte offset = elem * 4.
-        let a_byte_offset = (a_offset * std::mem::size_of::<f32>()) as u64;
-        let ids_byte_offset = (ids_offset * std::mem::size_of::<i32>()) as u64;
-        dispatch_gemv_moe_id_offset(
-            enc,
-            a_buf,
-            a_byte_offset,
-            weight,
-            ids_buf,
-            ids_byte_offset,
-            out_buf,
-            n_selected,
-            src1_stride,
-        )
     }
 
     fn from_slice_i32(data: &[i32]) -> Self::Buffer {
@@ -1264,162 +983,6 @@ impl Backend for MetalBackend {
             raw,
             dtype: Dtype::F32,
             n: data.len(),
-        }
-    }
-
-    fn gemm_quant_moe_id(
-        ctx: &mut Self::Context,
-        a: &Self::Buffer,
-        weight: &Self::QuantStore,
-        ids: &Self::Buffer,
-        tpe: &Self::Buffer,
-        out: &mut Self::Buffer,
-        ne11: usize,
-        top_k: usize,
-        max_per_expert: usize,
-        batch: usize,
-    ) -> Result<()> {
-        let a_buf = a.expect_f32("gemm_quant_moe_id a");
-        let ids_buf = &ids.raw;
-        let tpe_buf = &tpe.raw;
-        let out_buf = out.expect_f32_mut("gemm_quant_moe_id out");
-        let enc = ctx.compute_encoder();
-        match weight {
-            MetalQuantStore::Q4KExperts {
-                blocks,
-                byte_offset,
-                num_experts,
-                n_rows,
-                n_cols,
-            } => {
-                crate::q4_k_moe_id_gemm::dispatch_gemm_q4k_moe_id_on_encoder(
-                    &st().pipes.device,
-                    enc,
-                    blocks,
-                    *byte_offset,
-                    a_buf,
-                    ids_buf,
-                    tpe_buf,
-                    out_buf,
-                    *num_experts,
-                    *n_rows,
-                    *n_cols,
-                    ne11,
-                    top_k,
-                    max_per_expert,
-                    batch,
-                );
-                Ok(())
-            }
-            MetalQuantStore::Q6KExperts {
-                blocks,
-                byte_offset,
-                num_experts,
-                n_rows,
-                n_cols,
-            } => {
-                crate::q6_k_moe_id_gemm::dispatch_gemm_q6k_moe_id_on_encoder(
-                    &st().pipes.device,
-                    enc,
-                    blocks,
-                    *byte_offset,
-                    a_buf,
-                    ids_buf,
-                    tpe_buf,
-                    out_buf,
-                    *num_experts,
-                    *n_rows,
-                    *n_cols,
-                    ne11,
-                    top_k,
-                    max_per_expert,
-                    batch,
-                );
-                Ok(())
-            }
-            _ => Err(FerrumError::model(
-                "gemm_quant_moe_id: weight must be Q4KExperts or Q6KExperts".to_string(),
-            )),
-        }
-    }
-
-    fn gemm_quant_moe_id_indirect(
-        ctx: &mut Self::Context,
-        a: &Self::Buffer,
-        weight: &Self::QuantStore,
-        ids: &Self::Buffer,
-        tpe: &Self::Buffer,
-        out: &mut Self::Buffer,
-        args_buf: &Self::Buffer,
-        ne11: usize,
-        top_k: usize,
-        max_per_expert: usize,
-        batch: usize,
-    ) -> Result<()> {
-        let a_buf = a.expect_f32("gemm_quant_moe_id_indirect a");
-        let ids_buf = &ids.raw;
-        let tpe_buf = &tpe.raw;
-        let out_buf = out.expect_f32_mut("gemm_quant_moe_id_indirect out");
-        let args = &args_buf.raw;
-        let enc = ctx.compute_encoder();
-        match weight {
-            MetalQuantStore::Q4KExperts {
-                blocks,
-                byte_offset,
-                num_experts,
-                n_rows,
-                n_cols,
-            } => {
-                crate::q4_k_moe_id_gemm::dispatch_gemm_q4k_moe_id_indirect_on_encoder(
-                    &st().pipes.device,
-                    enc,
-                    blocks,
-                    *byte_offset,
-                    a_buf,
-                    ids_buf,
-                    tpe_buf,
-                    out_buf,
-                    args,
-                    *num_experts,
-                    *n_rows,
-                    *n_cols,
-                    ne11,
-                    top_k,
-                    max_per_expert,
-                    batch,
-                );
-                Ok(())
-            }
-            MetalQuantStore::Q6KExperts {
-                blocks,
-                byte_offset,
-                num_experts,
-                n_rows,
-                n_cols,
-            } => {
-                crate::q6_k_moe_id_gemm::dispatch_gemm_q6k_moe_id_indirect_on_encoder(
-                    &st().pipes.device,
-                    enc,
-                    blocks,
-                    *byte_offset,
-                    a_buf,
-                    ids_buf,
-                    tpe_buf,
-                    out_buf,
-                    args,
-                    *num_experts,
-                    *n_rows,
-                    *n_cols,
-                    ne11,
-                    top_k,
-                    max_per_expert,
-                    batch,
-                );
-                Ok(())
-            }
-            _ => Err(FerrumError::model(
-                "gemm_quant_moe_id_indirect: weight must be Q4KExperts or Q6KExperts".to_string(),
-            )),
         }
     }
 
@@ -1655,71 +1218,6 @@ impl Backend for MetalBackend {
         true
     }
 
-    fn gemv_quant_moe_id_gate_up_silu(
-        ctx: &mut Self::Context,
-        a: &Self::Buffer,
-        gate_w: &Self::QuantStore,
-        up_w: &Self::QuantStore,
-        ids: &Self::Buffer,
-        silu_out: &mut Self::Buffer,
-        n_selected: usize,
-    ) -> Result<()> {
-        let (gate_blocks, gate_byte_offset, gate_n_rows, gate_n_cols) = match gate_w {
-            MetalQuantStore::Q4KExperts {
-                blocks,
-                byte_offset,
-                n_rows,
-                n_cols,
-                ..
-            } => (blocks, *byte_offset, *n_rows, *n_cols),
-            _ => {
-                return Err(FerrumError::model(
-                    "gemv_quant_moe_id_gate_up_silu: gate_w must be Q4KExperts".to_string(),
-                ));
-            }
-        };
-        let (up_blocks, up_byte_offset, up_n_rows, up_n_cols) = match up_w {
-            MetalQuantStore::Q4KExperts {
-                blocks,
-                byte_offset,
-                n_rows,
-                n_cols,
-                ..
-            } => (blocks, *byte_offset, *n_rows, *n_cols),
-            _ => {
-                return Err(FerrumError::model(
-                    "gemv_quant_moe_id_gate_up_silu: up_w must be Q4KExperts".to_string(),
-                ));
-            }
-        };
-        if gate_n_rows != up_n_rows || gate_n_cols != up_n_cols {
-            return Err(FerrumError::model(format!(
-                "gemv_quant_moe_id_gate_up_silu: gate/up shape mismatch — \
-                 gate=({gate_n_rows}, {gate_n_cols}) up=({up_n_rows}, {up_n_cols})"
-            )));
-        }
-
-        let a_buf = a.expect_f32("gemv_quant_moe_id_gate_up_silu a");
-        let ids_buf = &ids.raw;
-        let out_buf = silu_out.expect_f32_mut("gemv_quant_moe_id_gate_up_silu silu_out");
-        let enc = ctx.compute_encoder();
-        crate::q4_k_moe_id_gate_up_silu::dispatch_gemv_q4k_moe_id_gate_up_silu_on_encoder(
-            &st().pipes.device,
-            enc,
-            a_buf,
-            gate_blocks,
-            gate_byte_offset,
-            up_blocks,
-            up_byte_offset,
-            ids_buf,
-            out_buf,
-            gate_n_rows,
-            gate_n_cols,
-            n_selected,
-        );
-        Ok(())
-    }
-
     fn weighted_sum_stacked(
         ctx: &mut Self::Context,
         slots: &Self::Buffer,
@@ -1762,240 +1260,6 @@ impl Backend for MetalBackend {
         unsafe {
             std::ptr::copy_nonoverlapping(data.as_ptr(), dst, n);
         }
-    }
-
-    fn load_quant_fused(
-        parts: &[(super::GgufQuantType, &[u8], usize)],
-        n_cols: usize,
-    ) -> Result<Self::QuantStore> {
-        let mut sub_stores: Vec<MetalQuantStore> = Vec::with_capacity(parts.len());
-        let mut total_rows = 0;
-        for (kind, bytes, n_rows) in parts {
-            let store = Self::load_quant(*kind, bytes, *n_rows, n_cols)?;
-            // Only leaf (Q4K / Q6K) parts are valid; nested Fused isn't.
-            if matches!(store, MetalQuantStore::Fused { .. }) {
-                return Err(FerrumError::model(
-                    "Metal load_quant_fused: nested Fused not supported".to_string(),
-                ));
-            }
-            total_rows += n_rows;
-            sub_stores.push(store);
-        }
-        Ok(MetalQuantStore::Fused {
-            parts: sub_stores,
-            total_rows,
-            n_cols,
-        })
-    }
-
-    fn gemm_quant(
-        ctx: &mut Self::Context,
-        a: &Self::Buffer,
-        weight: &Self::QuantStore,
-        out: &mut Self::Buffer,
-        m: usize,
-    ) -> Result<()> {
-        // Fused path: row-concatenation of mixed-quant parts (used for
-        // Qwen3 qkv_proj where q+k are Q4_K but v is Q6_K). For m=1
-        // dispatch each part with the right output offset; for m>1
-        // currently bail (prefill of mixed-fused matmuls is rare and
-        // would need a strided per-row inner loop).
-        if let MetalQuantStore::Fused {
-            parts,
-            total_rows,
-            n_cols,
-        } = weight
-        {
-            if m != 1 {
-                // **Fused mul_mm path** for prefill. Each part dispatches
-                // one mul_mm into a [m, part_rows] slice of the
-                // [m, total_rows] fused output via the strided variant
-                // (kernel uses `strideC = total_rows`, write width = part_rows,
-                // dst pre-offset to part column). Replaces the previous
-                // m × per-part gemv loop which scaled linearly with prompt
-                // length and was the dominant remaining prefill bottleneck
-                // on Qwen3 (mixed Q4+Q6 qkv).
-                let a_buf = a.expect_f32("gemm_quant a (fused)");
-                let out_buf = out.expect_f32_mut("gemm_quant out (fused)");
-                let enc = ctx.compute_encoder();
-                let mut col_off = 0usize;
-                for part in parts {
-                    let part_rows = part.n_rows();
-                    dispatch_part_gemm(
-                        enc,
-                        a_buf,
-                        part,
-                        out_buf,
-                        col_off,
-                        m,
-                        part_rows,
-                        *total_rows,
-                        *n_cols,
-                    )?;
-                    col_off += part_rows;
-                }
-                return Ok(());
-            }
-            // m == 1 — single output row of length total_rows.
-            let a_buf = a.expect_f32("gemm_quant a (fused m=1)");
-            let out_buf = out.expect_f32_mut("gemm_quant out (fused m=1)");
-            let enc = ctx.compute_encoder();
-            let mut row_off_elems = 0usize;
-            for part in parts {
-                let part_rows = part.n_rows();
-                let c_off = (row_off_elems * 4) as u64;
-                dispatch_part_gemv_offset(enc, a_buf, 0, part, out_buf, c_off, *n_cols)?;
-                row_off_elems += part_rows;
-            }
-            return Ok(());
-        }
-
-        // Borrow checker: `cmd` / `compute_encoder` need `&mut ctx` while
-        // we hold a borrow into `weight` for `blocks`. Snapshot the
-        // primitive fields out of `weight` first; `blocks` is a `Buffer`
-        // ref that is independent of ctx.
-        let (blocks, blocks_off, n_rows, n_cols, n_blocks, is_q6k) = match weight {
-            MetalQuantStore::Q4K {
-                blocks,
-                byte_offset,
-                n_rows,
-                n_cols,
-                n_blocks,
-            } => (blocks, *byte_offset, *n_rows, *n_cols, *n_blocks, false),
-            MetalQuantStore::Q6K {
-                blocks,
-                byte_offset,
-                n_rows,
-                n_cols,
-                n_blocks,
-            } => (blocks, *byte_offset, *n_rows, *n_cols, *n_blocks, true),
-            MetalQuantStore::Fused { .. } => unreachable!("handled above"),
-            MetalQuantStore::Q4KExperts { .. } | MetalQuantStore::Q6KExperts { .. } => {
-                return Err(FerrumError::model(
-                    "gemm_quant: ExpertsStacked must be dispatched via gemv_moe_id".to_string(),
-                ));
-            }
-        };
-
-        let _t0 = if debug_per_call_flush() {
-            Some(std::time::Instant::now())
-        } else {
-            None
-        };
-
-        let a_buf = a.expect_f32("gemm_quant a");
-        let out_buf = out.expect_f32_mut("gemm_quant out");
-
-        if m == 1 {
-            // **Fused path** for decode (m=1): one kernel reads the
-            // Q4_K / Q6_K super-blocks, decodes them inline, and reduces
-            // against `A`. No transient fp16 buffer materialised.
-            //
-            // All variants use N_R0=2, N_SG=2 layout from llama.cpp:
-            // 64 threads/threadgroup, 4 output rows/threadgroup. Requires
-            // N divisible by 4. Q6_K has no v1 fallback yet — Qwen3 /
-            // Llama always satisfy the constraint, so we just panic if
-            // not.
-            let enc = ctx.compute_encoder();
-            if is_q6k {
-                if n_rows % 4 != 0 {
-                    return Err(FerrumError::model(format!(
-                        "gemm_quant Q6K: n_rows={n_rows} not divisible by 4"
-                    )));
-                }
-                crate::q6_k_gemv::dispatch_gemv_q6k_v2_on_encoder(
-                    &st().pipes.device,
-                    enc,
-                    a_buf,
-                    blocks,
-                    blocks_off,
-                    out_buf,
-                    n_rows,
-                    n_cols,
-                );
-            } else if n_rows % 4 == 0 {
-                crate::q4_k_gemv_v2::dispatch_gemv_q4k_v2_on_encoder(
-                    &st().pipes.device,
-                    enc,
-                    a_buf,
-                    blocks,
-                    blocks_off,
-                    out_buf,
-                    n_rows,
-                    n_cols,
-                );
-            } else {
-                crate::q4_k_gemv::dispatch_gemv_q4k_on_encoder(
-                    &st().pipes.device,
-                    enc,
-                    a_buf,
-                    blocks,
-                    blocks_off,
-                    out_buf,
-                    n_rows,
-                    n_cols,
-                );
-            }
-        } else if is_q6k {
-            // **Q6_K m>1 fused mul_mm path** — ported from llama.cpp's
-            // `kernel_mul_mm_q6_K_f32`. Same 64×32 simdgroup-matmul
-            // tile + inline dequant as the Q4_K version. Replaces the
-            // prior per-row gemv loop which scaled linearly with m
-            // and was the dominant prefill bottleneck on Q4_K_M models
-            // where down_proj / lm_head live as Q6_K.
-            let enc = ctx.compute_encoder();
-            crate::q6_k_gemm::dispatch_gemm_q6k_on_encoder(
-                &st().pipes.device,
-                enc,
-                a_buf,
-                blocks,
-                blocks_off,
-                out_buf,
-                m,
-                n_rows,
-                n_cols,
-            );
-        } else {
-            // **Fused mul_mm path** for prefill (m > 1) Q4_K — ported
-            // from llama.cpp's `kernel_mul_mm_q4_K_f32`. Inlines Q4_K
-            // dequant into the threadgroup-memory load and uses
-            // `simdgroup_half8x8` matmul, eliminating both the fp16
-            // transient buffer (~2× memory traffic) and the scalar
-            // gemm_v2_f16w inner loop.
-            let enc = ctx.compute_encoder();
-            crate::q4_k_gemm::dispatch_gemm_q4k_on_encoder(
-                &st().pipes.device,
-                enc,
-                a_buf,
-                blocks,
-                blocks_off,
-                out_buf,
-                m,
-                n_rows,
-                n_cols,
-            );
-            let _ = n_blocks; // not consumed by mul_mm path; kept for the load-time block accounting
-        }
-
-        // Optional per-call timing: commit + wait the cmd buffer right
-        // here so we measure the GPU work for *this* matmul. Off by
-        // default (would serialize the whole pipeline).
-        if let Some(t0) = _t0 {
-            ctx.flush();
-            let elapsed_us = t0.elapsed().as_micros();
-            QUANT_GEMM_TIME_US.fetch_add(elapsed_us as u64, std::sync::atomic::Ordering::Relaxed);
-            QUANT_GEMM_CALLS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-            QUANT_GEMM_LAST_M.store(m as u64, std::sync::atomic::Ordering::Relaxed);
-            QUANT_GEMM_LAST_N.store(n_rows as u64, std::sync::atomic::Ordering::Relaxed);
-            QUANT_GEMM_LAST_K.store(n_cols as u64, std::sync::atomic::Ordering::Relaxed);
-            if QUANT_GEMM_CALLS.load(std::sync::atomic::Ordering::Relaxed) <= 16 {
-                eprintln!(
-                    "[gemm_quant] m={} n={} k={} took {} us",
-                    m, n_rows, n_cols, elapsed_us
-                );
-            }
-        }
-        Ok(())
     }
 
     // ── GEMM — dispatches on B-weight dtype ──────────────────────────
@@ -2666,3 +1930,734 @@ impl crate::backend::BackendGraph for MetalBackend {}
 
 // Metal has no multi-GPU collectives; inherit BackendCollective single-rank defaults.
 impl crate::backend::BackendCollective for MetalBackend {}
+
+// Metal does not ship Marlin INT4 kernels; inherit unsupported defaults.
+impl crate::backend::BackendQuantMarlin for MetalBackend {}
+
+impl crate::backend::BackendQuantGguf for MetalBackend {
+    fn load_quant(
+        kind: super::GgufQuantType,
+        bytes: &[u8],
+        n_rows: usize,
+        n_cols: usize,
+    ) -> Result<Self::QuantStore> {
+        use super::GgufQuantType;
+        const QK_K: usize = 256;
+        match kind {
+            GgufQuantType::Q4K => {
+                const BLOCK_BYTES: usize = 144;
+                let total_elems = n_rows * n_cols;
+                if total_elems % QK_K != 0 {
+                    return Err(FerrumError::model(format!(
+                        "load_quant Q4K: elements {total_elems} not multiple of {QK_K}"
+                    )));
+                }
+                let n_blocks = total_elems / QK_K;
+                let expected = n_blocks * BLOCK_BYTES;
+                if bytes.len() != expected {
+                    return Err(FerrumError::model(format!(
+                        "load_quant Q4K: bytes {} != expected {} ({n_blocks} blocks)",
+                        bytes.len(),
+                        expected
+                    )));
+                }
+                let (blocks, byte_offset) = buffer_for_quant_bytes(bytes);
+                Ok(MetalQuantStore::Q4K {
+                    blocks,
+                    byte_offset,
+                    n_rows,
+                    n_cols,
+                    n_blocks,
+                })
+            }
+            GgufQuantType::Q6K => {
+                const BLOCK_BYTES: usize = crate::q6_k_gemv::Q6_K_BLOCK_BYTES; // 210
+                let total_elems = n_rows * n_cols;
+                if total_elems % QK_K != 0 {
+                    return Err(FerrumError::model(format!(
+                        "load_quant Q6K: elements {total_elems} not multiple of {QK_K}"
+                    )));
+                }
+                let n_blocks = total_elems / QK_K;
+                let expected = n_blocks * BLOCK_BYTES;
+                if bytes.len() != expected {
+                    return Err(FerrumError::model(format!(
+                        "load_quant Q6K: bytes {} != expected {} ({n_blocks} blocks)",
+                        bytes.len(),
+                        expected
+                    )));
+                }
+                let (blocks, byte_offset) = buffer_for_quant_bytes(bytes);
+                Ok(MetalQuantStore::Q6K {
+                    blocks,
+                    byte_offset,
+                    n_rows,
+                    n_cols,
+                    n_blocks,
+                })
+            }
+            other => Err(FerrumError::unsupported(format!(
+                "Metal load_quant: {other:?} not yet implemented"
+            ))),
+        }
+    }
+    fn load_quant_experts(
+        kind: super::GgufQuantType,
+        bytes: &[u8],
+        num_experts: usize,
+        n_rows: usize,
+        n_cols: usize,
+    ) -> Result<Self::QuantStore> {
+        use super::GgufQuantType;
+        match kind {
+            GgufQuantType::Q4K => load_q4k_experts(bytes, num_experts, n_rows, n_cols),
+            GgufQuantType::Q6K => load_q6k_experts(bytes, num_experts, n_rows, n_cols),
+            other => Err(FerrumError::unsupported(format!(
+                "Metal load_quant_experts: {other:?} not implemented (only Q4K / Q6K)"
+            ))),
+        }
+    }
+    fn gemv_quant_moe_id(
+        ctx: &mut Self::Context,
+        a: &Self::Buffer,
+        weight: &Self::QuantStore,
+        ids: &Self::Buffer,
+        out: &mut Self::Buffer,
+        n_selected: usize,
+        src1_stride: usize,
+    ) -> Result<()> {
+        let a_buf = a.expect_f32("gemv_quant_moe_id a");
+        let ids_buf = &ids.raw;
+        let out_buf = out.expect_f32_mut("gemv_quant_moe_id out");
+        let enc = ctx.compute_encoder();
+        dispatch_gemv_moe_id(
+            enc,
+            a_buf,
+            weight,
+            ids_buf,
+            out_buf,
+            n_selected,
+            src1_stride,
+        )
+    }
+    fn gemv_quant_moe_id_gate_up_silu_batched(
+        ctx: &mut Self::Context,
+        a: &Self::Buffer,
+        gate_w: &Self::QuantStore,
+        up_w: &Self::QuantStore,
+        ids: &Self::Buffer,
+        silu_out: &mut Self::Buffer,
+        m: usize,
+        top_k: usize,
+        src1_outer_stride: usize,
+        src1_inner_stride: usize,
+    ) -> Result<()> {
+        let (gate_blocks, gate_byte_offset, gate_n_rows, gate_n_cols) = match gate_w {
+            MetalQuantStore::Q4KExperts {
+                blocks,
+                byte_offset,
+                n_rows,
+                n_cols,
+                ..
+            } => (blocks, *byte_offset, *n_rows, *n_cols),
+            _ => {
+                return Err(FerrumError::model(
+                    "gemv_quant_moe_id_gate_up_silu_batched: gate_w must be Q4KExperts".to_string(),
+                ));
+            }
+        };
+        let (up_blocks, up_byte_offset, up_n_rows, up_n_cols) = match up_w {
+            MetalQuantStore::Q4KExperts {
+                blocks,
+                byte_offset,
+                n_rows,
+                n_cols,
+                ..
+            } => (blocks, *byte_offset, *n_rows, *n_cols),
+            _ => {
+                return Err(FerrumError::model(
+                    "gemv_quant_moe_id_gate_up_silu_batched: up_w must be Q4KExperts".to_string(),
+                ));
+            }
+        };
+        if gate_n_rows != up_n_rows || gate_n_cols != up_n_cols {
+            return Err(FerrumError::model(format!(
+                "gemv_quant_moe_id_gate_up_silu_batched: gate/up shape mismatch — \
+                 gate=({gate_n_rows}, {gate_n_cols}) up=({up_n_rows}, {up_n_cols})"
+            )));
+        }
+
+        let a_buf = a.expect_f32("gemv_quant_moe_id_gate_up_silu_batched a");
+        let ids_buf = &ids.raw;
+        let out_buf = silu_out.expect_f32_mut("gemv_quant_moe_id_gate_up_silu_batched silu_out");
+        let enc = ctx.compute_encoder();
+        crate::q4_k_moe_id_gate_up_silu_batched::dispatch_gemv_q4k_moe_id_gate_up_silu_batched_on_encoder(
+            &st().pipes.device,
+            enc,
+            a_buf,
+            gate_blocks,
+            gate_byte_offset,
+            up_blocks,
+            up_byte_offset,
+            ids_buf,
+            out_buf,
+            gate_n_rows,
+            gate_n_cols,
+            m,
+            top_k,
+            src1_outer_stride,
+            src1_inner_stride,
+        );
+        Ok(())
+    }
+    fn gemv_quant_moe_id_batched(
+        ctx: &mut Self::Context,
+        a: &Self::Buffer,
+        weight: &Self::QuantStore,
+        ids: &Self::Buffer,
+        out: &mut Self::Buffer,
+        m: usize,
+        top_k: usize,
+        src1_outer_stride: usize,
+        src1_inner_stride: usize,
+    ) -> Result<()> {
+        let a_buf = a.expect_f32("gemv_quant_moe_id_batched a");
+        let ids_buf = &ids.raw;
+        let out_buf = out.expect_f32_mut("gemv_quant_moe_id_batched out");
+        let enc = ctx.compute_encoder();
+        match weight {
+            MetalQuantStore::Q4KExperts {
+                blocks,
+                byte_offset,
+                n_rows,
+                n_cols,
+                ..
+            } => {
+                crate::q4_k_moe_id_gemv_batched::dispatch_gemv_q4k_moe_id_batched_on_encoder(
+                    &st().pipes.device,
+                    enc,
+                    a_buf,
+                    blocks,
+                    *byte_offset,
+                    ids_buf,
+                    out_buf,
+                    *n_rows,
+                    *n_cols,
+                    m,
+                    top_k,
+                    src1_outer_stride,
+                    src1_inner_stride,
+                );
+                Ok(())
+            }
+            MetalQuantStore::Q6KExperts {
+                blocks,
+                byte_offset,
+                n_rows,
+                n_cols,
+                ..
+            } => {
+                crate::q6_k_moe_id_gemv_batched::dispatch_gemv_q6k_moe_id_batched_on_encoder(
+                    &st().pipes.device,
+                    enc,
+                    a_buf,
+                    blocks,
+                    *byte_offset,
+                    ids_buf,
+                    out_buf,
+                    *n_rows,
+                    *n_cols,
+                    m,
+                    top_k,
+                    src1_outer_stride,
+                    src1_inner_stride,
+                );
+                Ok(())
+            }
+            _ => Err(FerrumError::model(
+                "gemv_quant_moe_id_batched: weight must be Q4KExperts or Q6KExperts".to_string(),
+            )),
+        }
+    }
+    fn gemv_quant_moe_id_offset(
+        ctx: &mut Self::Context,
+        a: &Self::Buffer,
+        a_offset: usize,
+        weight: &Self::QuantStore,
+        ids: &Self::Buffer,
+        ids_offset: usize,
+        out: &mut Self::Buffer,
+        n_selected: usize,
+        src1_stride: usize,
+    ) -> Result<()> {
+        let a_buf = a.expect_f32("gemv_quant_moe_id_offset a");
+        let ids_buf = &ids.raw;
+        let out_buf = out.expect_f32_mut("gemv_quant_moe_id_offset out");
+        let enc = ctx.compute_encoder();
+        // a_offset is in floats (a is f32), ids_offset in i32s (ids is i32).
+        // Both kernels read with 4-byte stride, so byte offset = elem * 4.
+        let a_byte_offset = (a_offset * std::mem::size_of::<f32>()) as u64;
+        let ids_byte_offset = (ids_offset * std::mem::size_of::<i32>()) as u64;
+        dispatch_gemv_moe_id_offset(
+            enc,
+            a_buf,
+            a_byte_offset,
+            weight,
+            ids_buf,
+            ids_byte_offset,
+            out_buf,
+            n_selected,
+            src1_stride,
+        )
+    }
+    fn gemm_quant_moe_id(
+        ctx: &mut Self::Context,
+        a: &Self::Buffer,
+        weight: &Self::QuantStore,
+        ids: &Self::Buffer,
+        tpe: &Self::Buffer,
+        out: &mut Self::Buffer,
+        ne11: usize,
+        top_k: usize,
+        max_per_expert: usize,
+        batch: usize,
+    ) -> Result<()> {
+        let a_buf = a.expect_f32("gemm_quant_moe_id a");
+        let ids_buf = &ids.raw;
+        let tpe_buf = &tpe.raw;
+        let out_buf = out.expect_f32_mut("gemm_quant_moe_id out");
+        let enc = ctx.compute_encoder();
+        match weight {
+            MetalQuantStore::Q4KExperts {
+                blocks,
+                byte_offset,
+                num_experts,
+                n_rows,
+                n_cols,
+            } => {
+                crate::q4_k_moe_id_gemm::dispatch_gemm_q4k_moe_id_on_encoder(
+                    &st().pipes.device,
+                    enc,
+                    blocks,
+                    *byte_offset,
+                    a_buf,
+                    ids_buf,
+                    tpe_buf,
+                    out_buf,
+                    *num_experts,
+                    *n_rows,
+                    *n_cols,
+                    ne11,
+                    top_k,
+                    max_per_expert,
+                    batch,
+                );
+                Ok(())
+            }
+            MetalQuantStore::Q6KExperts {
+                blocks,
+                byte_offset,
+                num_experts,
+                n_rows,
+                n_cols,
+            } => {
+                crate::q6_k_moe_id_gemm::dispatch_gemm_q6k_moe_id_on_encoder(
+                    &st().pipes.device,
+                    enc,
+                    blocks,
+                    *byte_offset,
+                    a_buf,
+                    ids_buf,
+                    tpe_buf,
+                    out_buf,
+                    *num_experts,
+                    *n_rows,
+                    *n_cols,
+                    ne11,
+                    top_k,
+                    max_per_expert,
+                    batch,
+                );
+                Ok(())
+            }
+            _ => Err(FerrumError::model(
+                "gemm_quant_moe_id: weight must be Q4KExperts or Q6KExperts".to_string(),
+            )),
+        }
+    }
+    fn gemm_quant_moe_id_indirect(
+        ctx: &mut Self::Context,
+        a: &Self::Buffer,
+        weight: &Self::QuantStore,
+        ids: &Self::Buffer,
+        tpe: &Self::Buffer,
+        out: &mut Self::Buffer,
+        args_buf: &Self::Buffer,
+        ne11: usize,
+        top_k: usize,
+        max_per_expert: usize,
+        batch: usize,
+    ) -> Result<()> {
+        let a_buf = a.expect_f32("gemm_quant_moe_id_indirect a");
+        let ids_buf = &ids.raw;
+        let tpe_buf = &tpe.raw;
+        let out_buf = out.expect_f32_mut("gemm_quant_moe_id_indirect out");
+        let args = &args_buf.raw;
+        let enc = ctx.compute_encoder();
+        match weight {
+            MetalQuantStore::Q4KExperts {
+                blocks,
+                byte_offset,
+                num_experts,
+                n_rows,
+                n_cols,
+            } => {
+                crate::q4_k_moe_id_gemm::dispatch_gemm_q4k_moe_id_indirect_on_encoder(
+                    &st().pipes.device,
+                    enc,
+                    blocks,
+                    *byte_offset,
+                    a_buf,
+                    ids_buf,
+                    tpe_buf,
+                    out_buf,
+                    args,
+                    *num_experts,
+                    *n_rows,
+                    *n_cols,
+                    ne11,
+                    top_k,
+                    max_per_expert,
+                    batch,
+                );
+                Ok(())
+            }
+            MetalQuantStore::Q6KExperts {
+                blocks,
+                byte_offset,
+                num_experts,
+                n_rows,
+                n_cols,
+            } => {
+                crate::q6_k_moe_id_gemm::dispatch_gemm_q6k_moe_id_indirect_on_encoder(
+                    &st().pipes.device,
+                    enc,
+                    blocks,
+                    *byte_offset,
+                    a_buf,
+                    ids_buf,
+                    tpe_buf,
+                    out_buf,
+                    args,
+                    *num_experts,
+                    *n_rows,
+                    *n_cols,
+                    ne11,
+                    top_k,
+                    max_per_expert,
+                    batch,
+                );
+                Ok(())
+            }
+            _ => Err(FerrumError::model(
+                "gemm_quant_moe_id_indirect: weight must be Q4KExperts or Q6KExperts".to_string(),
+            )),
+        }
+    }
+    fn gemv_quant_moe_id_gate_up_silu(
+        ctx: &mut Self::Context,
+        a: &Self::Buffer,
+        gate_w: &Self::QuantStore,
+        up_w: &Self::QuantStore,
+        ids: &Self::Buffer,
+        silu_out: &mut Self::Buffer,
+        n_selected: usize,
+    ) -> Result<()> {
+        let (gate_blocks, gate_byte_offset, gate_n_rows, gate_n_cols) = match gate_w {
+            MetalQuantStore::Q4KExperts {
+                blocks,
+                byte_offset,
+                n_rows,
+                n_cols,
+                ..
+            } => (blocks, *byte_offset, *n_rows, *n_cols),
+            _ => {
+                return Err(FerrumError::model(
+                    "gemv_quant_moe_id_gate_up_silu: gate_w must be Q4KExperts".to_string(),
+                ));
+            }
+        };
+        let (up_blocks, up_byte_offset, up_n_rows, up_n_cols) = match up_w {
+            MetalQuantStore::Q4KExperts {
+                blocks,
+                byte_offset,
+                n_rows,
+                n_cols,
+                ..
+            } => (blocks, *byte_offset, *n_rows, *n_cols),
+            _ => {
+                return Err(FerrumError::model(
+                    "gemv_quant_moe_id_gate_up_silu: up_w must be Q4KExperts".to_string(),
+                ));
+            }
+        };
+        if gate_n_rows != up_n_rows || gate_n_cols != up_n_cols {
+            return Err(FerrumError::model(format!(
+                "gemv_quant_moe_id_gate_up_silu: gate/up shape mismatch — \
+                 gate=({gate_n_rows}, {gate_n_cols}) up=({up_n_rows}, {up_n_cols})"
+            )));
+        }
+
+        let a_buf = a.expect_f32("gemv_quant_moe_id_gate_up_silu a");
+        let ids_buf = &ids.raw;
+        let out_buf = silu_out.expect_f32_mut("gemv_quant_moe_id_gate_up_silu silu_out");
+        let enc = ctx.compute_encoder();
+        crate::q4_k_moe_id_gate_up_silu::dispatch_gemv_q4k_moe_id_gate_up_silu_on_encoder(
+            &st().pipes.device,
+            enc,
+            a_buf,
+            gate_blocks,
+            gate_byte_offset,
+            up_blocks,
+            up_byte_offset,
+            ids_buf,
+            out_buf,
+            gate_n_rows,
+            gate_n_cols,
+            n_selected,
+        );
+        Ok(())
+    }
+    fn load_quant_fused(
+        parts: &[(super::GgufQuantType, &[u8], usize)],
+        n_cols: usize,
+    ) -> Result<Self::QuantStore> {
+        let mut sub_stores: Vec<MetalQuantStore> = Vec::with_capacity(parts.len());
+        let mut total_rows = 0;
+        for (kind, bytes, n_rows) in parts {
+            let store = Self::load_quant(*kind, bytes, *n_rows, n_cols)?;
+            // Only leaf (Q4K / Q6K) parts are valid; nested Fused isn't.
+            if matches!(store, MetalQuantStore::Fused { .. }) {
+                return Err(FerrumError::model(
+                    "Metal load_quant_fused: nested Fused not supported".to_string(),
+                ));
+            }
+            total_rows += n_rows;
+            sub_stores.push(store);
+        }
+        Ok(MetalQuantStore::Fused {
+            parts: sub_stores,
+            total_rows,
+            n_cols,
+        })
+    }
+    fn gemm_quant(
+        ctx: &mut Self::Context,
+        a: &Self::Buffer,
+        weight: &Self::QuantStore,
+        out: &mut Self::Buffer,
+        m: usize,
+    ) -> Result<()> {
+        // Fused path: row-concatenation of mixed-quant parts (used for
+        // Qwen3 qkv_proj where q+k are Q4_K but v is Q6_K). For m=1
+        // dispatch each part with the right output offset; for m>1
+        // currently bail (prefill of mixed-fused matmuls is rare and
+        // would need a strided per-row inner loop).
+        if let MetalQuantStore::Fused {
+            parts,
+            total_rows,
+            n_cols,
+        } = weight
+        {
+            if m != 1 {
+                // **Fused mul_mm path** for prefill. Each part dispatches
+                // one mul_mm into a [m, part_rows] slice of the
+                // [m, total_rows] fused output via the strided variant
+                // (kernel uses `strideC = total_rows`, write width = part_rows,
+                // dst pre-offset to part column). Replaces the previous
+                // m × per-part gemv loop which scaled linearly with prompt
+                // length and was the dominant remaining prefill bottleneck
+                // on Qwen3 (mixed Q4+Q6 qkv).
+                let a_buf = a.expect_f32("gemm_quant a (fused)");
+                let out_buf = out.expect_f32_mut("gemm_quant out (fused)");
+                let enc = ctx.compute_encoder();
+                let mut col_off = 0usize;
+                for part in parts {
+                    let part_rows = part.n_rows();
+                    dispatch_part_gemm(
+                        enc,
+                        a_buf,
+                        part,
+                        out_buf,
+                        col_off,
+                        m,
+                        part_rows,
+                        *total_rows,
+                        *n_cols,
+                    )?;
+                    col_off += part_rows;
+                }
+                return Ok(());
+            }
+            // m == 1 — single output row of length total_rows.
+            let a_buf = a.expect_f32("gemm_quant a (fused m=1)");
+            let out_buf = out.expect_f32_mut("gemm_quant out (fused m=1)");
+            let enc = ctx.compute_encoder();
+            let mut row_off_elems = 0usize;
+            for part in parts {
+                let part_rows = part.n_rows();
+                let c_off = (row_off_elems * 4) as u64;
+                dispatch_part_gemv_offset(enc, a_buf, 0, part, out_buf, c_off, *n_cols)?;
+                row_off_elems += part_rows;
+            }
+            return Ok(());
+        }
+
+        // Borrow checker: `cmd` / `compute_encoder` need `&mut ctx` while
+        // we hold a borrow into `weight` for `blocks`. Snapshot the
+        // primitive fields out of `weight` first; `blocks` is a `Buffer`
+        // ref that is independent of ctx.
+        let (blocks, blocks_off, n_rows, n_cols, n_blocks, is_q6k) = match weight {
+            MetalQuantStore::Q4K {
+                blocks,
+                byte_offset,
+                n_rows,
+                n_cols,
+                n_blocks,
+            } => (blocks, *byte_offset, *n_rows, *n_cols, *n_blocks, false),
+            MetalQuantStore::Q6K {
+                blocks,
+                byte_offset,
+                n_rows,
+                n_cols,
+                n_blocks,
+            } => (blocks, *byte_offset, *n_rows, *n_cols, *n_blocks, true),
+            MetalQuantStore::Fused { .. } => unreachable!("handled above"),
+            MetalQuantStore::Q4KExperts { .. } | MetalQuantStore::Q6KExperts { .. } => {
+                return Err(FerrumError::model(
+                    "gemm_quant: ExpertsStacked must be dispatched via gemv_moe_id".to_string(),
+                ));
+            }
+        };
+
+        let _t0 = if debug_per_call_flush() {
+            Some(std::time::Instant::now())
+        } else {
+            None
+        };
+
+        let a_buf = a.expect_f32("gemm_quant a");
+        let out_buf = out.expect_f32_mut("gemm_quant out");
+
+        if m == 1 {
+            // **Fused path** for decode (m=1): one kernel reads the
+            // Q4_K / Q6_K super-blocks, decodes them inline, and reduces
+            // against `A`. No transient fp16 buffer materialised.
+            //
+            // All variants use N_R0=2, N_SG=2 layout from llama.cpp:
+            // 64 threads/threadgroup, 4 output rows/threadgroup. Requires
+            // N divisible by 4. Q6_K has no v1 fallback yet — Qwen3 /
+            // Llama always satisfy the constraint, so we just panic if
+            // not.
+            let enc = ctx.compute_encoder();
+            if is_q6k {
+                if n_rows % 4 != 0 {
+                    return Err(FerrumError::model(format!(
+                        "gemm_quant Q6K: n_rows={n_rows} not divisible by 4"
+                    )));
+                }
+                crate::q6_k_gemv::dispatch_gemv_q6k_v2_on_encoder(
+                    &st().pipes.device,
+                    enc,
+                    a_buf,
+                    blocks,
+                    blocks_off,
+                    out_buf,
+                    n_rows,
+                    n_cols,
+                );
+            } else if n_rows % 4 == 0 {
+                crate::q4_k_gemv_v2::dispatch_gemv_q4k_v2_on_encoder(
+                    &st().pipes.device,
+                    enc,
+                    a_buf,
+                    blocks,
+                    blocks_off,
+                    out_buf,
+                    n_rows,
+                    n_cols,
+                );
+            } else {
+                crate::q4_k_gemv::dispatch_gemv_q4k_on_encoder(
+                    &st().pipes.device,
+                    enc,
+                    a_buf,
+                    blocks,
+                    blocks_off,
+                    out_buf,
+                    n_rows,
+                    n_cols,
+                );
+            }
+        } else if is_q6k {
+            // **Q6_K m>1 fused mul_mm path** — ported from llama.cpp's
+            // `kernel_mul_mm_q6_K_f32`. Same 64×32 simdgroup-matmul
+            // tile + inline dequant as the Q4_K version. Replaces the
+            // prior per-row gemv loop which scaled linearly with m
+            // and was the dominant prefill bottleneck on Q4_K_M models
+            // where down_proj / lm_head live as Q6_K.
+            let enc = ctx.compute_encoder();
+            crate::q6_k_gemm::dispatch_gemm_q6k_on_encoder(
+                &st().pipes.device,
+                enc,
+                a_buf,
+                blocks,
+                blocks_off,
+                out_buf,
+                m,
+                n_rows,
+                n_cols,
+            );
+        } else {
+            // **Fused mul_mm path** for prefill (m > 1) Q4_K — ported
+            // from llama.cpp's `kernel_mul_mm_q4_K_f32`. Inlines Q4_K
+            // dequant into the threadgroup-memory load and uses
+            // `simdgroup_half8x8` matmul, eliminating both the fp16
+            // transient buffer (~2× memory traffic) and the scalar
+            // gemm_v2_f16w inner loop.
+            let enc = ctx.compute_encoder();
+            crate::q4_k_gemm::dispatch_gemm_q4k_on_encoder(
+                &st().pipes.device,
+                enc,
+                a_buf,
+                blocks,
+                blocks_off,
+                out_buf,
+                m,
+                n_rows,
+                n_cols,
+            );
+            let _ = n_blocks; // not consumed by mul_mm path; kept for the load-time block accounting
+        }
+
+        // Optional per-call timing: commit + wait the cmd buffer right
+        // here so we measure the GPU work for *this* matmul. Off by
+        // default (would serialize the whole pipeline).
+        if let Some(t0) = _t0 {
+            ctx.flush();
+            let elapsed_us = t0.elapsed().as_micros();
+            QUANT_GEMM_TIME_US.fetch_add(elapsed_us as u64, std::sync::atomic::Ordering::Relaxed);
+            QUANT_GEMM_CALLS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            QUANT_GEMM_LAST_M.store(m as u64, std::sync::atomic::Ordering::Relaxed);
+            QUANT_GEMM_LAST_N.store(n_rows as u64, std::sync::atomic::Ordering::Relaxed);
+            QUANT_GEMM_LAST_K.store(n_cols as u64, std::sync::atomic::Ordering::Relaxed);
+            if QUANT_GEMM_CALLS.load(std::sync::atomic::Ordering::Relaxed) <= 16 {
+                eprintln!(
+                    "[gemm_quant] m={} n={} k={} took {} us",
+                    m, n_rows, n_cols, elapsed_us
+                );
+            }
+        }
+        Ok(())
+    }
+}

--- a/crates/ferrum-kernels/src/backend/traits.rs
+++ b/crates/ferrum-kernels/src/backend/traits.rs
@@ -259,156 +259,6 @@ pub trait Backend: Send + Sync + Sized + 'static {
     // holds whatever backend-specific format is fastest; caller code
     // (GptqLinear) is dtype-agnostic.
 
-    /// Repack raw GPTQ tensors into the backend's preferred format.
-    /// Called once per layer at model load time.
-    ///
-    /// Inputs are host-side slices (CPU memory) — the loader reads from
-    /// safetensors and hands them off; each backend uploads + repacks
-    /// per its own strategy. `bits` is typically 4; `group_size` is
-    /// typically 128.
-    #[allow(clippy::too_many_arguments)]
-    fn load_gptq(
-        _qweight: &[i32],
-        _scales: &[f32],
-        _qzeros: &[i32],
-        _g_idx: Option<&[i32]>,
-        _bits: u32,
-        _group_size: usize,
-        _k: usize,
-        _n: usize,
-    ) -> Result<Self::GptqStore> {
-        Err(FerrumError::unsupported(
-            "load_gptq not implemented for this backend",
-        ))
-    }
-
-    /// Load num_experts GPTQ weight tiles into ONE stacked store, with
-    /// the property that **each expert's packed bytes are contiguous**
-    /// in the resulting store. This is what the offset GEMM needs to
-    /// dispatch per expert via pointer offset alone.
-    ///
-    /// Why this is a separate API from `load_gptq` + post-hoc concat:
-    /// Marlin's repack permutes data in `[K-tile-row outer, N-tile inner]`
-    /// order. A single repack of `concat(all experts along N)` produces
-    /// a buffer where expert e's bytes are spread across K-tile-rows,
-    /// NOT contiguous. Per-expert repack-then-concat keeps each
-    /// expert's data in one contiguous block.
-    ///
-    /// `qweights[i] / scales[i] / qzeros[i]` are each expert's raw GPTQ
-    /// tensors. All share the same K + group_size + bits + g_idx.
-    ///
-    /// Default returns Err(unsupported); override on backends with a
-    /// per-expert MoE GPTQ path.
-    #[allow(clippy::too_many_arguments)]
-    fn load_gptq_stacked(
-        _qweights: &[&[i32]],
-        _scales: &[&[f32]],
-        _qzeros: &[&[i32]],
-        _g_idx: Option<&[i32]>,
-        _bits: u32,
-        _group_size: usize,
-        _k: usize,
-        _n_per_expert: usize,
-    ) -> Result<Self::GptqStore> {
-        Err(FerrumError::unsupported(
-            "load_gptq_stacked not implemented for this backend",
-        ))
-    }
-
-    /// GEMM with pre-loaded GPTQ weights.
-    /// `out[m, n] = a[m, k] @ dequant(weight)^T`
-    fn gemm_gptq(
-        _ctx: &mut Self::Context,
-        _a: &Self::Buffer,
-        _weight: &Self::GptqStore,
-        _out: &mut Self::Buffer,
-        _m: usize,
-    ) -> Result<()> {
-        Err(FerrumError::unsupported(
-            "gemm_gptq not implemented for this backend",
-        ))
-    }
-
-    /// GEMM on a column-slice of a stacked GPTQ store. Used for MoE
-    /// expert dispatch where one big stacked weight tile holds all
-    /// experts' weights along N; per-expert calls process columns
-    /// `[expert_offset .. expert_offset + expert_n)` only.
-    ///
-    /// Output is written to `out[m, expert_n]` (NOT the full stacked N).
-    /// Caller is responsible for sizing `out` correctly.
-    ///
-    /// `expert_offset` and `expert_n` MUST be multiples of the backend's
-    /// natural N tile size (Marlin: 64). Default returns Err(unsupported).
-    fn gemm_gptq_with_offset(
-        _ctx: &mut Self::Context,
-        _a: &Self::Buffer,
-        _weight: &Self::GptqStore,
-        _expert_offset: usize,
-        _expert_n: usize,
-        _out: &mut Self::Buffer,
-        _m: usize,
-    ) -> Result<()> {
-        Err(FerrumError::unsupported(
-            "gemm_gptq_with_offset not implemented for this backend",
-        ))
-    }
-
-    /// Bulk-zero the per-expert Marlin workspace mutex slots for a
-    /// stacked GptqStore. Call ONCE before a batch of
-    /// `gemm_gptq_with_offset_strided_no_ws_zero` calls — saves the
-    /// per-call cuMemsetD32Async (one launch each → one launch total).
-    ///
-    /// At c=32 with 128 active experts × 2 (gate_up + down) × 48 layers:
-    /// 12 288 memset launches/token. Bulk-zeroing brings that to 96.
-    fn marlin_zero_stacked_workspace(
-        _ctx: &mut Self::Context,
-        _weight: &Self::GptqStore,
-    ) -> Result<()> {
-        Err(FerrumError::unsupported(
-            "marlin_zero_stacked_workspace not implemented for this backend",
-        ))
-    }
-
-    /// Batched per-expert offset GEMM dispatch — runs N concurrent
-    /// Marlin calls across a stream pool to amortize launch overhead
-    /// and overlap small-m kernels that under-utilize SMs individually.
-    ///
-    /// `dispatches[i]`: (expert_idx, in_row_offset, out_row_offset, m).
-    /// All calls share the same `weight`, `input`, `output`, `n_per_expert`,
-    /// `k`. Caller is responsible for bulk-zeroing workspace before this
-    /// call (use `marlin_zero_stacked_workspace`).
-    ///
-    /// Default: serial fallback that loops calling
-    /// `gemm_gptq_with_offset_strided`. CUDA backend overrides with
-    /// round-robin streams + sync-all at the end.
-    #[allow(clippy::too_many_arguments)]
-    fn moe_gemm_phase_batched(
-        ctx: &mut Self::Context,
-        input: &Self::Buffer,
-        weight: &Self::GptqStore,
-        dispatches: &[(usize, usize, usize, usize)],
-        n_per_expert: usize,
-        output: &mut Self::Buffer,
-        k: usize,
-    ) -> Result<()> {
-        // Default impl: serial fallback. CUDA overrides with multi-stream.
-        for (expert_idx, in_row_offset, out_row_offset, m) in dispatches {
-            Self::gemm_gptq_with_offset_strided(
-                ctx,
-                input,
-                *in_row_offset,
-                weight,
-                expert_idx * n_per_expert,
-                n_per_expert,
-                output,
-                *out_row_offset,
-                *m,
-                k,
-            )?;
-        }
-        Ok(())
-    }
-
     /// Routing inputs for `moe_gemm_phase_vllm` — host-built i32 arrays
     /// uploaded once per layer (or per token, depending on caller cadence).
     /// Matches the shape contract of `moe_align_block_size` outputs but is
@@ -432,157 +282,6 @@ pub trait Backend: Send + Sync + Sized + 'static {
     fn zero_buffer(_ctx: &mut Self::Context, _buf: &mut Self::Buffer, _len: usize) -> Result<()> {
         Err(FerrumError::unsupported(
             "zero_buffer not implemented for this backend",
-        ))
-    }
-
-    /// vLLM marlin_moe_wna16 phase GEMM. Replaces the per-expert loop in
-    /// `moe_gemm_phase_batched` with a single fused launch that routes
-    /// per-block via `expert_ids`. Caller responsibilities:
-    ///
-    /// - `weight` was loaded via the vLLM stacked-Marlin path (i.e.
-    ///   `Self::load_gptq_stacked` invoked under `FERRUM_VLLM_MOE=1`).
-    ///   Feeding an IST-DASLab-format weight here yields silent garbage.
-    /// - `output` MUST be pre-zeroed (the kernel's atomic-add path does
-    ///   not self-zero the global tile).
-    /// - `sorted_token_ids` / `expert_ids` / `num_tokens_past_padded`
-    ///   come from `moe_align_block_size` or an equivalent host build.
-    /// - `prob_m` is the unique-token count (we feed pre-gathered rows
-    ///   with `top_k=1` so it equals `total_pairs`).
-    ///
-    /// Default: returns unsupported. CUDA overrides on `vllm-moe-marlin`.
-    #[allow(clippy::too_many_arguments)]
-    fn moe_gemm_phase_vllm(
-        _ctx: &mut Self::Context,
-        _input: &Self::Buffer,
-        _weight: &Self::GptqStore,
-        _sorted_token_ids: &Self::Buffer,
-        _expert_ids: &Self::Buffer,
-        _num_tokens_past_padded: &Self::Buffer,
-        _output: &mut Self::Buffer,
-        _prob_m: usize,
-        _n_per_expert: usize,
-        _k: usize,
-        _moe_block_size: usize,
-        _top_k: usize,
-    ) -> Result<()> {
-        Err(FerrumError::unsupported(
-            "moe_gemm_phase_vllm not implemented for this backend",
-        ))
-    }
-
-    /// Load GGUF k-quant weights into the backend's preferred format.
-    ///
-    /// `kind` discriminates Q4_K / Q5_K / Q6_K / Q8_0 etc. The CPU path
-    /// typically eager-dequants to fp32; the Metal path keeps raw block
-    /// bytes in MTLBuffer and dequants per matmul into a transient fp16
-    /// buffer. Adding a new k-quant flavour is a matched pair of
-    /// `QuantStore` variant + `match` arm, not a new trait method.
-    ///
-    /// `bytes`: contiguous on-disk payload — `n_blocks × block_size`.
-    /// `n_rows`: out_features. `n_cols`: in_features. The block count
-    /// is derived per-kind from these dims.
-    fn load_quant(
-        _kind: GgufQuantType,
-        _bytes: &[u8],
-        _n_rows: usize,
-        _n_cols: usize,
-    ) -> Result<Self::QuantStore> {
-        Err(FerrumError::unsupported(
-            "load_quant not implemented for this backend",
-        ))
-    }
-
-    /// Build a fused `QuantStore` from multiple `(kind, bytes, n_rows)`
-    /// parts that share `n_cols`. Used by `GgufLoader::load_fused` when
-    /// parts have heterogeneous quant kinds (e.g. Qwen3 qkv_proj where
-    /// q+k are Q4_K but v is Q6_K) — byte-concatenation isn't possible,
-    /// so each part stays as its own QuantStore and the gemm dispatches
-    /// one matvec per part with output offsets.
-    ///
-    /// Default: not supported. Backends that have a `Fused`-like variant
-    /// override.
-    fn load_quant_fused(
-        _parts: &[(GgufQuantType, &[u8], usize)],
-        _n_cols: usize,
-    ) -> Result<Self::QuantStore> {
-        Err(FerrumError::unsupported(
-            "load_quant_fused not implemented for this backend",
-        ))
-    }
-
-    /// GEMM with k-quant weights. Mirrors `gemm` / `gemm_gptq` shape:
-    /// `out[m, n] = a[m, k] @ dequant(weight)^T`. The dispatch on the
-    /// quant flavour happens inside the backend's `QuantStore` enum.
-    fn gemm_quant(
-        _ctx: &mut Self::Context,
-        _a: &Self::Buffer,
-        _weight: &Self::QuantStore,
-        _out: &mut Self::Buffer,
-        _m: usize,
-    ) -> Result<()> {
-        Err(FerrumError::unsupported(
-            "gemm_quant not implemented for this backend",
-        ))
-    }
-
-    /// Build a stacked-experts `QuantStore` from a contiguous 3-D weight
-    /// payload `[num_experts, n_rows, n_cols/256]` super-blocks.
-    /// Used for the MoE indirect-dispatch fast path; backends without
-    /// such a kernel return `Err(unsupported)` and the model code falls
-    /// back to the per-expert loop.
-    ///
-    /// Default: not supported. Override on backends with batched MoE
-    /// kernels (e.g. Metal `gemv_q*kw_moe_id_f32`).
-    fn load_quant_experts(
-        _kind: GgufQuantType,
-        _bytes: &[u8],
-        _num_experts: usize,
-        _n_rows: usize,
-        _n_cols: usize,
-    ) -> Result<Self::QuantStore> {
-        Err(FerrumError::unsupported(
-            "load_quant_experts not implemented for this backend",
-        ))
-    }
-
-    /// MoE 2-D indirect-dispatch GEMM (prefill m > 1).
-    ///
-    /// Computes per (token, expert_slot) pair, batched across all
-    /// experts in one launch:
-    ///
-    ///   `out[token, slot, :] = a[token, slot_or_0, :] @ dequant(weight[expert(token, slot), :])^T`
-    ///
-    /// `ids[expert][slot] = pair_id` encodes `(token_idx, slot_within_token)`
-    /// so the kernel reads activations indirectly (src1 row for the
-    /// pair) and writes outputs directly to the natural
-    /// `[batch, top_k, M]` layout. `tpe[expert]` gives the count of
-    /// pairs assigned to each expert — threadgroups past `tpe[e]`
-    /// early-exit.
-    ///
-    /// `ne11` selects the src1 inner-batch shape:
-    /// - `1` for `gate` / `up` (broadcast — all slots read the same
-    ///   activation row per token).
-    /// - `top_k` for `down` (per-slot — each pair reads its own row in
-    ///   the upstream silu·gate output).
-    ///
-    /// Closes the prefill MoE gap: the per-token gemv loop becomes one
-    /// batched gemm where each expert's slab handles m ≈ batch·top_k /
-    /// num_experts pairs in parallel via simdgroup_half8x8 matmul.
-    #[allow(clippy::too_many_arguments)]
-    fn gemm_quant_moe_id(
-        _ctx: &mut Self::Context,
-        _a: &Self::Buffer,
-        _weight: &Self::QuantStore,
-        _ids: &Self::Buffer,
-        _tpe: &Self::Buffer,
-        _out: &mut Self::Buffer,
-        _ne11: usize,
-        _top_k: usize,
-        _max_per_expert: usize,
-        _batch: usize,
-    ) -> Result<()> {
-        Err(FerrumError::unsupported(
-            "gemm_quant_moe_id not implemented for this backend",
         ))
     }
 
@@ -710,33 +409,6 @@ pub trait Backend: Send + Sync + Sized + 'static {
         ))
     }
 
-    /// Indirect-dispatch variant of `gemm_quant_moe_id`.
-    ///
-    /// Identical inputs except the grid is read from `args_buf` (a 12-
-    /// byte u32 triple written by `compute_ids_tpe_gpu`) instead of
-    /// being computed from `max_per_expert`. `max_per_expert` is still
-    /// the kernel parameter used as the row stride for `ids` indexing
-    /// (= `batch * top_k`, worst case); only the dispatched grid
-    /// shrinks to cover `max(tpe[e])` columns.
-    #[allow(clippy::too_many_arguments)]
-    fn gemm_quant_moe_id_indirect(
-        _ctx: &mut Self::Context,
-        _src1: &Self::Buffer,
-        _weights: &Self::QuantStore,
-        _ids: &Self::Buffer,
-        _tpe: &Self::Buffer,
-        _out: &mut Self::Buffer,
-        _args_buf: &Self::Buffer,
-        _ne11: usize,
-        _top_k: usize,
-        _max_per_expert: usize,
-        _batch: usize,
-    ) -> Result<()> {
-        Err(FerrumError::unsupported(
-            "gemm_quant_moe_id_indirect not implemented for this backend",
-        ))
-    }
-
     /// Stacked SiLU·gate over `[batch * top_k, ffn]` rows (prefill version
     /// of `silu_mul_stacked`).
     fn silu_mul_batched(
@@ -848,70 +520,6 @@ pub trait Backend: Send + Sync + Sized + 'static {
         ))
     }
 
-    /// MoE indirect-dispatch GEMV: `out[i, :] = a[i, :] @ dequant(weight[ids[i], :])^T`
-    /// for each `i ∈ [0, n_selected)`. Single backend dispatch covers
-    /// all selected (token, expert) pairs.
-    ///
-    /// `weight` must be a stacked-experts variant produced by
-    /// [`Self::load_quant_experts`]. `ids` is a backend-side buffer of
-    /// `n_selected` i32 expert IDs. `out` is sized `[n_selected, n_rows]`.
-    /// `src1_stride` is the per-slot activation stride in **elements**:
-    /// `0` ⇒ every slot reads the same activation row (broadcast — for
-    /// `gate` / `up` projections); `n_cols` ⇒ each slot reads its own
-    /// activation row (for `down` projections, where each expert
-    /// consumes its own silu(gate)·up output).
-    fn gemv_quant_moe_id(
-        _ctx: &mut Self::Context,
-        _a: &Self::Buffer,
-        _weight: &Self::QuantStore,
-        _ids: &Self::Buffer,
-        _out: &mut Self::Buffer,
-        _n_selected: usize,
-        _src1_stride: usize,
-    ) -> Result<()> {
-        Err(FerrumError::unsupported(
-            "gemv_quant_moe_id not implemented for this backend",
-        ))
-    }
-
-    /// Offset-aware variant of [`Self::gemv_quant_moe_id`] — reads `a`
-    /// from `a_offset` (in elements; meaningful only when src1_stride=0
-    /// for the broadcast case, or as the start of an `n_selected × K`
-    /// strided read when src1_stride≥K), reads `ids` from `ids_offset`
-    /// (the i-th `top_k` block in a stacked-batch `[M, top_k]` ids
-    /// buffer), and writes `out` from offset 0 (output stays per-iter
-    /// scratch). Used by the per-item batched-decode path so the M=N
-    /// concurrent decodes can read directly from the M-batch
-    /// `selected_ids_buf` / `norm_out` without materialising
-    /// per-iteration copies.
-    #[allow(clippy::too_many_arguments)]
-    fn gemv_quant_moe_id_offset(
-        ctx: &mut Self::Context,
-        a: &Self::Buffer,
-        a_offset: usize,
-        weight: &Self::QuantStore,
-        ids: &Self::Buffer,
-        ids_offset: usize,
-        out: &mut Self::Buffer,
-        n_selected: usize,
-        src1_stride: usize,
-    ) -> Result<()> {
-        let _ = (
-            ctx,
-            a,
-            a_offset,
-            weight,
-            ids,
-            ids_offset,
-            out,
-            n_selected,
-            src1_stride,
-        );
-        Err(FerrumError::unsupported(
-            "gemv_quant_moe_id_offset not implemented for this backend",
-        ))
-    }
-
     /// Allocate a backend buffer of i32-typed values for kernels that
     /// need integer indices (MoE expert IDs, scatter indices, etc.).
     ///
@@ -965,42 +573,6 @@ pub trait Backend: Send + Sync + Sized + 'static {
         ))
     }
 
-    /// Fused gate+up MoE GEMV with in-register `SiLU(gate) * up`.
-    ///
-    /// Folds the three back-to-back dispatches that the stacked MoE
-    /// FFN decode path emitted per layer:
-    ///   1. `gemv_quant_moe_id` (gate) → gate_out_stacked
-    ///   2. `gemv_quant_moe_id` (up)   → up_out_stacked
-    ///   3. `silu_mul_stacked`         → silu_stacked
-    /// into a single dispatch that writes `silu_stacked` directly.
-    /// Saves 2 dispatches per layer plus the entire round-trip through
-    /// the gate_out / up_out scratch buffers (≈4× `[top_k, ffn]` of
-    /// intermediate traffic). The activation read is also halved
-    /// because the inner Q4_K reduction reuses one register-file load
-    /// across both weight matrices.
-    ///
-    /// Both `gate_w` and `up_w` must be `Q4KExperts` stacks with
-    /// matching `(num_experts, n_rows, n_cols)` (true for Qwen3-MoE
-    /// GGUFs). Backends without the fused kernel can fall back to the
-    /// 3-dispatch path; callers should gate via
-    /// [`Self::supports_fused_moe_gate_up_silu`] to avoid the
-    /// `Unsupported` String-allocating error round trip on the decode
-    /// hot path.
-    #[allow(clippy::too_many_arguments)]
-    fn gemv_quant_moe_id_gate_up_silu(
-        _ctx: &mut Self::Context,
-        _a: &Self::Buffer,
-        _gate_w: &Self::QuantStore,
-        _up_w: &Self::QuantStore,
-        _ids: &Self::Buffer,
-        _silu_out: &mut Self::Buffer,
-        _n_selected: usize,
-    ) -> Result<()> {
-        Err(FerrumError::unsupported(
-            "gemv_quant_moe_id_gate_up_silu not implemented for this backend",
-        ))
-    }
-
     /// Capability probe for [`Self::gemv_quant_moe_id_gate_up_silu`].
     ///
     /// `true` ⇒ the fused kernel is wired in and the caller should
@@ -1010,49 +582,6 @@ pub trait Backend: Send + Sync + Sized + 'static {
     /// allocation per (layer, step).
     fn supports_fused_moe_gate_up_silu() -> bool {
         false
-    }
-
-    /// Batched MoE indirect-dispatch GEMV — one Metal launch covers
-    /// **all** `m * top_k` (token, expert) pairs at once.
-    ///
-    /// This is the symmetric counterpart of
-    /// [`Self::gemv_quant_moe_id`]: same Q4_K decode loop, same
-    /// per-pair output, but the grid Z-axis spans `m * top_k` instead
-    /// of just `top_k`. Eliminates the engine-level per-token outer
-    /// loop that emits ~16× the dispatches llama.cpp emits at c=16
-    /// (their `kernel_mul_mv_id` already handles the M batch in one
-    /// dispatch).
-    ///
-    /// `a`           : activation buffer; pair `p` reads
-    ///                 `(p / top_k) * src1_outer_stride
-    ///                  + (p % top_k) * src1_inner_stride` floats.
-    ///                 gate / up:  src1 = `norm_out [m, K]`,
-    ///                              outer = K, inner = 0
-    ///                              (slots within a token broadcast).
-    ///                 down:       src1 = `silu_stacked [m, top_k, K]`,
-    ///                              outer = top_k * K, inner = K.
-    /// `weight`      : Q4KExperts stacked weights, common across
-    ///                 selected experts.
-    /// `ids`         : flat `[m * top_k]` selected-expert IDs (i32).
-    /// `out`         : `[m * top_k, n_rows]` outputs.
-    /// `m`           : token batch size.
-    /// `top_k`       : selected experts per token.
-    /// `src1_outer_stride`, `src1_inner_stride`: in **floats**.
-    #[allow(clippy::too_many_arguments)]
-    fn gemv_quant_moe_id_batched(
-        _ctx: &mut Self::Context,
-        _a: &Self::Buffer,
-        _weight: &Self::QuantStore,
-        _ids: &Self::Buffer,
-        _out: &mut Self::Buffer,
-        _m: usize,
-        _top_k: usize,
-        _src1_outer_stride: usize,
-        _src1_inner_stride: usize,
-    ) -> Result<()> {
-        Err(FerrumError::unsupported(
-            "gemv_quant_moe_id_batched not implemented for this backend",
-        ))
     }
 
     /// Capability probe for [`Self::gemv_quant_moe_id_batched`].
@@ -1068,47 +597,6 @@ pub trait Backend: Send + Sync + Sized + 'static {
     /// having to learn the flag.
     fn supports_paged_kv() -> bool {
         false
-    }
-
-    /// Pre-grow any backend-internal scratch slots whose size depends
-    /// on `m_total * intermediate_size` (the largest matmul fan-in
-    /// inside `unified_forward_internal`). Default no-op. CUDA
-    /// implements this to grow the perm-aware Marlin gather scratch
-    /// EAGERLY before the caller enters a CUDA-graph capture region —
-    /// `cuLaunchKernel` after a runtime alloc inside a captured
-    /// stream returns `CUDA_ERROR_INVALID_VALUE`.
-    fn pregrow_marlin_gather_scratch(_ctx: &mut Self::Context, _required: usize) {
-        // default: no scratch to pre-grow
-    }
-
-    /// Batched fused gate+up MoE GEMV with in-register `SiLU(gate) * up`.
-    ///
-    /// Counterpart of [`Self::gemv_quant_moe_id_gate_up_silu`] for the
-    /// batched-decode path: same in-register fusion, but the grid Z
-    /// dimension covers all `m * top_k` (token, expert) pairs in one
-    /// dispatch. Folds the three batched MoE FFN dispatches per layer
-    /// (gate gemv + up gemv + silu_mul_batched) into one — the missing
-    /// fusion that left the m≥2 batched-decode path slower than the
-    /// per-token loop (which already had this fusion at m=1).
-    ///
-    /// Both `gate_w` and `up_w` must be `Q4KExperts` stacks with
-    /// matching `(num_experts, n_rows, n_cols)`.
-    #[allow(clippy::too_many_arguments)]
-    fn gemv_quant_moe_id_gate_up_silu_batched(
-        _ctx: &mut Self::Context,
-        _a: &Self::Buffer,
-        _gate_w: &Self::QuantStore,
-        _up_w: &Self::QuantStore,
-        _ids: &Self::Buffer,
-        _silu_out: &mut Self::Buffer,
-        _m: usize,
-        _top_k: usize,
-        _src1_outer_stride: usize,
-        _src1_inner_stride: usize,
-    ) -> Result<()> {
-        Err(FerrumError::unsupported(
-            "gemv_quant_moe_id_gate_up_silu_batched not implemented for this backend",
-        ))
     }
 
     /// Capability probe for [`Self::gemv_quant_moe_id_gate_up_silu_batched`].
@@ -1832,32 +1320,6 @@ pub trait Backend: Send + Sync + Sized + 'static {
         *dst = Self::from_slice(&dst_v);
     }
 
-    /// Variant of [`Backend::gemm_gptq_with_offset`] that also takes
-    /// row-offsets into the input and output buffers. Lets the bucketed
-    /// MoE dispatcher run an expert's column-slice GEMM against a
-    /// sub-range of the packed input/output buffers without needing a
-    /// buffer-view type.
-    ///
-    /// Default impl returns Err so backends without MoE batched dispatch
-    /// don't have to implement.
-    #[allow(clippy::too_many_arguments)]
-    fn gemm_gptq_with_offset_strided(
-        _ctx: &mut Self::Context,
-        _input: &Self::Buffer,
-        _in_row_offset: usize,
-        _weight: &Self::GptqStore,
-        _expert_offset: usize,
-        _expert_n: usize,
-        _output: &mut Self::Buffer,
-        _out_row_offset: usize,
-        _m: usize,
-        _k: usize,
-    ) -> Result<()> {
-        Err(ferrum_types::FerrumError::unsupported(
-            "gemm_gptq_with_offset_strided not implemented for this backend",
-        ))
-    }
-
     /// Strided variant of [`Backend::fused_silu_mul_split`] for the
     /// bucketed MoE path: reads `gate_up` rows starting at
     /// `in_row_offset`, writes `out` rows starting at `out_row_offset`.
@@ -2104,5 +1566,553 @@ pub trait BackendCollective: Backend {
     }
     fn broadcast(_ctx: &mut Self::Context, _buf: &mut Self::Buffer, _len: usize, _src_rank: usize) {
         // single-rank: no-op
+    }
+}
+
+// ════════════════════════════════════════════════════════════════════════
+// BackendQuantMarlin capability (CUDA Marlin INT4 / GPTQ)
+// ════════════════════════════════════════════════════════════════════════
+//
+// CUDA-specific INT4 GEMM via Marlin tile kernels (Tensor Core required).
+// Metal/CPU don't have Marlin; they `impl BackendQuantMarlin for X {}` empty
+// and inherit `unsupported` Err defaults. GPTQ models targeting non-CUDA
+// backends are loaded via the dequant-fallback path in the Linear impls.
+
+/// Capability-trait for backends that natively support Marlin INT4 GEMM.
+/// CUDA wires this to the Marlin (or vLLM marlin_moe_wna16) tile kernels;
+/// other backends inherit defaults that error or no-op.
+pub trait BackendQuantMarlin: Backend {
+    /// Repack raw GPTQ tensors into the backend's preferred format.
+    /// Called once per layer at model load time.
+    ///
+    /// Inputs are host-side slices (CPU memory) — the loader reads from
+    /// safetensors and hands them off; each backend uploads + repacks
+    /// per its own strategy. `bits` is typically 4; `group_size` is
+    /// typically 128.
+    #[allow(clippy::too_many_arguments)]
+    fn load_gptq(
+        _qweight: &[i32],
+        _scales: &[f32],
+        _qzeros: &[i32],
+        _g_idx: Option<&[i32]>,
+        _bits: u32,
+        _group_size: usize,
+        _k: usize,
+        _n: usize,
+    ) -> Result<Self::GptqStore> {
+        Err(FerrumError::unsupported(
+            "load_gptq not implemented for this backend",
+        ))
+    }
+    /// Load num_experts GPTQ weight tiles into ONE stacked store, with
+    /// the property that **each expert's packed bytes are contiguous**
+    /// in the resulting store. This is what the offset GEMM needs to
+    /// dispatch per expert via pointer offset alone.
+    ///
+    /// Why this is a separate API from `load_gptq` + post-hoc concat:
+    /// Marlin's repack permutes data in `[K-tile-row outer, N-tile inner]`
+    /// order. A single repack of `concat(all experts along N)` produces
+    /// a buffer where expert e's bytes are spread across K-tile-rows,
+    /// NOT contiguous. Per-expert repack-then-concat keeps each
+    /// expert's data in one contiguous block.
+    ///
+    /// `qweights[i] / scales[i] / qzeros[i]` are each expert's raw GPTQ
+    /// tensors. All share the same K + group_size + bits + g_idx.
+    ///
+    /// Default returns Err(unsupported); override on backends with a
+    /// per-expert MoE GPTQ path.
+    #[allow(clippy::too_many_arguments)]
+    fn load_gptq_stacked(
+        _qweights: &[&[i32]],
+        _scales: &[&[f32]],
+        _qzeros: &[&[i32]],
+        _g_idx: Option<&[i32]>,
+        _bits: u32,
+        _group_size: usize,
+        _k: usize,
+        _n_per_expert: usize,
+    ) -> Result<Self::GptqStore> {
+        Err(FerrumError::unsupported(
+            "load_gptq_stacked not implemented for this backend",
+        ))
+    }
+    /// GEMM with pre-loaded GPTQ weights.
+    /// `out[m, n] = a[m, k] @ dequant(weight)^T`
+    fn gemm_gptq(
+        _ctx: &mut Self::Context,
+        _a: &Self::Buffer,
+        _weight: &Self::GptqStore,
+        _out: &mut Self::Buffer,
+        _m: usize,
+    ) -> Result<()> {
+        Err(FerrumError::unsupported(
+            "gemm_gptq not implemented for this backend",
+        ))
+    }
+    /// GEMM on a column-slice of a stacked GPTQ store. Used for MoE
+    /// expert dispatch where one big stacked weight tile holds all
+    /// experts' weights along N; per-expert calls process columns
+    /// `[expert_offset .. expert_offset + expert_n)` only.
+    ///
+    /// Output is written to `out[m, expert_n]` (NOT the full stacked N).
+    /// Caller is responsible for sizing `out` correctly.
+    ///
+    /// `expert_offset` and `expert_n` MUST be multiples of the backend's
+    /// natural N tile size (Marlin: 64). Default returns Err(unsupported).
+    fn gemm_gptq_with_offset(
+        _ctx: &mut Self::Context,
+        _a: &Self::Buffer,
+        _weight: &Self::GptqStore,
+        _expert_offset: usize,
+        _expert_n: usize,
+        _out: &mut Self::Buffer,
+        _m: usize,
+    ) -> Result<()> {
+        Err(FerrumError::unsupported(
+            "gemm_gptq_with_offset not implemented for this backend",
+        ))
+    }
+    /// Bulk-zero the per-expert Marlin workspace mutex slots for a
+    /// stacked GptqStore. Call ONCE before a batch of
+    /// `gemm_gptq_with_offset_strided_no_ws_zero` calls — saves the
+    /// per-call cuMemsetD32Async (one launch each → one launch total).
+    ///
+    /// At c=32 with 128 active experts × 2 (gate_up + down) × 48 layers:
+    /// 12 288 memset launches/token. Bulk-zeroing brings that to 96.
+    fn marlin_zero_stacked_workspace(
+        _ctx: &mut Self::Context,
+        _weight: &Self::GptqStore,
+    ) -> Result<()> {
+        Err(FerrumError::unsupported(
+            "marlin_zero_stacked_workspace not implemented for this backend",
+        ))
+    }
+    /// Batched per-expert offset GEMM dispatch — runs N concurrent
+    /// Marlin calls across a stream pool to amortize launch overhead
+    /// and overlap small-m kernels that under-utilize SMs individually.
+    ///
+    /// `dispatches[i]`: (expert_idx, in_row_offset, out_row_offset, m).
+    /// All calls share the same `weight`, `input`, `output`, `n_per_expert`,
+    /// `k`. Caller is responsible for bulk-zeroing workspace before this
+    /// call (use `marlin_zero_stacked_workspace`).
+    ///
+    /// Default: serial fallback that loops calling
+    /// `gemm_gptq_with_offset_strided`. CUDA backend overrides with
+    /// round-robin streams + sync-all at the end.
+    #[allow(clippy::too_many_arguments)]
+    fn moe_gemm_phase_batched(
+        ctx: &mut Self::Context,
+        input: &Self::Buffer,
+        weight: &Self::GptqStore,
+        dispatches: &[(usize, usize, usize, usize)],
+        n_per_expert: usize,
+        output: &mut Self::Buffer,
+        k: usize,
+    ) -> Result<()> {
+        // Default impl: serial fallback. CUDA overrides with multi-stream.
+        for (expert_idx, in_row_offset, out_row_offset, m) in dispatches {
+            Self::gemm_gptq_with_offset_strided(
+                ctx,
+                input,
+                *in_row_offset,
+                weight,
+                expert_idx * n_per_expert,
+                n_per_expert,
+                output,
+                *out_row_offset,
+                *m,
+                k,
+            )?;
+        }
+        Ok(())
+    }
+    /// vLLM marlin_moe_wna16 phase GEMM. Replaces the per-expert loop in
+    /// `moe_gemm_phase_batched` with a single fused launch that routes
+    /// per-block via `expert_ids`. Caller responsibilities:
+    ///
+    /// - `weight` was loaded via the vLLM stacked-Marlin path (i.e.
+    ///   `Self::load_gptq_stacked` invoked under `FERRUM_VLLM_MOE=1`).
+    ///   Feeding an IST-DASLab-format weight here yields silent garbage.
+    /// - `output` MUST be pre-zeroed (the kernel's atomic-add path does
+    ///   not self-zero the global tile).
+    /// - `sorted_token_ids` / `expert_ids` / `num_tokens_past_padded`
+    ///   come from `moe_align_block_size` or an equivalent host build.
+    /// - `prob_m` is the unique-token count (we feed pre-gathered rows
+    ///   with `top_k=1` so it equals `total_pairs`).
+    ///
+    /// Default: returns unsupported. CUDA overrides on `vllm-moe-marlin`.
+    #[allow(clippy::too_many_arguments)]
+    fn moe_gemm_phase_vllm(
+        _ctx: &mut Self::Context,
+        _input: &Self::Buffer,
+        _weight: &Self::GptqStore,
+        _sorted_token_ids: &Self::Buffer,
+        _expert_ids: &Self::Buffer,
+        _num_tokens_past_padded: &Self::Buffer,
+        _output: &mut Self::Buffer,
+        _prob_m: usize,
+        _n_per_expert: usize,
+        _k: usize,
+        _moe_block_size: usize,
+        _top_k: usize,
+    ) -> Result<()> {
+        Err(FerrumError::unsupported(
+            "moe_gemm_phase_vllm not implemented for this backend",
+        ))
+    }
+    /// Pre-grow any backend-internal scratch slots whose size depends
+    /// on `m_total * intermediate_size` (the largest matmul fan-in
+    /// inside `unified_forward_internal`). Default no-op. CUDA
+    /// implements this to grow the perm-aware Marlin gather scratch
+    /// EAGERLY before the caller enters a CUDA-graph capture region —
+    /// `cuLaunchKernel` after a runtime alloc inside a captured
+    /// stream returns `CUDA_ERROR_INVALID_VALUE`.
+    fn pregrow_marlin_gather_scratch(_ctx: &mut Self::Context, _required: usize) {
+        // default: no scratch to pre-grow
+    }
+    /// Variant of [`Backend::gemm_gptq_with_offset`] that also takes
+    /// row-offsets into the input and output buffers. Lets the bucketed
+    /// MoE dispatcher run an expert's column-slice GEMM against a
+    /// sub-range of the packed input/output buffers without needing a
+    /// buffer-view type.
+    ///
+    /// Default impl returns Err so backends without MoE batched dispatch
+    /// don't have to implement.
+    #[allow(clippy::too_many_arguments)]
+    fn gemm_gptq_with_offset_strided(
+        _ctx: &mut Self::Context,
+        _input: &Self::Buffer,
+        _in_row_offset: usize,
+        _weight: &Self::GptqStore,
+        _expert_offset: usize,
+        _expert_n: usize,
+        _output: &mut Self::Buffer,
+        _out_row_offset: usize,
+        _m: usize,
+        _k: usize,
+    ) -> Result<()> {
+        Err(ferrum_types::FerrumError::unsupported(
+            "gemm_gptq_with_offset_strided not implemented for this backend",
+        ))
+    }
+}
+
+// ════════════════════════════════════════════════════════════════════════
+// BackendQuantGguf capability (Metal GGUF Q4_K / Q6_K / Q8_0)
+// ════════════════════════════════════════════════════════════════════════
+//
+// Metal-specific GGUF k-quant GEMM/GEMV via simdgroup_matmul shaders.
+// CUDA/CPU don't ship GGUF kernels; they `impl BackendQuantGguf for X {}`
+// empty and inherit unsupported defaults. GGUF models targeting non-Metal
+// backends are loaded via dequant-fallback in the Linear impls.
+
+/// Capability-trait for backends that natively dispatch GGUF k-quant
+/// GEMM / GEMV. Metal wires its q4k/q6k shaders here; CUDA/CPU inherit
+/// defaults that error.
+pub trait BackendQuantGguf: Backend {
+    /// Load GGUF k-quant weights into the backend's preferred format.
+    ///
+    /// `kind` discriminates Q4_K / Q5_K / Q6_K / Q8_0 etc. The CPU path
+    /// typically eager-dequants to fp32; the Metal path keeps raw block
+    /// bytes in MTLBuffer and dequants per matmul into a transient fp16
+    /// buffer. Adding a new k-quant flavour is a matched pair of
+    /// `QuantStore` variant + `match` arm, not a new trait method.
+    ///
+    /// `bytes`: contiguous on-disk payload — `n_blocks × block_size`.
+    /// `n_rows`: out_features. `n_cols`: in_features. The block count
+    /// is derived per-kind from these dims.
+    fn load_quant(
+        _kind: GgufQuantType,
+        _bytes: &[u8],
+        _n_rows: usize,
+        _n_cols: usize,
+    ) -> Result<Self::QuantStore> {
+        Err(FerrumError::unsupported(
+            "load_quant not implemented for this backend",
+        ))
+    }
+    /// Build a fused `QuantStore` from multiple `(kind, bytes, n_rows)`
+    /// parts that share `n_cols`. Used by `GgufLoader::load_fused` when
+    /// parts have heterogeneous quant kinds (e.g. Qwen3 qkv_proj where
+    /// q+k are Q4_K but v is Q6_K) — byte-concatenation isn't possible,
+    /// so each part stays as its own QuantStore and the gemm dispatches
+    /// one matvec per part with output offsets.
+    ///
+    /// Default: not supported. Backends that have a `Fused`-like variant
+    /// override.
+    fn load_quant_fused(
+        _parts: &[(GgufQuantType, &[u8], usize)],
+        _n_cols: usize,
+    ) -> Result<Self::QuantStore> {
+        Err(FerrumError::unsupported(
+            "load_quant_fused not implemented for this backend",
+        ))
+    }
+    /// GEMM with k-quant weights. Mirrors `gemm` / `gemm_gptq` shape:
+    /// `out[m, n] = a[m, k] @ dequant(weight)^T`. The dispatch on the
+    /// quant flavour happens inside the backend's `QuantStore` enum.
+    fn gemm_quant(
+        _ctx: &mut Self::Context,
+        _a: &Self::Buffer,
+        _weight: &Self::QuantStore,
+        _out: &mut Self::Buffer,
+        _m: usize,
+    ) -> Result<()> {
+        Err(FerrumError::unsupported(
+            "gemm_quant not implemented for this backend",
+        ))
+    }
+    /// Build a stacked-experts `QuantStore` from a contiguous 3-D weight
+    /// payload `[num_experts, n_rows, n_cols/256]` super-blocks.
+    /// Used for the MoE indirect-dispatch fast path; backends without
+    /// such a kernel return `Err(unsupported)` and the model code falls
+    /// back to the per-expert loop.
+    ///
+    /// Default: not supported. Override on backends with batched MoE
+    /// kernels (e.g. Metal `gemv_q*kw_moe_id_f32`).
+    fn load_quant_experts(
+        _kind: GgufQuantType,
+        _bytes: &[u8],
+        _num_experts: usize,
+        _n_rows: usize,
+        _n_cols: usize,
+    ) -> Result<Self::QuantStore> {
+        Err(FerrumError::unsupported(
+            "load_quant_experts not implemented for this backend",
+        ))
+    }
+    /// MoE 2-D indirect-dispatch GEMM (prefill m > 1).
+    ///
+    /// Computes per (token, expert_slot) pair, batched across all
+    /// experts in one launch:
+    ///
+    ///   `out[token, slot, :] = a[token, slot_or_0, :] @ dequant(weight[expert(token, slot), :])^T`
+    ///
+    /// `ids[expert][slot] = pair_id` encodes `(token_idx, slot_within_token)`
+    /// so the kernel reads activations indirectly (src1 row for the
+    /// pair) and writes outputs directly to the natural
+    /// `[batch, top_k, M]` layout. `tpe[expert]` gives the count of
+    /// pairs assigned to each expert — threadgroups past `tpe[e]`
+    /// early-exit.
+    ///
+    /// `ne11` selects the src1 inner-batch shape:
+    /// - `1` for `gate` / `up` (broadcast — all slots read the same
+    ///   activation row per token).
+    /// - `top_k` for `down` (per-slot — each pair reads its own row in
+    ///   the upstream silu·gate output).
+    ///
+    /// Closes the prefill MoE gap: the per-token gemv loop becomes one
+    /// batched gemm where each expert's slab handles m ≈ batch·top_k /
+    /// num_experts pairs in parallel via simdgroup_half8x8 matmul.
+    #[allow(clippy::too_many_arguments)]
+    fn gemm_quant_moe_id(
+        _ctx: &mut Self::Context,
+        _a: &Self::Buffer,
+        _weight: &Self::QuantStore,
+        _ids: &Self::Buffer,
+        _tpe: &Self::Buffer,
+        _out: &mut Self::Buffer,
+        _ne11: usize,
+        _top_k: usize,
+        _max_per_expert: usize,
+        _batch: usize,
+    ) -> Result<()> {
+        Err(FerrumError::unsupported(
+            "gemm_quant_moe_id not implemented for this backend",
+        ))
+    }
+    /// Indirect-dispatch variant of `gemm_quant_moe_id`.
+    ///
+    /// Identical inputs except the grid is read from `args_buf` (a 12-
+    /// byte u32 triple written by `compute_ids_tpe_gpu`) instead of
+    /// being computed from `max_per_expert`. `max_per_expert` is still
+    /// the kernel parameter used as the row stride for `ids` indexing
+    /// (= `batch * top_k`, worst case); only the dispatched grid
+    /// shrinks to cover `max(tpe[e])` columns.
+    #[allow(clippy::too_many_arguments)]
+    fn gemm_quant_moe_id_indirect(
+        _ctx: &mut Self::Context,
+        _src1: &Self::Buffer,
+        _weights: &Self::QuantStore,
+        _ids: &Self::Buffer,
+        _tpe: &Self::Buffer,
+        _out: &mut Self::Buffer,
+        _args_buf: &Self::Buffer,
+        _ne11: usize,
+        _top_k: usize,
+        _max_per_expert: usize,
+        _batch: usize,
+    ) -> Result<()> {
+        Err(FerrumError::unsupported(
+            "gemm_quant_moe_id_indirect not implemented for this backend",
+        ))
+    }
+    /// MoE indirect-dispatch GEMV: `out[i, :] = a[i, :] @ dequant(weight[ids[i], :])^T`
+    /// for each `i ∈ [0, n_selected)`. Single backend dispatch covers
+    /// all selected (token, expert) pairs.
+    ///
+    /// `weight` must be a stacked-experts variant produced by
+    /// [`Self::load_quant_experts`]. `ids` is a backend-side buffer of
+    /// `n_selected` i32 expert IDs. `out` is sized `[n_selected, n_rows]`.
+    /// `src1_stride` is the per-slot activation stride in **elements**:
+    /// `0` ⇒ every slot reads the same activation row (broadcast — for
+    /// `gate` / `up` projections); `n_cols` ⇒ each slot reads its own
+    /// activation row (for `down` projections, where each expert
+    /// consumes its own silu(gate)·up output).
+    fn gemv_quant_moe_id(
+        _ctx: &mut Self::Context,
+        _a: &Self::Buffer,
+        _weight: &Self::QuantStore,
+        _ids: &Self::Buffer,
+        _out: &mut Self::Buffer,
+        _n_selected: usize,
+        _src1_stride: usize,
+    ) -> Result<()> {
+        Err(FerrumError::unsupported(
+            "gemv_quant_moe_id not implemented for this backend",
+        ))
+    }
+    /// Offset-aware variant of [`Self::gemv_quant_moe_id`] — reads `a`
+    /// from `a_offset` (in elements; meaningful only when src1_stride=0
+    /// for the broadcast case, or as the start of an `n_selected × K`
+    /// strided read when src1_stride≥K), reads `ids` from `ids_offset`
+    /// (the i-th `top_k` block in a stacked-batch `[M, top_k]` ids
+    /// buffer), and writes `out` from offset 0 (output stays per-iter
+    /// scratch). Used by the per-item batched-decode path so the M=N
+    /// concurrent decodes can read directly from the M-batch
+    /// `selected_ids_buf` / `norm_out` without materialising
+    /// per-iteration copies.
+    #[allow(clippy::too_many_arguments)]
+    fn gemv_quant_moe_id_offset(
+        ctx: &mut Self::Context,
+        a: &Self::Buffer,
+        a_offset: usize,
+        weight: &Self::QuantStore,
+        ids: &Self::Buffer,
+        ids_offset: usize,
+        out: &mut Self::Buffer,
+        n_selected: usize,
+        src1_stride: usize,
+    ) -> Result<()> {
+        let _ = (
+            ctx,
+            a,
+            a_offset,
+            weight,
+            ids,
+            ids_offset,
+            out,
+            n_selected,
+            src1_stride,
+        );
+        Err(FerrumError::unsupported(
+            "gemv_quant_moe_id_offset not implemented for this backend",
+        ))
+    }
+    /// Fused gate+up MoE GEMV with in-register `SiLU(gate) * up`.
+    ///
+    /// Folds the three back-to-back dispatches that the stacked MoE
+    /// FFN decode path emitted per layer:
+    ///   1. `gemv_quant_moe_id` (gate) → gate_out_stacked
+    ///   2. `gemv_quant_moe_id` (up)   → up_out_stacked
+    ///   3. `silu_mul_stacked`         → silu_stacked
+    /// into a single dispatch that writes `silu_stacked` directly.
+    /// Saves 2 dispatches per layer plus the entire round-trip through
+    /// the gate_out / up_out scratch buffers (≈4× `[top_k, ffn]` of
+    /// intermediate traffic). The activation read is also halved
+    /// because the inner Q4_K reduction reuses one register-file load
+    /// across both weight matrices.
+    ///
+    /// Both `gate_w` and `up_w` must be `Q4KExperts` stacks with
+    /// matching `(num_experts, n_rows, n_cols)` (true for Qwen3-MoE
+    /// GGUFs). Backends without the fused kernel can fall back to the
+    /// 3-dispatch path; callers should gate via
+    /// [`Self::supports_fused_moe_gate_up_silu`] to avoid the
+    /// `Unsupported` String-allocating error round trip on the decode
+    /// hot path.
+    #[allow(clippy::too_many_arguments)]
+    fn gemv_quant_moe_id_gate_up_silu(
+        _ctx: &mut Self::Context,
+        _a: &Self::Buffer,
+        _gate_w: &Self::QuantStore,
+        _up_w: &Self::QuantStore,
+        _ids: &Self::Buffer,
+        _silu_out: &mut Self::Buffer,
+        _n_selected: usize,
+    ) -> Result<()> {
+        Err(FerrumError::unsupported(
+            "gemv_quant_moe_id_gate_up_silu not implemented for this backend",
+        ))
+    }
+    /// Batched MoE indirect-dispatch GEMV — one Metal launch covers
+    /// **all** `m * top_k` (token, expert) pairs at once.
+    ///
+    /// This is the symmetric counterpart of
+    /// [`Self::gemv_quant_moe_id`]: same Q4_K decode loop, same
+    /// per-pair output, but the grid Z-axis spans `m * top_k` instead
+    /// of just `top_k`. Eliminates the engine-level per-token outer
+    /// loop that emits ~16× the dispatches llama.cpp emits at c=16
+    /// (their `kernel_mul_mv_id` already handles the M batch in one
+    /// dispatch).
+    ///
+    /// `a`           : activation buffer; pair `p` reads
+    ///                 `(p / top_k) * src1_outer_stride
+    ///                  + (p % top_k) * src1_inner_stride` floats.
+    ///                 gate / up:  src1 = `norm_out [m, K]`,
+    ///                              outer = K, inner = 0
+    ///                              (slots within a token broadcast).
+    ///                 down:       src1 = `silu_stacked [m, top_k, K]`,
+    ///                              outer = top_k * K, inner = K.
+    /// `weight`      : Q4KExperts stacked weights, common across
+    ///                 selected experts.
+    /// `ids`         : flat `[m * top_k]` selected-expert IDs (i32).
+    /// `out`         : `[m * top_k, n_rows]` outputs.
+    /// `m`           : token batch size.
+    /// `top_k`       : selected experts per token.
+    /// `src1_outer_stride`, `src1_inner_stride`: in **floats**.
+    #[allow(clippy::too_many_arguments)]
+    fn gemv_quant_moe_id_batched(
+        _ctx: &mut Self::Context,
+        _a: &Self::Buffer,
+        _weight: &Self::QuantStore,
+        _ids: &Self::Buffer,
+        _out: &mut Self::Buffer,
+        _m: usize,
+        _top_k: usize,
+        _src1_outer_stride: usize,
+        _src1_inner_stride: usize,
+    ) -> Result<()> {
+        Err(FerrumError::unsupported(
+            "gemv_quant_moe_id_batched not implemented for this backend",
+        ))
+    }
+    /// Batched fused gate+up MoE GEMV with in-register `SiLU(gate) * up`.
+    ///
+    /// Counterpart of [`Self::gemv_quant_moe_id_gate_up_silu`] for the
+    /// batched-decode path: same in-register fusion, but the grid Z
+    /// dimension covers all `m * top_k` (token, expert) pairs in one
+    /// dispatch. Folds the three batched MoE FFN dispatches per layer
+    /// (gate gemv + up gemv + silu_mul_batched) into one — the missing
+    /// fusion that left the m≥2 batched-decode path slower than the
+    /// per-token loop (which already had this fusion at m=1).
+    ///
+    /// Both `gate_w` and `up_w` must be `Q4KExperts` stacks with
+    /// matching `(num_experts, n_rows, n_cols)`.
+    #[allow(clippy::too_many_arguments)]
+    fn gemv_quant_moe_id_gate_up_silu_batched(
+        _ctx: &mut Self::Context,
+        _a: &Self::Buffer,
+        _gate_w: &Self::QuantStore,
+        _up_w: &Self::QuantStore,
+        _ids: &Self::Buffer,
+        _silu_out: &mut Self::Buffer,
+        _m: usize,
+        _top_k: usize,
+        _src1_outer_stride: usize,
+        _src1_inner_stride: usize,
+    ) -> Result<()> {
+        Err(FerrumError::unsupported(
+            "gemv_quant_moe_id_gate_up_silu_batched not implemented for this backend",
+        ))
     }
 }

--- a/crates/ferrum-models/src/architectures/qwen3_tts_backbone.rs
+++ b/crates/ferrum-models/src/architectures/qwen3_tts_backbone.rs
@@ -14,7 +14,7 @@
 //! `Qwen3TTSTalker` keeps its embeddings / projection / codec_head, and
 //! swaps only the transformer stack.
 
-use ferrum_kernels::backend::{Backend, BackendGraph};
+use ferrum_kernels::backend::{Backend, BackendGraph, BackendQuantGguf, BackendQuantMarlin};
 use ferrum_quantization::loader::WeightLoader;
 use ferrum_quantization::PrefixedLoader;
 use ferrum_types::Result;
@@ -36,13 +36,13 @@ pub trait TalkerBackboneForward: Send + Sync {
 
 /// Backbone adapter — wraps `LlamaFamilyModel<B>` loaded as a backbone-only
 /// (no embed / no lm_head) plus a per-sequence position counter.
-pub struct TalkerBackboneBackend<B: BackendGraph> {
+pub struct TalkerBackboneBackend<B: BackendGraph + BackendQuantMarlin + BackendQuantGguf> {
     backbone: LlamaFamilyModel<B>,
     cache_id: String,
     pos: usize,
 }
 
-impl<B: BackendGraph> TalkerBackboneBackend<B> {
+impl<B: BackendGraph + BackendQuantMarlin + BackendQuantGguf> TalkerBackboneBackend<B> {
     /// Build from a TTS model-directory loader. Uses `PrefixedLoader`
     /// with `"talker."` so `LlamaFamilyModel::new_backbone_only` picks up
     /// `talker.model.layers.*` and `talker.model.norm.weight`.
@@ -104,7 +104,9 @@ impl<B: BackendGraph> TalkerBackboneBackend<B> {
     }
 }
 
-impl<B: BackendGraph> TalkerBackboneForward for TalkerBackboneBackend<B> {
+impl<B: BackendGraph + BackendQuantMarlin + BackendQuantGguf> TalkerBackboneForward
+    for TalkerBackboneBackend<B>
+{
     fn forward(&mut self, input_f32: &[f32], seq_len: usize) -> Vec<f32> {
         let h = self.backbone.cfg.hidden_size;
         assert_eq!(

--- a/crates/ferrum-models/src/architectures/qwen3_tts_backend.rs
+++ b/crates/ferrum-models/src/architectures/qwen3_tts_backend.rs
@@ -13,7 +13,7 @@
 //! and batched decode — and adds TTS-specific wiring on top: dual text /
 //! codec embeddings, a text projection MLP, and the codec output head.
 
-use ferrum_kernels::backend::{Backend, BackendGraph};
+use ferrum_kernels::backend::{Backend, BackendGraph, BackendQuantGguf, BackendQuantMarlin};
 use ferrum_quantization::loader::WeightLoader;
 use ferrum_quantization::traits::Linear;
 use ferrum_quantization::PrefixedLoader;
@@ -35,7 +35,7 @@ use crate::models::llama_family::{LlamaFamilyConfig, LlamaFamilyModel};
 ///   codec_ids → codec_embed → mixed_embeds
 ///   mixed_embeds → backbone.{prefill,decode}_from_embed → hidden
 ///   hidden → final_norm (via backbone.final_norm_w) → codec_head → logits
-pub struct Qwen3TtsTalker<B: BackendGraph> {
+pub struct Qwen3TtsTalker<B: BackendGraph + BackendQuantMarlin + BackendQuantGguf> {
     pub cfg: TalkerConfig,
 
     /// Transformer backbone — only `layers`, `final_norm_w`, `scratch`,
@@ -65,7 +65,7 @@ pub struct Qwen3TtsTalker<B: BackendGraph> {
     positions: HashMap<String, u32>,
 }
 
-impl<B: BackendGraph> Qwen3TtsTalker<B> {
+impl<B: BackendGraph + BackendQuantMarlin + BackendQuantGguf> Qwen3TtsTalker<B> {
     /// Build a Qwen3-TTS Talker from weights. Uses `PrefixedLoader` with
     /// `"talker."` prefix internally so the backbone can reuse its standard
     /// `model.layers.{i}.*` / `model.norm.weight` lookups.
@@ -284,7 +284,7 @@ impl<B: BackendGraph> Qwen3TtsTalker<B> {
 // embedding. Has per-codebook embedding tables and per-codebook output
 // heads (N-1 of each).
 
-pub struct Qwen3TtsSubTalker<B: BackendGraph> {
+pub struct Qwen3TtsSubTalker<B: BackendGraph + BackendQuantMarlin + BackendQuantGguf> {
     pub cfg: TalkerConfig,
 
     /// Backbone — 4-5 layer Qwen3 with `code_predictor_*` dims.
@@ -303,7 +303,7 @@ pub struct Qwen3TtsSubTalker<B: BackendGraph> {
     pub lm_heads: Vec<Box<dyn Linear<B>>>,
 }
 
-impl<B: BackendGraph> Qwen3TtsSubTalker<B> {
+impl<B: BackendGraph + BackendQuantMarlin + BackendQuantGguf> Qwen3TtsSubTalker<B> {
     pub fn new(cfg: TalkerConfig, loader: &dyn WeightLoader<B>) -> Result<Self> {
         let cp_h = cfg.code_predictor_hidden_size;
         let cp_im = cp_h * 3; // ~3072 for 1024 hidden; matches existing impl

--- a/crates/ferrum-models/src/models/llama_family.rs
+++ b/crates/ferrum-models/src/models/llama_family.rs
@@ -19,7 +19,9 @@
 use std::collections::HashMap;
 use std::sync::atomic::AtomicU64;
 
-use ferrum_kernels::backend::{Backend, BackendGraph, KvCache, MAX_LAYERS_FOR_GRAPH};
+use ferrum_kernels::backend::{
+    Backend, BackendGraph, BackendQuantGguf, BackendQuantMarlin, KvCache, MAX_LAYERS_FOR_GRAPH,
+};
 
 /// Graph cache key for the single-item decode path (`decode_internal`).
 /// Distinct from any `m_padded`-based key used by the batched path.
@@ -171,7 +173,7 @@ struct LlamaFamilyConfigBase {
 
 /// Per-layer weights. `Box<dyn Linear<B>>` means each projection can be
 /// Dense / GPTQ / AWQ / GGUF without the surrounding code caring.
-pub struct LlamaFamilyLayer<B: Backend> {
+pub struct LlamaFamilyLayer<B: Backend + BackendQuantMarlin + BackendQuantGguf> {
     pub input_ln_w: B::Buffer,
     pub qkv_proj: Box<dyn Linear<B>>,
     /// QK-norm weight per head: `[head_dim]`. Optional for non-Qwen3 derivatives.
@@ -184,7 +186,7 @@ pub struct LlamaFamilyLayer<B: Backend> {
 }
 
 /// Precomputed RoPE cos/sin tables (shape `[max_seq, head_dim / 2]` each).
-pub struct RopeCache<B: Backend> {
+pub struct RopeCache<B: Backend + BackendQuantMarlin + BackendQuantGguf> {
     pub cos: B::Buffer,
     pub sin: B::Buffer,
 }
@@ -194,7 +196,7 @@ pub struct RopeCache<B: Backend> {
 ///
 /// Sized lazily on first use so tiny decode steps don't pay for prefill-sized
 /// buffers. Grows monotonically when a larger prefill arrives.
-pub struct LlamaFamilyScratch<B: Backend> {
+pub struct LlamaFamilyScratch<B: Backend + BackendQuantMarlin + BackendQuantGguf> {
     /// Residual stream — wrapped in Option so decode_internal can
     /// `.take()` it without needing an alloc placeholder.
     ///
@@ -331,7 +333,7 @@ pub struct LlamaFamilyScratch<B: Backend> {
     pub max_tokens: usize,
 }
 
-impl<B: Backend> LlamaFamilyScratch<B> {
+impl<B: Backend + BackendQuantMarlin + BackendQuantGguf> LlamaFamilyScratch<B> {
     fn alloc(cfg: &LlamaFamilyConfig, max_tokens: usize) -> Self {
         let h = cfg.hidden_size;
         let im = cfg.intermediate_size;
@@ -471,10 +473,10 @@ impl<B: Backend> LlamaFamilyScratch<B> {
 ///
 /// Holds all parameters, scratch space, RoPE cache, and per-sequence KV caches.
 ///
-/// `B: BackendGraph` because the decode hot path uses CUDA Graph capture/replay
+/// `B: BackendGraph + BackendQuantMarlin + BackendQuantGguf` because the decode hot path uses CUDA Graph capture/replay
 /// when the backend supports it; non-graph backends (Metal/CPU) inherit no-op
 /// defaults, so this bound is satisfied by every concrete `Backend`.
-pub struct LlamaFamilyModel<B: BackendGraph> {
+pub struct LlamaFamilyModel<B: BackendGraph + BackendQuantMarlin + BackendQuantGguf> {
     pub cfg: LlamaFamilyConfig,
     pub runtime_cfg: LlmRuntimeConfig,
 
@@ -551,7 +553,7 @@ pub struct LlamaFamilyModel<B: BackendGraph> {
     unified_graph_keys_seen: std::collections::HashSet<u64>,
 }
 
-impl<B: BackendGraph> LlamaFamilyModel<B> {
+impl<B: BackendGraph + BackendQuantMarlin + BackendQuantGguf> LlamaFamilyModel<B> {
     /// Build a Qwen3 model from weights provided by the loader.
     ///
     /// The loader decides per-projection whether to instantiate DenseLinear,
@@ -4083,7 +4085,9 @@ impl<B: BackendGraph> LlamaFamilyModel<B> {
     }
 }
 
-impl<B: BackendGraph> DecoderOnlyLLM for LlamaFamilyModel<B> {
+impl<B: BackendGraph + BackendQuantMarlin + BackendQuantGguf> DecoderOnlyLLM
+    for LlamaFamilyModel<B>
+{
     fn config(&self) -> &LlmRuntimeConfig {
         &self.runtime_cfg
     }
@@ -4281,7 +4285,9 @@ impl<B: BackendGraph> DecoderOnlyLLM for LlamaFamilyModel<B> {
     }
 }
 
-fn build_rope_cache<B: Backend>(cfg: &LlamaFamilyConfig) -> RopeCache<B> {
+fn build_rope_cache<B: Backend + BackendQuantMarlin + BackendQuantGguf>(
+    cfg: &LlamaFamilyConfig,
+) -> RopeCache<B> {
     let hd = cfg.head_dim;
     let half = hd / 2;
     let max = cfg.max_seq_len;

--- a/crates/ferrum-models/src/models/qwen3_moe.rs
+++ b/crates/ferrum-models/src/models/qwen3_moe.rs
@@ -28,7 +28,9 @@ use std::collections::HashMap;
 use std::sync::atomic::AtomicU64;
 use std::sync::OnceLock;
 
-use ferrum_kernels::backend::{Backend, BackendGraph, KvCache};
+use ferrum_kernels::backend::{
+    Backend, BackendGraph, BackendQuantGguf, BackendQuantMarlin, KvCache,
+};
 use ferrum_quantization::WeightLoader;
 use ferrum_types::{FerrumError, Result};
 
@@ -93,7 +95,7 @@ static BD_MOE_US: AtomicU64 = AtomicU64::new(0); // router + MoE FFN + residual 
 static BD_LAYER_CALLS: AtomicU64 = AtomicU64::new(0);
 
 /// Per-layer MoE state: router linear (small) + per-expert MLP stack.
-pub struct Qwen3MoeLayerState<B: Backend> {
+pub struct Qwen3MoeLayerState<B: Backend + BackendQuantMarlin + BackendQuantGguf> {
     /// Router projection `[hidden] → [num_experts]` — tiny, never sparse,
     /// always runs the full GEMV.
     pub router: Box<dyn ferrum_quantization::Linear<B>>,
@@ -104,7 +106,7 @@ pub struct Qwen3MoeLayerState<B: Backend> {
 
 /// Reusable scratch buffers for the MoE forward path. All sized at
 /// allocation time and reused across layers / forward calls.
-pub struct Qwen3MoeScratch<B: Backend> {
+pub struct Qwen3MoeScratch<B: Backend + BackendQuantMarlin + BackendQuantGguf> {
     /// See [`crate::models::llama_family::LlamaFamilyScratch`] for the
     /// attention scratch — we re-use those names verbatim.
     pub residual: Option<B::Buffer>,
@@ -257,7 +259,7 @@ pub struct Qwen3MoeScratch<B: Backend> {
     pub moe_route_scratch: crate::moe::MoeRouteScratch,
 }
 
-impl<B: Backend> Qwen3MoeScratch<B> {
+impl<B: Backend + BackendQuantMarlin + BackendQuantGguf> Qwen3MoeScratch<B> {
     fn alloc(cfg: &Qwen3MoeConfig, max_tokens: usize) -> Self {
         let h = cfg.base.hidden_size;
         let q_dim = cfg.base.num_heads * cfg.base.head_dim;
@@ -383,7 +385,7 @@ impl<B: Backend> Qwen3MoeScratch<B> {
 /// expert dispatch, and weighted combine all happen inside
 /// [`moe_forward`]; this struct only owns the storage and orchestrates
 /// the per-layer call sequence.
-pub struct Qwen3MoeModel<B: BackendGraph> {
+pub struct Qwen3MoeModel<B: BackendGraph + BackendQuantMarlin + BackendQuantGguf> {
     pub cfg: Qwen3MoeConfig,
     pub runtime_cfg: LlmRuntimeConfig,
 
@@ -410,7 +412,7 @@ pub struct Qwen3MoeModel<B: BackendGraph> {
     pub paged_block_alloc: Option<std::sync::Mutex<crate::common::paged_pool::BlockAllocator>>,
 }
 
-impl<B: BackendGraph> Qwen3MoeModel<B> {
+impl<B: BackendGraph + BackendQuantMarlin + BackendQuantGguf> Qwen3MoeModel<B> {
     /// Build a Qwen3-MoE model from a generic `WeightLoader<B>` plus a
     /// GGUF reader for the experts (which `WeightLoader` doesn't model
     /// directly — its API is rank-2 only).
@@ -2772,7 +2774,7 @@ impl<B: BackendGraph> Qwen3MoeModel<B> {
     }
 }
 
-impl<B: BackendGraph> DecoderOnlyLLM for Qwen3MoeModel<B> {
+impl<B: BackendGraph + BackendQuantMarlin + BackendQuantGguf> DecoderOnlyLLM for Qwen3MoeModel<B> {
     fn config(&self) -> &LlmRuntimeConfig {
         &self.runtime_cfg
     }
@@ -2921,7 +2923,7 @@ impl<B: BackendGraph> DecoderOnlyLLM for Qwen3MoeModel<B> {
 /// Free function (not a method) so the caller can split the borrow on
 /// `self` between `moe_layers[li]` (immutable) and `scratch` (mutable).
 #[allow(clippy::too_many_arguments)]
-fn moe_forward_stacked_decode_impl<B: Backend>(
+fn moe_forward_stacked_decode_impl<B: Backend + BackendQuantMarlin + BackendQuantGguf>(
     ctx: &mut B::Context,
     moe_layer: &Qwen3MoeLayerState<B>,
     scratch: &mut Qwen3MoeScratch<B>,
@@ -3131,7 +3133,7 @@ fn moe_forward_stacked_decode_impl<B: Backend>(
 /// Free function so the caller can split the borrow on `self` between
 /// `moe_layers[li]` (immutable) and `scratch` (mutable).
 #[allow(clippy::too_many_arguments)]
-fn moe_forward_batched_prefill_impl<B: Backend>(
+fn moe_forward_batched_prefill_impl<B: Backend + BackendQuantMarlin + BackendQuantGguf>(
     ctx: &mut B::Context,
     moe_layer: &Qwen3MoeLayerState<B>,
     scratch: &mut Qwen3MoeScratch<B>,
@@ -3388,7 +3390,7 @@ fn moe_forward_batched_prefill_impl<B: Backend>(
 /// Per-layer dispatch budget: 5 (independent of m). At c=16 / 48 layers
 /// that's 240 dispatches per decode step vs the per-token loop's ~3,840.
 #[allow(clippy::too_many_arguments)]
-fn moe_forward_batched_decode_impl<B: Backend>(
+fn moe_forward_batched_decode_impl<B: Backend + BackendQuantMarlin + BackendQuantGguf>(
     ctx: &mut B::Context,
     moe_layer: &Qwen3MoeLayerState<B>,
     scratch: &mut Qwen3MoeScratch<B>,
@@ -3540,7 +3542,7 @@ fn moe_forward_batched_decode_impl<B: Backend>(
 /// for MoE models — those slots are never invoked because the MoE FFN
 /// path runs through `moe_layer.experts` instead. The stub's only purpose
 /// is to satisfy the struct's type signature with minimal memory cost.
-fn stub_linear<B: Backend>(
+fn stub_linear<B: Backend + BackendQuantMarlin + BackendQuantGguf>(
     out_features: usize,
     in_features: usize,
 ) -> Box<dyn ferrum_quantization::Linear<B>> {
@@ -3555,7 +3557,9 @@ fn stub_linear<B: Backend>(
     ))
 }
 
-fn build_rope_cache<B: Backend>(cfg: &LlamaFamilyConfig) -> RopeCache<B> {
+fn build_rope_cache<B: Backend + BackendQuantMarlin + BackendQuantGguf>(
+    cfg: &LlamaFamilyConfig,
+) -> RopeCache<B> {
     let hd = cfg.head_dim;
     let half = hd / 2;
     let max = cfg.max_seq_len;

--- a/crates/ferrum-models/src/moe/dispatch.rs
+++ b/crates/ferrum-models/src/moe/dispatch.rs
@@ -25,7 +25,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use candle_core::quantized::GgmlDType;
 use candle_core::{Device, Result as CandleResult};
 use ferrum_kernels::backend::cpu::CpuBackend;
-use ferrum_kernels::backend::{Backend, GgufQuantType};
+use ferrum_kernels::backend::{Backend, BackendQuantGguf, BackendQuantMarlin, GgufQuantType};
 use ferrum_kernels::Linear;
 use ferrum_quantization::gguf::GgufFile;
 use ferrum_quantization::{DenseLinear, QuantLinear};
@@ -76,7 +76,7 @@ fn moe_profile_enabled() -> bool {
 /// over backend, but Phase 2's only consumer (`moe_forward_cpu`) is CPU-
 /// only — generic `moe_forward<B>` is deferred until the trait gains
 /// scaled-accumulate + cheap buffer slicing.
-pub struct ExpertStack<B: Backend> {
+pub struct ExpertStack<B: Backend + BackendQuantMarlin + BackendQuantGguf> {
     /// Fused `[gate; up]` projection per expert. Output shape per token:
     /// `[2 * expert_intermediate]` — the lower half is gate, upper is up.
     pub gate_up: Vec<Box<dyn Linear<B>>>,
@@ -105,7 +105,7 @@ pub struct ExpertStack<B: Backend> {
     pub down_gptq_stacked: Option<std::sync::Arc<B::GptqStore>>,
 }
 
-impl<B: Backend> ExpertStack<B> {
+impl<B: Backend + BackendQuantMarlin + BackendQuantGguf> ExpertStack<B> {
     /// Returns the shared stacked GPTQ store for `gate_up` if loaded
     /// via the bucketed/Marlin path. Used by [`moe_forward_bucketed`].
     pub fn gate_up_stacked_store(&self, _expert_idx: usize) -> Option<&B::GptqStore> {
@@ -118,7 +118,7 @@ impl<B: Backend> ExpertStack<B> {
     }
 }
 
-impl<B: Backend> ExpertStack<B> {
+impl<B: Backend + BackendQuantMarlin + BackendQuantGguf> ExpertStack<B> {
     /// Build from raw fp32 stacked tensors (test helper). Caller has
     /// already dequantised and laid out the data:
     ///   `gate_stack`: `[num_experts * expert_inter * hidden]`
@@ -503,7 +503,7 @@ impl<B: Backend> ExpertStack<B> {
 ///   8×5 + 2 = 42 dispatches/layer × 48 ≈ 2k/token (vs. ~3.5k in the
 ///   pre-PR scheme that round-tripped through `out` per pair).
 #[allow(clippy::too_many_arguments)]
-pub fn moe_forward<B: Backend>(
+pub fn moe_forward<B: Backend + BackendQuantMarlin + BackendQuantGguf>(
     ctx: &mut B::Context,
     x: &B::Buffer,
     router_logits: &B::Buffer,
@@ -808,7 +808,7 @@ impl Default for MoeRouteScratch {
 /// caller is responsible for sizing these to `batch * top_k` rows
 /// (worst-case all top_k pairs alive).
 #[allow(clippy::too_many_arguments)]
-pub fn moe_forward_bucketed<B: Backend>(
+pub fn moe_forward_bucketed<B: Backend + BackendQuantMarlin + BackendQuantGguf>(
     ctx: &mut B::Context,
     x: &B::Buffer,
     router_logits: &B::Buffer,

--- a/crates/ferrum-models/src/moe/layer.rs
+++ b/crates/ferrum-models/src/moe/layer.rs
@@ -7,7 +7,7 @@
 //! `Backend<B>` support is deferred (see `dispatch.rs` for why).
 
 use ferrum_kernels::backend::cpu::CpuBackend;
-use ferrum_kernels::backend::Backend;
+use ferrum_kernels::backend::{Backend, BackendQuantGguf, BackendQuantMarlin};
 use ferrum_kernels::Linear;
 use ferrum_quantization::gguf::{GgufFile, GgufLinear};
 use ferrum_types::{FerrumError, Result};
@@ -20,7 +20,7 @@ use crate::moe_config::Qwen3MoeConfig;
 ///
 /// Construct with [`Self::load_from_gguf`] (or its convenience wrappers).
 /// Call [`Self::forward_cpu`] to run one MoE layer's forward pass.
-pub struct Qwen3MoeLayer<B: Backend> {
+pub struct Qwen3MoeLayer<B: Backend + BackendQuantMarlin + BackendQuantGguf> {
     /// Gating linear: `[hidden] → [num_experts]` per token.
     pub router: Box<dyn Linear<B>>,
     /// Per-expert MLP weights.
@@ -38,7 +38,7 @@ pub struct Qwen3MoeLayer<B: Backend> {
     pub num_experts: usize,
 }
 
-impl<B: Backend> Qwen3MoeLayer<B> {
+impl<B: Backend + BackendQuantMarlin + BackendQuantGguf> Qwen3MoeLayer<B> {
     /// Load both router and expert weights for layer `layer_idx` from a
     /// GGUF file. Convenience wrapper around the lower-level GGUF reader
     /// + `ExpertStack::load_from_gguf` + manual router construction.

--- a/crates/ferrum-models/tests/moe_bucketed_parity_test.rs
+++ b/crates/ferrum-models/tests/moe_bucketed_parity_test.rs
@@ -6,7 +6,7 @@
 use std::sync::Arc;
 
 use ferrum_kernels::backend::cpu::CpuBackend;
-use ferrum_kernels::backend::Backend;
+use ferrum_kernels::backend::{Backend, BackendQuantMarlin};
 use ferrum_models::moe::{moe_forward, moe_forward_bucketed, ExpertStack, MoeRouteScratch};
 use ferrum_quantization::{Linear, StackedExpertLinear};
 
@@ -85,7 +85,7 @@ fn build_stacked(
             );
         }
     }
-    let store = <CpuBackend as Backend>::load_gptq(
+    let store = <CpuBackend as BackendQuantMarlin>::load_gptq(
         &qw_acc, &sc_acc, &qz_acc, None, 4, group_size, k, total_n,
     )
     .expect("CPU stacked load_gptq");

--- a/crates/ferrum-models/tests/qwen3_tts_backend_smoke.rs
+++ b/crates/ferrum-models/tests/qwen3_tts_backend_smoke.rs
@@ -60,7 +60,12 @@ fn load_talker_config(model_dir: &PathBuf) -> TalkerConfig {
 /// 4 decode steps, then exercise SubTalker.predict_greedy. Returns
 /// `(first_5_codec_tokens, subtalker_tokens)` for caller to compare
 /// across backends.
-fn run_full_chain<B: ferrum_kernels::backend::Backend + ferrum_kernels::backend::BackendGraph>(
+fn run_full_chain<
+    B: ferrum_kernels::backend::Backend
+        + ferrum_kernels::backend::BackendGraph
+        + ferrum_kernels::backend::BackendQuantMarlin
+        + ferrum_kernels::backend::BackendQuantGguf,
+>(
     dir: &PathBuf,
     cfg: &TalkerConfig,
     tag: &str,
@@ -181,7 +186,12 @@ fn cuda_smoke() {
 /// argmax codec tokens to `/tmp/tts_smoke_<backend>.tokens`. Diffing the
 /// CPU and CUDA outputs pinpoints the first step where precision drift
 /// flips a codec selection (if it happens at all).
-fn run_long_decode<B: ferrum_kernels::backend::Backend + ferrum_kernels::backend::BackendGraph>(
+fn run_long_decode<
+    B: ferrum_kernels::backend::Backend
+        + ferrum_kernels::backend::BackendGraph
+        + ferrum_kernels::backend::BackendQuantMarlin
+        + ferrum_kernels::backend::BackendQuantGguf,
+>(
     dir: &PathBuf,
     cfg: &TalkerConfig,
     tag: &str,

--- a/crates/ferrum-quantization/src/gguf/loader.rs
+++ b/crates/ferrum-quantization/src/gguf/loader.rs
@@ -21,7 +21,7 @@ use std::path::Path;
 use std::sync::Arc;
 
 use candle_core::Device;
-use ferrum_kernels::backend::Backend;
+use ferrum_kernels::backend::{Backend, BackendQuantGguf, BackendQuantMarlin};
 use ferrum_types::{FerrumError, Result};
 
 use crate::config::QuantConfig;
@@ -36,7 +36,7 @@ use crate::traits::Linear;
 /// Build with [`GgufLoader::open`]. The underlying file stays mmap'd for
 /// the lifetime of the loader so per-tensor reads only do byte slicing,
 /// not file I/O.
-pub struct GgufLoader<B: Backend> {
+pub struct GgufLoader<B: Backend + BackendQuantGguf + BackendQuantMarlin> {
     gguf: Arc<GgufFile>,
     /// Decode device for `QTensor::dequantize`. We always use CPU here:
     /// the dequant is followed by `B::from_slice`, which uploads to the
@@ -46,7 +46,7 @@ pub struct GgufLoader<B: Backend> {
     _marker: std::marker::PhantomData<B>,
 }
 
-impl<B: Backend> GgufLoader<B> {
+impl<B: Backend + BackendQuantGguf + BackendQuantMarlin> GgufLoader<B> {
     /// Open and parse a `.gguf` file. Tensor payloads stay on disk (mmap'd)
     /// until each `load_tensor` / `load_linear` call.
     pub fn open(path: impl AsRef<Path>) -> Result<Self> {
@@ -382,7 +382,7 @@ impl<B: Backend> GgufLoader<B> {
     }
 }
 
-impl<B: Backend> WeightLoader<B> for GgufLoader<B> {
+impl<B: Backend + BackendQuantGguf + BackendQuantMarlin> WeightLoader<B> for GgufLoader<B> {
     fn load_tensor(&self, name: &str) -> Result<B::Buffer> {
         let gguf_name = self.locate(name)?;
         let raw = self.read_dequant(&gguf_name)?;

--- a/crates/ferrum-quantization/src/gptq.rs
+++ b/crates/ferrum-quantization/src/gptq.rs
@@ -13,18 +13,18 @@
 //! needs (CUDA: Marlin-repacked tiles; CPU: dequantized f32 weights;
 //! Metal: unsupported).
 
-use ferrum_kernels::backend::Backend;
+use ferrum_kernels::backend::{Backend, BackendQuantMarlin};
 use ferrum_kernels::Linear;
 use ferrum_types::Result;
 
-pub struct GptqLinear<B: Backend> {
+pub struct GptqLinear<B: Backend + BackendQuantMarlin> {
     store: B::GptqStore,
     bias: Option<B::Buffer>,
     in_features: usize,
     out_features: usize,
 }
 
-impl<B: Backend> GptqLinear<B> {
+impl<B: Backend + BackendQuantMarlin> GptqLinear<B> {
     /// Build from raw host-side GPTQ tensors. The Backend repacks into
     /// its preferred format once; inference uses the repacked store.
     ///
@@ -88,7 +88,7 @@ impl<B: Backend> GptqLinear<B> {
     }
 }
 
-impl<B: Backend> Linear<B> for GptqLinear<B> {
+impl<B: Backend + BackendQuantMarlin> Linear<B> for GptqLinear<B> {
     fn in_features(&self) -> usize {
         self.in_features
     }
@@ -114,7 +114,7 @@ impl<B: Backend> Linear<B> for GptqLinear<B> {
 ///
 /// The store itself is `Arc<B::GptqStore>` so cloning a view is cheap;
 /// dropping all views drops the underlying store.
-pub struct StackedExpertLinear<B: Backend> {
+pub struct StackedExpertLinear<B: Backend + BackendQuantMarlin> {
     pub store: std::sync::Arc<B::GptqStore>,
     pub expert_offset: usize,
     pub expert_n: usize,
@@ -122,7 +122,7 @@ pub struct StackedExpertLinear<B: Backend> {
     pub bias: Option<B::Buffer>,
 }
 
-impl<B: Backend> StackedExpertLinear<B> {
+impl<B: Backend + BackendQuantMarlin> StackedExpertLinear<B> {
     pub fn new(
         store: std::sync::Arc<B::GptqStore>,
         expert_offset: usize,
@@ -139,7 +139,7 @@ impl<B: Backend> StackedExpertLinear<B> {
     }
 }
 
-impl<B: Backend> Linear<B> for StackedExpertLinear<B> {
+impl<B: Backend + BackendQuantMarlin> Linear<B> for StackedExpertLinear<B> {
     fn in_features(&self) -> usize {
         self.k
     }

--- a/crates/ferrum-quantization/src/native_safetensors.rs
+++ b/crates/ferrum-quantization/src/native_safetensors.rs
@@ -18,7 +18,7 @@ use std::collections::HashMap;
 use std::fs::File;
 use std::path::Path;
 
-use ferrum_kernels::backend::{Backend, SrcDtype};
+use ferrum_kernels::backend::{Backend, BackendQuantMarlin, SrcDtype};
 use ferrum_types::{FerrumError, Result};
 use half::{bf16, f16};
 use memmap2::Mmap;
@@ -126,7 +126,7 @@ impl Shard {
 
 /// Native safetensors loader. Generic over `Backend` so every tensor is
 /// materialised directly into backend-native buffers.
-pub struct NativeSafetensorsLoader<B: Backend> {
+pub struct NativeSafetensorsLoader<B: Backend + BackendQuantMarlin> {
     /// All shards keyed by file; each tensor's name maps to its shard here.
     shards: Vec<Shard>,
     /// Name → shard index. Populated once at construction.
@@ -136,7 +136,7 @@ pub struct NativeSafetensorsLoader<B: Backend> {
     _m: std::marker::PhantomData<B>,
 }
 
-impl<B: Backend> NativeSafetensorsLoader<B> {
+impl<B: Backend + BackendQuantMarlin> NativeSafetensorsLoader<B> {
     /// Discover shards under `model_dir` and build the name → shard index.
     pub fn open(model_dir: impl AsRef<Path>) -> Result<Self> {
         let dir = model_dir.as_ref();
@@ -511,7 +511,7 @@ impl<B: Backend> NativeSafetensorsLoader<B> {
     }
 }
 
-impl<B: Backend> WeightLoader<B> for NativeSafetensorsLoader<B> {
+impl<B: Backend + BackendQuantMarlin> WeightLoader<B> for NativeSafetensorsLoader<B> {
     fn load_tensor(&self, name: &str) -> Result<B::Buffer> {
         // Route through `from_weight_bytes` so fp16-preferring backends can
         // materialise big tensors (embed table) directly as half-precision
@@ -605,7 +605,7 @@ impl<B: Backend> WeightLoader<B> for NativeSafetensorsLoader<B> {
     }
 }
 
-impl<B: Backend> NativeSafetensorsLoader<B> {
+impl<B: Backend + BackendQuantMarlin> NativeSafetensorsLoader<B> {
     /// Load a GPTQ-packed linear projection: reads `<name>.qweight`,
     /// `<name>.scales`, `<name>.qzeros`, optionally `<name>.g_idx`, and
     /// hands the raw host-side tensors to `Backend::load_gptq` which

--- a/crates/ferrum-quantization/src/quant_linear.rs
+++ b/crates/ferrum-quantization/src/quant_linear.rs
@@ -18,7 +18,7 @@
 //! `GgufLinear`'s eager-dequant path; the loader's split-fusion logic
 //! already concatenates the dequanted parts into one dense weight.
 
-use ferrum_kernels::backend::{Backend, GgufQuantType};
+use ferrum_kernels::backend::{Backend, BackendQuantGguf, GgufQuantType};
 use ferrum_kernels::Linear;
 use ferrum_types::Result;
 
@@ -33,13 +33,13 @@ use ferrum_types::Result;
 /// Future k-quant flavours (Q5_K, Q6_K, Q8_0) plug in via the
 /// [`GgufQuantType`] discriminator passed to the constructor — no new
 /// `QuantLinear` type required.
-pub struct QuantLinear<B: Backend> {
+pub struct QuantLinear<B: Backend + BackendQuantGguf> {
     store: B::QuantStore,
     in_features: usize,
     out_features: usize,
 }
 
-impl<B: Backend> QuantLinear<B> {
+impl<B: Backend + BackendQuantGguf> QuantLinear<B> {
     /// Build from raw GGUF block bytes.
     ///
     /// `kind`: which k-quant flavour the bytes encode (Q4_K, Q5_K, …).
@@ -92,7 +92,7 @@ impl<B: Backend> QuantLinear<B> {
     }
 }
 
-impl<B: Backend> Linear<B> for QuantLinear<B> {
+impl<B: Backend + BackendQuantGguf> Linear<B> for QuantLinear<B> {
     fn in_features(&self) -> usize {
         self.in_features
     }

--- a/crates/ferrum-quantization/tests/gptq_parity_test.rs
+++ b/crates/ferrum-quantization/tests/gptq_parity_test.rs
@@ -14,6 +14,8 @@
 
 use ferrum_kernels::backend::cpu::CpuBackend;
 use ferrum_kernels::backend::Backend;
+#[cfg(feature = "cuda")]
+use ferrum_kernels::backend::BackendQuantMarlin;
 use ferrum_kernels::Linear;
 use ferrum_quantization::GptqLinear;
 
@@ -232,7 +234,7 @@ fn cuda_vs_cpu() {
 #[ignore]
 fn cuda_stacked_offset_vs_per_expert() {
     use ferrum_kernels::backend::cuda::CudaBackend;
-    use ferrum_kernels::backend::Backend;
+    use ferrum_kernels::backend::{Backend, BackendQuantMarlin};
 
     let k = 256;
     let n_per = 128;
@@ -268,7 +270,7 @@ fn cuda_stacked_offset_vs_per_expert() {
     let qw_refs: Vec<&[i32]> = experts.iter().map(|e| e.qweight.as_slice()).collect();
     let sc_refs: Vec<&[f32]> = experts.iter().map(|e| e.scales.as_slice()).collect();
     let qz_refs: Vec<&[i32]> = experts.iter().map(|e| e.qzeros.as_slice()).collect();
-    let stacked = <CudaBackend as Backend>::load_gptq_stacked(
+    let stacked = <CudaBackend as BackendQuantMarlin>::load_gptq_stacked(
         &qw_refs, &sc_refs, &qz_refs, None, 4, gs, k, n_per,
     )
     .expect("stacked load_gptq");
@@ -287,7 +289,7 @@ fn cuda_stacked_offset_vs_per_expert() {
 
         let input_dev_off = CudaBackend::from_slice(&input);
         let mut off_out_dev = CudaBackend::alloc(m * n_per);
-        <CudaBackend as Backend>::gemm_gptq_with_offset(
+        <CudaBackend as BackendQuantMarlin>::gemm_gptq_with_offset(
             &mut ctx,
             &input_dev_off,
             &stacked,
@@ -330,7 +332,7 @@ fn cuda_stacked_offset_vs_per_expert() {
 #[test]
 fn cpu_stacked_vs_per_expert_parity() {
     use ferrum_kernels::backend::cpu::CpuBackend;
-    use ferrum_kernels::backend::Backend;
+    use ferrum_kernels::backend::{Backend, BackendQuantMarlin};
 
     let k = 256;
     let n_per = 128; // per expert
@@ -393,16 +395,17 @@ fn cpu_stacked_vs_per_expert_parity() {
         }
     }
 
-    let stacked_store =
-        <CpuBackend as Backend>::load_gptq(&qw_acc, &sc_acc, &qz_acc, None, 4, gs, k, total_n)
-            .expect("stacked load_gptq");
+    let stacked_store = <CpuBackend as BackendQuantMarlin>::load_gptq(
+        &qw_acc, &sc_acc, &qz_acc, None, 4, gs, k, total_n,
+    )
+    .expect("stacked load_gptq");
 
     // Slice-and-compare: for each expert, `gemm_gptq_with_offset` on
     // the stacked store must equal the per-expert dedicated GEMM.
     for (e, ref_out) in per_expert_outs.iter().enumerate() {
         let mut stacked_out = vec![0.0f32; m * n_per];
         let mut ctx = <CpuBackend as Backend>::new_context();
-        <CpuBackend as Backend>::gemm_gptq_with_offset(
+        <CpuBackend as BackendQuantMarlin>::gemm_gptq_with_offset(
             &mut ctx,
             &input,
             &stacked_store,

--- a/crates/ferrum-quantization/tests/marlin_moe_parity_test.rs
+++ b/crates/ferrum-quantization/tests/marlin_moe_parity_test.rs
@@ -72,7 +72,7 @@ mod synth {
 #[ignore]
 fn cuda_marlin_moe_fused_vs_per_expert() {
     use ferrum_kernels::backend::cuda::CudaBackend;
-    use ferrum_kernels::backend::Backend;
+    use ferrum_kernels::backend::{Backend, BackendQuantMarlin};
 
     // Marlin tile constraints: k % 128 == 0, n_per % 64 == 0, n_per % 256 ==
     // 0 for some specs. Use a shape Qwen3-30B-A3B-like: k=2048 hidden,
@@ -104,7 +104,7 @@ fn cuda_marlin_moe_fused_vs_per_expert() {
     let qw_refs: Vec<&[i32]> = experts.iter().map(|e| e.qweight.as_slice()).collect();
     let sc_refs: Vec<&[f32]> = experts.iter().map(|e| e.scales.as_slice()).collect();
     let qz_refs: Vec<&[i32]> = experts.iter().map(|e| e.qzeros.as_slice()).collect();
-    let stacked = <CudaBackend as Backend>::load_gptq_stacked(
+    let stacked = <CudaBackend as BackendQuantMarlin>::load_gptq_stacked(
         &qw_refs, &sc_refs, &qz_refs, None, 4, gs, k, n_per,
     )
     .expect("stacked load_gptq");
@@ -132,7 +132,7 @@ fn cuda_marlin_moe_fused_vs_per_expert() {
         let a_e: Vec<f32> = a_data[row_start * k..(row_start + m_e) * k].to_vec();
         let a_e_dev = CudaBackend::from_slice(&a_e);
         let mut out_e_dev = CudaBackend::alloc(m_e * n_per);
-        <CudaBackend as Backend>::gemm_gptq_with_offset(
+        <CudaBackend as BackendQuantMarlin>::gemm_gptq_with_offset(
             &mut ctx,
             &a_e_dev,
             &stacked,
@@ -173,7 +173,7 @@ fn cuda_marlin_moe_fused_vs_per_expert() {
         .expect("upload tokens_per_expert");
 
     // Pre-zero stacked workspace (mirrors production).
-    let _ = <CudaBackend as Backend>::marlin_zero_stacked_workspace(&mut ctx, &stacked);
+    let _ = <CudaBackend as BackendQuantMarlin>::marlin_zero_stacked_workspace(&mut ctx, &stacked);
 
     ferrum_kernels::marlin::marlin_gemm_moe(
         &stream,

--- a/crates/ferrum-quantization/tests/marlin_moe_vllm_parity_test.rs
+++ b/crates/ferrum-quantization/tests/marlin_moe_vllm_parity_test.rs
@@ -66,7 +66,7 @@ mod synth {
 #[ignore]
 fn cuda_marlin_moe_vllm_vs_per_expert() {
     use ferrum_kernels::backend::cuda::CudaBackend;
-    use ferrum_kernels::backend::Backend;
+    use ferrum_kernels::backend::{Backend, BackendQuantMarlin};
 
     let k: usize = 256;
     let n_per: usize = 256;
@@ -106,7 +106,7 @@ fn cuda_marlin_moe_vllm_vs_per_expert() {
     let qw_refs: Vec<&[i32]> = experts.iter().map(|e| e.qweight.as_slice()).collect();
     let sc_refs: Vec<&[f32]> = experts.iter().map(|e| e.scales.as_slice()).collect();
     let qz_refs: Vec<&[i32]> = experts.iter().map(|e| e.qzeros.as_slice()).collect();
-    let stacked = <CudaBackend as Backend>::load_gptq_stacked(
+    let stacked = <CudaBackend as BackendQuantMarlin>::load_gptq_stacked(
         &qw_refs, &sc_refs, &qz_refs, None, 4, gs, k, n_per,
     )
     .expect("stacked load_gptq (IST-DASLab format, ref path)");
@@ -146,7 +146,7 @@ fn cuda_marlin_moe_vllm_vs_per_expert() {
         // expert 0, so the reference must also use expert 0 weights for
         // all rows (same offset for every expert).
         let weight_expert = if force_expert0 { 0 } else { e };
-        <CudaBackend as Backend>::gemm_gptq_with_offset(
+        <CudaBackend as BackendQuantMarlin>::gemm_gptq_with_offset(
             &mut ctx,
             &a_e_dev,
             &stacked,
@@ -235,7 +235,8 @@ fn cuda_marlin_moe_vllm_vs_per_expert() {
         .clone_htod(&num_tokens_past_padded)
         .expect("upload num_tokens_past_padded");
 
-    let _ = <CudaBackend as Backend>::marlin_zero_stacked_workspace(&mut ctx, &stacked_vllm);
+    let _ =
+        <CudaBackend as BackendQuantMarlin>::marlin_zero_stacked_workspace(&mut ctx, &stacked_vllm);
 
     ferrum_kernels::marlin::marlin_gemm_moe_vllm(
         &stream,


### PR DESCRIPTION
## Summary

Phase 2.3 of the architecture audit cleanup — split the quantization methods out of the umbrella `Backend` trait into two new capability supertraits, following the supertrait extraction pattern from Phase 2.1 (`BackendGraph`) and 2.2 (`BackendCollective`).

**Trait extracted: `BackendQuantMarlin: Backend`** (9 methods, CUDA-only)
- \`load_gptq\`, \`load_gptq_stacked\`
- \`gemm_gptq\`, \`gemm_gptq_with_offset\`, \`gemm_gptq_with_offset_strided\`
- \`marlin_zero_stacked_workspace\`, \`pregrow_marlin_gather_scratch\`
- \`moe_gemm_phase_batched\`, \`moe_gemm_phase_vllm\`

**Trait extracted: `BackendQuantGguf: Backend`** (11 methods, Metal-only)
- \`load_quant\`, \`load_quant_fused\`, \`load_quant_experts\`
- \`gemm_quant\`, \`gemm_quant_moe_id\`, \`gemm_quant_moe_id_indirect\`
- \`gemv_quant_moe_id\` + 4 variants (\`_offset\`, \`_gate_up_silu\`, \`_batched\`, \`_gate_up_silu_batched\`)

**Backend impls**:
- CudaBackend: full BackendQuantMarlin override; empty BackendQuantGguf
- MetalBackend: empty BackendQuantMarlin; full BackendQuantGguf override
- CpuBackend: subset of both (load_gptq + gemm_gptq* via dequant fallback; load_quant + gemm_quant for Q4_K dequant)

## Why

Per the [2026-05-09 architecture audit](https://github.com/sizzlecar/ferrum-infer-rs/pull/107) — the `Backend` trait had grown to 94 methods because every backend-specific optimization landed as a default-`unsupported` method on the umbrella. After Phase 2.1+2.2+2.3, it's down to ~62 methods.

**Concrete wins**:
1. **AMD support is now structurally cheaper** — adding AMD doesn't require 11 GGUF stub methods nor 9 GPTQ ones; AMD just impls the supertraits it actually has (BackendCore + BackendGraph via hipGraph + BackendCollective via RCCL + skip Marlin since Marlin is NVIDIA-Tensor-Core-only).
2. **Capability is type-level explicit** — Models that don't touch quantization (future fp16-only or bf16-only paths) can drop the quant bounds and stay strict.
3. **Sets up Phase 3** — the full split lays groundwork for Linear impls in \`ferrum-quantization\` to own the actual method bodies, removing them from \`Backend\` entirely.

## Acceptance gates

- \`cargo check --workspace --all-targets\` — clean (2.10s incremental)
- \`cargo fmt --all -- --check\` — clean
- \`cargo test --workspace --lib\` — all green
- Metal smoke (Qwen3-0.6B, 3 rounds × 128 tokens, \`--release\`):
  | path | baseline | Phase 2.3 | delta |
  |---|---|---|---|
  | FP16 (Qwen3-0.6B safetensors) | 60.5 tok/s | 60.7 tok/s | **+0.3%** |
  | GGUF Q8_0 (Qwen3-0.6B-GGUF) | 60.7 tok/s | 60.9 tok/s | **+0.3%** |
  - Both well within ±3% tolerance, no regression
  - GGUF path exercises the new BackendQuantGguf impl on Metal — confirmed alive
- CUDA validation: deferred to Vast.ai 4090 verification before merge (Marlin INT4 GPTQ on Qwen2.5-3B-GPTQ-Int4)

## What this PR DOES NOT do (deferred)

- **Phase 2.4** — extract \`BackendPagedKv\` (paged_decode_attention variants) and \`BackendMoeFused\` (weighted_sum_*, route_topk_softmax, etc.)
- **Phase 2.5** — narrow each model's where-bound to the strict capability list it actually uses (right now everything bounds on all 5 supertraits; granularize after the trait set is stable)
- **Phase 3** — move method bodies from Backend impls into Linear impls in ferrum-quantization

## Net diff

19 files, +3462/-3436 (mostly methods relocated within files; net +26 line trait scaffolding).

## Test plan

- [ ] CI passes (CPU Linux, Metal macOS, CUDA Linux)
- [ ] Vast.ai 4090 CUDA validation passes for Qwen2.5-3B-GPTQ-Int4 Marlin path
- [ ] Reviewer confirms supertrait pattern continues to be the right shape (matches Phase 2.1/2.2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)