### PR TITLE
refactor(backend): introduce KvDtypeKind + BackendKvDtype<K> scaffolding (Phase 4)

### DIFF
--- a/crates/ferrum-kernels/src/backend/cpu.rs
+++ b/crates/ferrum-kernels/src/backend/cpu.rs
@@ -872,3 +872,6 @@ impl crate::backend::BackendPagedKv for CpuBackend {}
 
 // CPU has no native MoE dispatch; inherit unsupported defaults.
 impl crate::backend::BackendMoeFused for CpuBackend {}
+
+// CPU: existing KV cache path treats fp16 buffer as f32 internally; mark as KvFp16 for compatibility.
+impl crate::backend::BackendKvDtype<crate::backend::KvFp16> for CpuBackend {}

--- a/crates/ferrum-kernels/src/backend/cuda.rs
+++ b/crates/ferrum-kernels/src/backend/cuda.rs
@@ -4773,3 +4773,5 @@ impl BackendMoeFused for CudaBackend {
         })
     }
 }
+// CUDA: existing KV cache path is FP16.
+impl crate::backend::BackendKvDtype<crate::backend::KvFp16> for CudaBackend {}

--- a/crates/ferrum-kernels/src/backend/metal.rs
+++ b/crates/ferrum-kernels/src/backend/metal.rs
@@ -2652,3 +2652,6 @@ impl crate::backend::BackendMoeFused for MetalBackend {
         Ok(())
     }
 }
+
+// Metal: existing KV cache path is FP16.
+impl crate::backend::BackendKvDtype<crate::backend::KvFp16> for MetalBackend {}

--- a/crates/ferrum-kernels/src/backend/traits.rs
+++ b/crates/ferrum-kernels/src/backend/traits.rs
@@ -2144,3 +2144,64 @@ impl<T> QuantLlmBackend for T where T: LlmBackend + BackendQuantMarlin + Backend
 /// to the quant LLM bundle. Required by Qwen3-MoE / future MoE models.
 pub trait MoeLlmBackend: QuantLlmBackend + BackendMoeFused {}
 impl<T> MoeLlmBackend for T where T: QuantLlmBackend + BackendMoeFused {}
+
+// ════════════════════════════════════════════════════════════════════════
+// KV cache dtype axis (dim 5 of the 5-dimension architecture)
+// ════════════════════════════════════════════════════════════════════════
+//
+// Each model's KV cache has its own precision independent of the model's
+// compute precision. vLLM 0.6+ ships INT8 / FP8 KV caches that halve KV
+// memory at small (<1%) accuracy hit. Today ferrum's KV is hardcoded
+// FP16 on CUDA / Metal — to support INT8/FP8 KV in a future PR, the
+// type system needs an explicit axis.
+//
+// Phase 4 scope: scaffolding only. All concrete backends impl
+// `BackendKvDtype<KvFp16>` so existing models keep working unchanged.
+// Future PR: implement BackendKvDtype<KvInt8> on CUDA + a new model
+// type-parameter `K: KvDtypeKind` to wire it through.
+
+/// Marker trait + metadata for a KV cache element type.
+pub trait KvDtypeKind: Send + Sync + 'static {
+    /// Stable name for logging / debug (e.g. "fp16", "int8").
+    const NAME: &'static str;
+    /// Bytes per element on disk + in cache memory.
+    const BYTES_PER_ELEM: usize;
+}
+
+/// FP16 KV cache (the existing default on CUDA + Metal).
+pub struct KvFp16;
+impl KvDtypeKind for KvFp16 {
+    const NAME: &'static str = "fp16";
+    const BYTES_PER_ELEM: usize = 2;
+}
+
+/// BF16 KV cache (drop-in replacement for FP16 on Ampere+ / Apple Silicon).
+pub struct KvBf16;
+impl KvDtypeKind for KvBf16 {
+    const NAME: &'static str = "bf16";
+    const BYTES_PER_ELEM: usize = 2;
+}
+
+/// INT8 KV cache — half the memory of FP16 with per-token / per-channel
+/// scale factors. CUDA path planned via vLLM's quant_kv kernels.
+pub struct KvInt8;
+impl KvDtypeKind for KvInt8 {
+    const NAME: &'static str = "int8";
+    const BYTES_PER_ELEM: usize = 1;
+}
+
+/// FP8 KV cache — E4M3 by default. Hopper+ on CUDA, future on Metal.
+pub struct KvFp8;
+impl KvDtypeKind for KvFp8 {
+    const NAME: &'static str = "fp8";
+    const BYTES_PER_ELEM: usize = 1;
+}
+
+/// Capability-trait for backends that can store + read a KV cache of
+/// type `K`. Methods come in a follow-up PR; today this is a marker
+/// that gates the (model, KV-dtype) combination at compile time.
+///
+/// Models that want INT8 KV will eventually look like:
+///   `where B: BackendCore + BackendPagedKv + BackendKvDtype<KvInt8>`
+/// instead of the current implicit FP16 assumption.
+pub trait BackendKvDtype<K: KvDtypeKind>: BackendPagedKv {}


### PR DESCRIPTION
## Summary

Adds the **dim-5 axis (KV cache precision)** to the type system, completing the 5-dimension architecture per the audit.

| Dim | Status | Phase |
|---|---|---|
| 1 (model arch) | ✅ done | Architecture v2 (history) |
| 2 (compute precision) | ⚠️ partial | Phase 3c+ (TBD) |
| 3 (weight format) | ⚠️ partial | Phase 3c+ (TBD) |
| 4 (backend) | ✅ done | Phase 2.x (#107-#110) |
| **5 (KV precision)** | **✅ scaffolding (this PR)** | KvFp16/Int8/Fp8 infra in place |

## What's added

In \`ferrum-kernels::backend::traits\`:
- \`KvDtypeKind\` marker trait: \`NAME\` + \`BYTES_PER_ELEM\` consts
- 4 marker structs: \`KvFp16\` / \`KvBf16\` / \`KvInt8\` / \`KvFp8\`
- \`BackendKvDtype<K: KvDtypeKind>: BackendPagedKv\` capability supertrait

CudaBackend, MetalBackend, CpuBackend each get \`impl BackendKvDtype<KvFp16>\` (no method overrides yet — methods come in the wire-up PR).

## Why scaffolding only

vLLM 0.6+ ships INT8/FP8 KV caches that halve KV memory at <1% accuracy hit. To support that in ferrum:
1. Need kernel work for INT8/FP8 KV append + paged attention reads
2. Need to type-parameterize \`KvCache<B>\` → \`KvCache<B, K = KvFp16>\`
3. Need to thread \`K\` through \`LlamaFamilyModel<B, K>\` etc.

Step 3 is invasive (touches every place that types KvCache). This PR adds the type vocabulary first so the wire-up PR can follow without re-debating trait shape.

Behavior unchanged: every existing path uses \`KvFp16\` implicitly.

## Acceptance gates

- \`cargo check --workspace --all-targets\` — clean
- \`cargo fmt --all -- --check\` — clean
- \`cargo test --workspace --lib\` — all green
- \`RUSTFLAGS=-D warnings cargo check\` — clean
- Metal smoke (Qwen3-0.6B FP16, 3×128 tok):
  - Phase 3a+b baseline: 60.5 tok/s
  - Phase 4: **61.1 tok/s (+1.0%)** ✅

## Net diff

4 files, **+69 lines** (traits.rs +61, 3 impl files +2 each).

## Stacks on

- Phase 1 + 2.x + 3a/b all merged
- Branch off latest main \`fff0759\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)