### PR TITLE
docs: architecture refactor status — 5-dim goal, progress, GPU workflow

### DIFF
--- a/docs/architecture-refactor-status.md
+++ b/docs/architecture-refactor-status.md
@@ -1,0 +1,205 @@
+# Architecture Refactor — 5-Dim Complete-Form Goal & Status
+
+> Started 2026-05-09. Tracks the audit-driven refactor toward a clean
+> 5-dimension architecture where new backends / models / quant formats /
+> KV precisions can be added independently.
+
+## The 5-dim goal
+
+Inference engines compose 5 orthogonal axes. Naive multiplication is
+~7 200 cells (8×5×15×4×3); the right design has each axis as a single
+polymorphism point so total maintenance units are ~44 (additive, not
+multiplicative).
+
+| # | Dimension | Polymorphism point | Examples |
+|---|---|---|---|
+| 1 | **Model architecture** | Per-family Rust struct (`LlamaFamilyModel<B>`, `Qwen3MoeModel<B>`, future `DeepseekV3Model<B>`) | Llama / Qwen2 / Qwen3 / Qwen3-MoE / Mistral SW / DeepSeek-V3 MLA / Gemma |
+| 2 | **Compute precision** | `Linear<B>` impl | FP32 / FP16 / BF16 / FP8 (E4M3) / INT8 / INT4 |
+| 3 | **Weight format** | `WeightLoader<B>` produces format-specific `Linear<B>` impl | safetensors / GPTQ / AWQ / GGUF (Q2K-Q8) / Marlin-packed / HQQ / EXL2 |
+| 4 | **Inference device** | `Backend` trait + capability supertraits + bundle aliases | CUDA / Metal / CPU / AMD / Intel / 国产 GPU |
+| 5 | **KV cache precision** | `KvDtypeKind` marker + `BackendKvDtype<K>` supertrait | FP16 / BF16 / INT8 / FP8 |
+
+The combinatorial complexity stays additive because each axis only adds
+its own units, never multiplies with the others.
+
+### Acceptance for "完全体" (complete form)
+
+Three gates — ALL must pass before the refactor is considered done:
+
+1. **CLI + server use the new architecture** — not just trait切片 in
+   ferrum-kernels; CLI commands and HTTP handlers reference the new
+   modality-specific traits / Linear impls.
+2. **All previously perf-tested models infer correctly** — Qwen3
+   (0.6B / 1.7B / 4B / 8B), Qwen2.5-Instruct (FP16 + GPTQ-Int4),
+   Qwen3-30B-A3B MoE (Marlin INT4 on CUDA, Q4_K_M GGUF on Metal),
+   Qwen3-TTS-0.6B/1.7B, whisper-large-v3-turbo, BERT, CLIP.
+3. **Performance does not regress** — Metal smoke for each phase
+   relative to per-phase baseline ≤ 3% drift (LTO usually folds trait
+   reorganization to identical machine code; thermals are the noise
+   floor).
+
+## Progress (as of 2026-05-10)
+
+### Dim status
+
+| Dim | Status | Notes |
+|---|---|---|
+| 1. Model architecture | ✅ done | Architecture v2 (historical, pre-audit) |
+| 2. Compute precision | 🟡 partial | Backend trait still owns Marlin/GGUF method bodies; `Linear<B>` exists as polymorphism point but kernel dispatch hasn't moved into impls yet (Phase 3e/3f) |
+| 3. Weight format | 🟡 partial | `WeightLoader<B>` + `Linear<B>` infra in place; same Phase 3e/3f gap as dim 2 |
+| 4. **Inference device** | ✅ done | Backend → 5 supertraits + 3 capability bundles (#107-#110) |
+| 5. KV cache precision | 🟢 scaffolding | `KvDtypeKind` + `BackendKvDtype<K>` traits exist (#112); kernel impls + `KvCache<B, K>` wire-up pending |
+
+### PRs landed (in order)
+
+| PR | Phase | Effect |
+|---|---|---|
+| [#106](https://github.com/sizzlecar/ferrum-infer-rs/pull/106) | 1 | Delete 377 lines of dead code (KernelExecutor / DecodeBackend / orphan EngineFactory) |
+| [#107](https://github.com/sizzlecar/ferrum-infer-rs/pull/107) | 2.1 + 2.2 | Extract `BackendGraph` + `BackendCollective` supertraits |
+| [#108](https://github.com/sizzlecar/ferrum-infer-rs/pull/108) | 2.3 | Extract `BackendQuantMarlin` + `BackendQuantGguf` supertraits |
+| [#109](https://github.com/sizzlecar/ferrum-infer-rs/pull/109) | 2.4 | Extract `BackendPagedKv` + `BackendMoeFused` supertraits |
+| [#110](https://github.com/sizzlecar/ferrum-infer-rs/pull/110) | 2.5 | `LlmBackend` + `QuantLlmBackend` + `MoeLlmBackend` capability bundles |
+| [#111](https://github.com/sizzlecar/ferrum-infer-rs/pull/111) | 3a + 3b | Split `qwen3_moe.rs` (3579 → 2950) + `llama_family.rs` (4305 → 2652); -2282 lines combined in two largest files |
+
+### PRs in flight
+
+| PR | Phase | Status |
+|---|---|---|
+| [#112](https://github.com/sizzlecar/ferrum-infer-rs/pull/112) | 4 | KV-dtype scaffolding (Metal +1.0%) |
+| [#113](https://github.com/sizzlecar/ferrum-infer-rs/pull/113) | 3c | `ExpertStack::gemv_*` methods replace 4 `B::gemv_quant_moe_id*` call sites in stacked-decode path (Metal +2.5%) |
+| [#114](https://github.com/sizzlecar/ferrum-infer-rs/pull/114) | 5a step 1 | Extract `modality_stubs` helper for the 3 fake engines (-39 lines copy-paste, +59 shared) |
+
+### Backend trait shrinkage
+
+| Phase | Method count | Δ |
+|---|---|---|
+| Pre-Phase-2 | 94 | — |
+| 2.1 + 2.2 (#107) | ~82 | -12 |
+| 2.3 (#108) | ~62 | -20 |
+| 2.4 (#109) | ~32 | -30 |
+
+### Remaining work for full "完全体"
+
+| Phase | Scope | Risk | Estimate |
+|---|---|---|---|
+| 3d | Convert remaining `B::gemm_quant_moe_id*` and `B::gemv_quant_moe_id_offset/batched/etc.` calls in `moe_forward_batched_prefill_impl` + `moe_forward_batched_decode_impl` to `ExpertStack` methods | Low | half-day |
+| **3e** | Move CudaBackend Marlin (~700 lines) + MetalBackend GGUF (~700 lines) impl bodies INTO `Linear<B>` impls in ferrum-kernels (NOT ferrum-quantization to avoid cudarc/metal dep cycle); delete `BackendQuantMarlin/Gguf` traits | Medium | 1-2 days; needs careful design |
+| 4 wire-up | Add `K: KvDtypeKind` type parameter to `KvCache<B>`; thread through `LlamaFamilyModel<B, K = KvFp16>`; implement `BackendKvDtype<KvInt8>` for CUDA (vLLM-style) | Medium | 1 day for type plumbing + 1-2 days for INT8 KV kernel work |
+| **5a step 2** | Split `InferenceEngine` into per-modality traits (`LlmInferenceEngine` + `EmbedEngine` + `TranscribeEngine` + `TtsEngine`); change `AppState` to hold `Option<Arc<dyn ModalityTrait>>` per modality; delete the 3 fake engine wrappers | Medium | half-day |
+| 5b | Delete `ferrum-runtime` crate (legacy `ComputeBackend` impls); delete `DefaultInferenceEngine` after CLI migrates to `ContinuousBatchEngine`; clean up registry | Medium | 1 day |
+
+## GPU testing workflow (Vast.ai 4090)
+
+CUDA-only validation runs on Vast.ai rented GPUs. Mac local handles
+Metal + CPU; Vast pod handles CUDA. Cost ~$0.30/hr for an RTX 4090.
+
+### Spin up a pod
+
+Use the Vast HTTP API (the `vastai` CLI has a urllib3 incompatibility on
+macOS LibreSSL):
+
+```bash
+source .env.local  # exports VAST_API_KEY + HF_TOKEN
+
+# Find cheapest 4090 (filter rentable + verified preferred)
+curl -s "https://console.vast.ai/api/v0/bundles/?q=%7B%22gpu_name%22%3A%7B%22eq%22%3A%22RTX%204090%22%7D%2C%22rentable%22%3A%7B%22eq%22%3Atrue%7D%2C%22dph_total%22%3A%7B%22lt%22%3A0.40%7D%7D&order=%5B%5B%22dph_total%22%2C%22asc%22%5D%5D" \
+  -H "Authorization: Bearer $VAST_API_KEY" | jq '.offers[0:3] | .[] | {id, dph_total, cuda_max_good, geolocation}'
+
+# Create instance — image must be nvidia/cuda:*-devel-ubuntu22.04
+# (NOT pytorch/pytorch:* — that pulls 5-10 GB of unused ML deps)
+PUBKEY=$(cat ~/.ssh/id_ed25519.pub)
+curl -X PUT "https://console.vast.ai/api/v0/asks/<OFFER_ID>/" \
+  -H "Authorization: Bearer $VAST_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d "$(python3 -c "import json; print(json.dumps({
+    'client_id': 'me',
+    'image': 'nvidia/cuda:12.4.0-devel-ubuntu22.04',
+    'env': {'-p 22:22': '1'},
+    'disk': 60,
+    'runtype': 'ssh ssh_proxy',
+    'onstart': 'apt-get update -qq && apt-get install -y -qq openssh-server pkg-config libssl-dev git build-essential && mkdir -p /run/sshd /root/.ssh && echo \"$PUBKEY\" > /root/.ssh/authorized_keys && chmod 600 /root/.ssh/authorized_keys && /usr/sbin/sshd -D &',
+    'label': 'ferrum-cuda-validation',
+}))")"
+```
+
+Notes:
+- ~30% of new pods hit a Vast SSH proxy port-forwarding bug — destroy
+  + retry if SSH refuses for >2 min after `actual_status=running`.
+- Pod returns `ssh_host` + `ssh_port` (e.g. `ssh1.vast.ai:19862`).
+
+### Bootstrap on the pod
+
+```bash
+ssh -p <PORT> root@<HOST>
+
+# One-time: install Rust + clone ferrum
+curl -sSf https://sh.rustup.rs | sh -s -- -y
+source $HOME/.cargo/env
+mkdir -p /workspace && cd /workspace
+git clone https://github.com/sizzlecar/ferrum-infer-rs.git
+cd ferrum-infer-rs
+
+# HF token for gated models (Qwen3-30B-A3B-GPTQ-Int4 etc).
+# Pipe via stdin (NOT --token CLI arg — that exposes in `ps`):
+printf '%s\n' "$HF_TOKEN" | ssh -p <PORT> root@<HOST> \
+  'mkdir -p /root/.cache/huggingface && cat > /root/.cache/huggingface/token && chmod 600 /root/.cache/huggingface/token'
+```
+
+### Build + bench
+
+```bash
+# Build (LTO + codegen-units=1 → ~5 min cold, ~3 min incremental)
+cargo build --release --features cuda -p ferrum-cli
+
+# For vLLM Marlin MoE path, add the feature:
+cargo build --release --features cuda,vllm-moe-marlin -p ferrum-cli
+
+# Standard smokes
+HF_HOME=/workspace/.hf_home ./target/release/ferrum bench Qwen/Qwen3-0.6B \
+    --rounds 3 --max-tokens 128
+
+# Marlin INT4 on Llama-8B (no auth needed, hugging-quants mirror)
+HF_HOME=/workspace/.hf_home ./target/release/ferrum bench \
+    hugging-quants/Meta-Llama-3.1-8B-Instruct-GPTQ-INT4 \
+    --rounds 3 --max-tokens 128
+
+# MoE Marlin (gated; needs HF login above)
+HF_HOME=/workspace/.hf_home FERRUM_VLLM_MOE=1 ./target/release/ferrum bench \
+    Qwen/Qwen3-30B-A3B-GPTQ-Int4 --rounds 3 --max-tokens 64 --concurrency 4
+```
+
+### Background workflow (don't block on cargo build)
+
+```bash
+nohup bash -c "
+    cargo build --release --features cuda -p ferrum-cli 2>&1 | tail -3
+    HF_HOME=/workspace/.hf_home ./target/release/ferrum bench Qwen/Qwen3-0.6B --rounds 2 --max-tokens 64 2>&1 | tail -10
+    echo __DONE__
+" > /tmp/build_bench.log 2>&1 &
+```
+
+Then check periodically with `ssh ... 'tail /tmp/build_bench.log'`.
+
+### Pod cost / cleanup
+
+- Idle pod: ~$0.30/hr; destroy when not actively benching.
+- Destroy: `curl -X DELETE "https://console.vast.ai/api/v0/instances/<INSTANCE_ID>/" -H "Authorization: Bearer $VAST_API_KEY"`
+- Or via web console.
+
+### Reference baselines (Vast 4090, post-Phase-3a/b main = `fff0759`)
+
+| Model | Path | tok/s e2e | TPOT |
+|---|---|---|---|
+| Qwen3-0.6B | FP16 (safetensors) | 83.0 | 11.88 ms |
+| Llama-3.1-8B-Instruct | GPTQ-Int4 (Marlin) | 60.4 | 16.55 ms |
+| Qwen3-30B-A3B | GPTQ-Int4 (vLLM Marlin moe path, c=4) | 54.2 | 69.95 ms |
+| Qwen3-30B-A3B | GPTQ-Int4 (IST-DASLab Marlin path, c=4) | 57.6 | 66.65 ms |
+
+Note: c=4 isn't in the historical bench tables (`docs/bench/cuda-rtx4090-2026-05-09-pr-101-102/` only logged c=1/8/16/32). Treat
+these as new baselines.
+
+## References
+
+- Audit memory: `~/.claude/projects/-Users-chejinxuan-rust-ws-ferrum-infer-rs/memory/project_arch_audit_2026_05_09.md`
+- Acceptance memory: `~/.claude/projects/-Users-chejinxuan-rust-ws-ferrum-infer-rs/memory/project_arch_refactor_done_criteria.md`
+- Vast workflow memory: `~/.claude/projects/-Users-chejinxuan-rust-ws-ferrum-infer-rs/memory/feedback_arch_refactor_validation.md`


### PR DESCRIPTION
Single doc that lives next to the code, capturing the 2026-05-09 audit-driven refactor.

## Contents

- **5-dim goal**: model arch / compute precision / weight format / device / KV precision — and why the design stays additive (~44 maintenance units) rather than multiplicative (~7200 cells).
- **Per-dim status**: which polymorphism point owns each axis today and what's still TBD.
- **PR ledger**: 6 merged (#106-#111) + 3 open (#112-#114), with what each PR reduces.
- **Backend trait shrinkage**: 94 → ~32 methods.
- **Remaining "完全体" work**: Phase 3d/3e/4-wireup/5a-step2/5b with risk + estimate.
- **GPU testing workflow**: full Vast.ai 4090 spinup recipe — uses the HTTP API (the \`vastai\` CLI has a urllib3 incompatibility on macOS LibreSSL), HF token via stdin (avoids \`ps\` exposure), build + bench commands, cost/cleanup, current baselines.

## Acceptance criteria captured

- CLI + server adopt the new architecture
- All previously perf-tested models infer correctly
- ≤3% Metal regression per phase

🤖 Generated with [Claude Code](https://claude.com/claude-code)