### PR TITLE
refactor(moe): extract gemm/gemv MoE-id wrappers on ExpertStack (Phase 3d)

### DIFF
--- a/crates/ferrum-models/src/models/qwen3_moe.rs
+++ b/crates/ferrum-models/src/models/qwen3_moe.rs
@@ -2548,9 +2548,6 @@ impl<B: MoeLlmBackend> Qwen3MoeModel<B> {
             let top_k = self.cfg.num_experts_per_tok;
             let n_exp = self.cfg.num_experts;
             let norm_topk_prob = self.cfg.norm_topk_prob;
-            let gate_stacked = moe_layer.experts.gate_stacked.as_ref().unwrap();
-            let up_stacked = moe_layer.experts.up_stacked.as_ref().unwrap();
-            let down_stacked = moe_layer.experts.down_stacked.as_ref().unwrap();
 
             // Single batched router pass: writes selected_ids_buf [M, top_k]
             // and weights_2d [M, top_k]. Replaces M individual route calls.
@@ -2569,7 +2566,7 @@ impl<B: MoeLlmBackend> Qwen3MoeModel<B> {
             // the 4 copy_slice round-trips per iteration that the
             // earlier implementation needed (ids, weights, x_single,
             // moe_out). At c=16 / 48 layers that's ~3,072 dispatches
-            // saved per token. Uses `gemv_quant_moe_id_offset` to read
+            // saved per token. Uses `gemv_*_offset` to read
             // `selected_ids_buf` at the i-th `top_k` block and
             // `norm_out` at the i-th hidden row directly. Falls back
             // to copy_slice path if backend doesn't support offsets.
@@ -2581,11 +2578,10 @@ impl<B: MoeLlmBackend> Qwen3MoeModel<B> {
 
                 // Stacked gate / up gemvs — broadcast item i's row of
                 // norm_out across top_k slots, read item i's ids.
-                let gate_res = B::gemv_quant_moe_id_offset(
+                let gate_res = moe_layer.experts.gemv_gate_offset(
                     ctx,
                     &self.scratch.norm_out,
                     activation_offset,
-                    gate_stacked,
                     &self.scratch.selected_ids_buf,
                     ids_offset,
                     &mut self.scratch.gate_out_stacked,
@@ -2619,23 +2615,19 @@ impl<B: MoeLlmBackend> Qwen3MoeModel<B> {
                         0,
                         h,
                     );
-                    B::gemv_quant_moe_id(
+                    moe_layer.experts.gemv_gate(
                         ctx,
                         &self.scratch.x_single,
-                        gate_stacked,
                         &self.scratch.ids_buf,
                         &mut self.scratch.gate_out_stacked,
                         top_k,
-                        0,
                     )?;
-                    B::gemv_quant_moe_id(
+                    moe_layer.experts.gemv_up(
                         ctx,
                         &self.scratch.x_single,
-                        up_stacked,
                         &self.scratch.ids_buf,
                         &mut self.scratch.up_out_stacked,
                         top_k,
-                        0,
                     )?;
                     B::silu_mul_stacked(
                         ctx,
@@ -2645,10 +2637,9 @@ impl<B: MoeLlmBackend> Qwen3MoeModel<B> {
                         top_k,
                         inter,
                     )?;
-                    B::gemv_quant_moe_id(
+                    moe_layer.experts.gemv_down(
                         ctx,
                         &self.scratch.silu_stacked,
-                        down_stacked,
                         &self.scratch.ids_buf,
                         &mut self.scratch.down_out_stacked,
                         top_k,
@@ -2674,11 +2665,10 @@ impl<B: MoeLlmBackend> Qwen3MoeModel<B> {
                     continue;
                 }
                 // Fast path: offset-aware all the way through.
-                B::gemv_quant_moe_id_offset(
+                moe_layer.experts.gemv_up_offset(
                     ctx,
                     &self.scratch.norm_out,
                     activation_offset,
-                    up_stacked,
                     &self.scratch.selected_ids_buf,
                     ids_offset,
                     &mut self.scratch.up_out_stacked,
@@ -2693,11 +2683,10 @@ impl<B: MoeLlmBackend> Qwen3MoeModel<B> {
                     top_k,
                     inter,
                 )?;
-                B::gemv_quant_moe_id_offset(
+                moe_layer.experts.gemv_down_offset(
                     ctx,
                     &self.scratch.silu_stacked,
                     0, // silu_stacked itself stays at offset 0 each iter
-                    down_stacked,
                     &self.scratch.selected_ids_buf,
                     ids_offset,
                     &mut self.scratch.down_out_stacked,

--- a/crates/ferrum-models/src/moe/dispatch.rs
+++ b/crates/ferrum-models/src/moe/dispatch.rs
@@ -197,6 +197,381 @@ impl<B: QuantLlmBackend + BackendMoeFused> ExpertStack<B> {
         })?;
         B::gemv_quant_moe_id_gate_up_silu(ctx, input, gate, up, ids, out_silu_stacked, top_k)
     }
+
+    // ── Prefill GEMM dispatch (Phase 3d) ──
+    //
+    // Same role as the gemv wrappers above, but for the m>1 path that
+    // emits batched mul_mm_id instead of per-pair gemv. `args_buf`
+    // toggles between direct (`gemm_quant_moe_id`) and indirect-grid
+    // (`gemm_quant_moe_id_indirect`) dispatch — the indirect form lets
+    // `compute_ids_tpe_gpu` produce a tighter grid sized to `max(tpe[e])`.
+    //
+    // ne11 is fixed by role: gate/up = 1 (broadcast across slots),
+    // down = top_k (per-slot src1 read). Callers no longer pass it.
+
+    /// Gate prefill GEMM. `dst` shape: `[batch, top_k, expert_inter]`.
+    /// `args_buf=Some` triggers indirect-grid dispatch.
+    #[allow(clippy::too_many_arguments)]
+    pub fn gemm_gate(
+        &self,
+        ctx: &mut B::Context,
+        src1: &B::Buffer,
+        ids: &B::Buffer,
+        tpe: &B::Buffer,
+        dst: &mut B::Buffer,
+        args_buf: Option<&B::Buffer>,
+        top_k: usize,
+        max_per_expert: usize,
+        tokens: usize,
+    ) -> Result<()> {
+        let weight = self.gate_stacked.as_ref().ok_or_else(|| {
+            FerrumError::unsupported("ExpertStack::gemm_gate: gate_stacked not loaded")
+        })?;
+        match args_buf {
+            Some(args) => B::gemm_quant_moe_id_indirect(
+                ctx,
+                src1,
+                weight,
+                ids,
+                tpe,
+                dst,
+                args,
+                1,
+                top_k,
+                max_per_expert,
+                tokens,
+            ),
+            None => B::gemm_quant_moe_id(
+                ctx,
+                src1,
+                weight,
+                ids,
+                tpe,
+                dst,
+                1,
+                top_k,
+                max_per_expert,
+                tokens,
+            ),
+        }
+    }
+
+    /// Up prefill GEMM. Same shape contract as [`Self::gemm_gate`].
+    #[allow(clippy::too_many_arguments)]
+    pub fn gemm_up(
+        &self,
+        ctx: &mut B::Context,
+        src1: &B::Buffer,
+        ids: &B::Buffer,
+        tpe: &B::Buffer,
+        dst: &mut B::Buffer,
+        args_buf: Option<&B::Buffer>,
+        top_k: usize,
+        max_per_expert: usize,
+        tokens: usize,
+    ) -> Result<()> {
+        let weight = self.up_stacked.as_ref().ok_or_else(|| {
+            FerrumError::unsupported("ExpertStack::gemm_up: up_stacked not loaded")
+        })?;
+        match args_buf {
+            Some(args) => B::gemm_quant_moe_id_indirect(
+                ctx,
+                src1,
+                weight,
+                ids,
+                tpe,
+                dst,
+                args,
+                1,
+                top_k,
+                max_per_expert,
+                tokens,
+            ),
+            None => B::gemm_quant_moe_id(
+                ctx,
+                src1,
+                weight,
+                ids,
+                tpe,
+                dst,
+                1,
+                top_k,
+                max_per_expert,
+                tokens,
+            ),
+        }
+    }
+
+    /// Down prefill GEMM. `dst` shape: `[batch, top_k, hidden]`.
+    /// ne11=top_k (per-slot src1 read from `silu_stacked[batch, top_k, inter]`).
+    #[allow(clippy::too_many_arguments)]
+    pub fn gemm_down(
+        &self,
+        ctx: &mut B::Context,
+        src1: &B::Buffer,
+        ids: &B::Buffer,
+        tpe: &B::Buffer,
+        dst: &mut B::Buffer,
+        args_buf: Option<&B::Buffer>,
+        top_k: usize,
+        max_per_expert: usize,
+        tokens: usize,
+    ) -> Result<()> {
+        let weight = self.down_stacked.as_ref().ok_or_else(|| {
+            FerrumError::unsupported("ExpertStack::gemm_down: down_stacked not loaded")
+        })?;
+        match args_buf {
+            Some(args) => B::gemm_quant_moe_id_indirect(
+                ctx,
+                src1,
+                weight,
+                ids,
+                tpe,
+                dst,
+                args,
+                top_k,
+                top_k,
+                max_per_expert,
+                tokens,
+            ),
+            None => B::gemm_quant_moe_id(
+                ctx,
+                src1,
+                weight,
+                ids,
+                tpe,
+                dst,
+                top_k,
+                top_k,
+                max_per_expert,
+                tokens,
+            ),
+        }
+    }
+
+    // ── Batched-decode GEMV dispatch (Phase 3d) ──
+    //
+    // For the small-m batched-decode range (c=2..32). Single Metal
+    // launch covers all m*top_k (token, expert) pairs.
+
+    /// Gate batched gemv: `dst[m * top_k]` with broadcast input
+    /// (slots within a token share the activation row).
+    #[allow(clippy::too_many_arguments)]
+    pub fn gemv_gate_batched(
+        &self,
+        ctx: &mut B::Context,
+        input: &B::Buffer,
+        ids: &B::Buffer,
+        dst: &mut B::Buffer,
+        m: usize,
+        top_k: usize,
+        src1_outer_stride: usize,
+        src1_inner_stride: usize,
+    ) -> Result<()> {
+        let weight = self.gate_stacked.as_ref().ok_or_else(|| {
+            FerrumError::unsupported("ExpertStack::gemv_gate_batched: gate_stacked not loaded")
+        })?;
+        B::gemv_quant_moe_id_batched(
+            ctx,
+            input,
+            weight,
+            ids,
+            dst,
+            m,
+            top_k,
+            src1_outer_stride,
+            src1_inner_stride,
+        )
+    }
+
+    /// Up batched gemv: same shape as [`Self::gemv_gate_batched`].
+    #[allow(clippy::too_many_arguments)]
+    pub fn gemv_up_batched(
+        &self,
+        ctx: &mut B::Context,
+        input: &B::Buffer,
+        ids: &B::Buffer,
+        dst: &mut B::Buffer,
+        m: usize,
+        top_k: usize,
+        src1_outer_stride: usize,
+        src1_inner_stride: usize,
+    ) -> Result<()> {
+        let weight = self.up_stacked.as_ref().ok_or_else(|| {
+            FerrumError::unsupported("ExpertStack::gemv_up_batched: up_stacked not loaded")
+        })?;
+        B::gemv_quant_moe_id_batched(
+            ctx,
+            input,
+            weight,
+            ids,
+            dst,
+            m,
+            top_k,
+            src1_outer_stride,
+            src1_inner_stride,
+        )
+    }
+
+    /// Down batched gemv: src1 = `silu_stacked[m, top_k, inter]` per-slot read.
+    #[allow(clippy::too_many_arguments)]
+    pub fn gemv_down_batched(
+        &self,
+        ctx: &mut B::Context,
+        input: &B::Buffer,
+        ids: &B::Buffer,
+        dst: &mut B::Buffer,
+        m: usize,
+        top_k: usize,
+        src1_outer_stride: usize,
+        src1_inner_stride: usize,
+    ) -> Result<()> {
+        let weight = self.down_stacked.as_ref().ok_or_else(|| {
+            FerrumError::unsupported("ExpertStack::gemv_down_batched: down_stacked not loaded")
+        })?;
+        B::gemv_quant_moe_id_batched(
+            ctx,
+            input,
+            weight,
+            ids,
+            dst,
+            m,
+            top_k,
+            src1_outer_stride,
+            src1_inner_stride,
+        )
+    }
+
+    /// Fused batched gate + up + SiLU·gate. Single dispatch over `m * top_k`
+    /// pairs. Caller gates on `B::supports_batched_moe_gate_up_silu()` first.
+    #[allow(clippy::too_many_arguments)]
+    pub fn gemv_gate_up_silu_batched_fused(
+        &self,
+        ctx: &mut B::Context,
+        input: &B::Buffer,
+        ids: &B::Buffer,
+        silu_out: &mut B::Buffer,
+        m: usize,
+        top_k: usize,
+        src1_outer_stride: usize,
+        src1_inner_stride: usize,
+    ) -> Result<()> {
+        let gate = self.gate_stacked.as_ref().ok_or_else(|| {
+            FerrumError::unsupported(
+                "ExpertStack::gemv_gate_up_silu_batched_fused: gate_stacked not loaded",
+            )
+        })?;
+        let up = self.up_stacked.as_ref().ok_or_else(|| {
+            FerrumError::unsupported(
+                "ExpertStack::gemv_gate_up_silu_batched_fused: up_stacked not loaded",
+            )
+        })?;
+        B::gemv_quant_moe_id_gate_up_silu_batched(
+            ctx,
+            input,
+            gate,
+            up,
+            ids,
+            silu_out,
+            m,
+            top_k,
+            src1_outer_stride,
+            src1_inner_stride,
+        )
+    }
+
+    // ── Per-item offset GEMV (Phase 3d, qwen3_moe.rs decode path) ──
+    //
+    // Used by the per-item batched-decode loop in `Qwen3MoeModel::forward`
+    // when offset variants are supported. Reads `src1` at `src1_offset`
+    // floats and `ids` at `ids_offset` ids, writes `dst` from offset 0.
+
+    /// Gate offset gemv. `src1_stride=0` → broadcast.
+    #[allow(clippy::too_many_arguments)]
+    pub fn gemv_gate_offset(
+        &self,
+        ctx: &mut B::Context,
+        src1: &B::Buffer,
+        src1_offset: usize,
+        ids: &B::Buffer,
+        ids_offset: usize,
+        dst: &mut B::Buffer,
+        top_k: usize,
+        src1_stride: usize,
+    ) -> Result<()> {
+        let weight = self.gate_stacked.as_ref().ok_or_else(|| {
+            FerrumError::unsupported("ExpertStack::gemv_gate_offset: gate_stacked not loaded")
+        })?;
+        B::gemv_quant_moe_id_offset(
+            ctx,
+            src1,
+            src1_offset,
+            weight,
+            ids,
+            ids_offset,
+            dst,
+            top_k,
+            src1_stride,
+        )
+    }
+
+    /// Up offset gemv.
+    #[allow(clippy::too_many_arguments)]
+    pub fn gemv_up_offset(
+        &self,
+        ctx: &mut B::Context,
+        src1: &B::Buffer,
+        src1_offset: usize,
+        ids: &B::Buffer,
+        ids_offset: usize,
+        dst: &mut B::Buffer,
+        top_k: usize,
+        src1_stride: usize,
+    ) -> Result<()> {
+        let weight = self.up_stacked.as_ref().ok_or_else(|| {
+            FerrumError::unsupported("ExpertStack::gemv_up_offset: up_stacked not loaded")
+        })?;
+        B::gemv_quant_moe_id_offset(
+            ctx,
+            src1,
+            src1_offset,
+            weight,
+            ids,
+            ids_offset,
+            dst,
+            top_k,
+            src1_stride,
+        )
+    }
+
+    /// Down offset gemv.
+    #[allow(clippy::too_many_arguments)]
+    pub fn gemv_down_offset(
+        &self,
+        ctx: &mut B::Context,
+        src1: &B::Buffer,
+        src1_offset: usize,
+        ids: &B::Buffer,
+        ids_offset: usize,
+        dst: &mut B::Buffer,
+        top_k: usize,
+        src1_stride: usize,
+    ) -> Result<()> {
+        let weight = self.down_stacked.as_ref().ok_or_else(|| {
+            FerrumError::unsupported("ExpertStack::gemv_down_offset: down_stacked not loaded")
+        })?;
+        B::gemv_quant_moe_id_offset(
+            ctx,
+            src1,
+            src1_offset,
+            weight,
+            ids,
+            ids_offset,
+            dst,
+            top_k,
+            src1_stride,
+        )
+    }
 }
 
 impl<B: QuantLlmBackend + BackendMoeFused> ExpertStack<B> {

--- a/crates/ferrum-models/src/moe/forward.rs
+++ b/crates/ferrum-models/src/moe/forward.rs
@@ -343,75 +343,39 @@ pub(crate) fn moe_forward_batched_prefill_impl<B: QuantLlmBackend + BackendMoeFu
         max_per_expert
     };
 
-    let gate_stacked = moe_layer.experts.gate_stacked.as_ref().unwrap();
-    let up_stacked = moe_layer.experts.up_stacked.as_ref().unwrap();
-    let down_stacked = moe_layer.experts.down_stacked.as_ref().unwrap();
-
     // 1. Batched gate gemm — one launch covers all (token, expert) pairs.
     //    src1 layout: [batch, ne11=1, K] (broadcast: each pair reads its
     //    token's row, slot index ignored).
     //    dst layout:  [batch, top_k, expert_inter] — natural.
+    let gate_up_args = use_indirect_dispatch.then_some(&scratch.gate_up_args_buf);
+    let down_args = use_indirect_dispatch.then_some(&scratch.down_args_buf);
     let t0 = stage_t0();
-    if use_indirect_dispatch {
-        B::gemm_quant_moe_id_indirect(
-            ctx,
-            &scratch.norm_out,
-            gate_stacked,
-            &scratch.ids_2d,
-            &scratch.tpe_buf,
-            &mut scratch.gate_out_stacked,
-            &scratch.gate_up_args_buf,
-            1, // ne11 = 1: broadcast
-            top_k,
-            max_per_expert,
-            tokens,
-        )?;
-    } else {
-        B::gemm_quant_moe_id(
-            ctx,
-            &scratch.norm_out,
-            gate_stacked,
-            &scratch.ids_2d,
-            &scratch.tpe_buf,
-            &mut scratch.gate_out_stacked,
-            1,
-            top_k,
-            max_per_expert,
-            tokens,
-        )?;
-    }
+    moe_layer.experts.gemm_gate(
+        ctx,
+        &scratch.norm_out,
+        &scratch.ids_2d,
+        &scratch.tpe_buf,
+        &mut scratch.gate_out_stacked,
+        gate_up_args,
+        top_k,
+        max_per_expert,
+        tokens,
+    )?;
     stage_end(t0, ctx, &MOE_PREFILL_GATE_US, &MOE_PREFILL_GATE_CALLS);
 
     // 2. Batched up gemm — same shape as gate.
     let t0 = stage_t0();
-    if use_indirect_dispatch {
-        B::gemm_quant_moe_id_indirect(
-            ctx,
-            &scratch.norm_out,
-            up_stacked,
-            &scratch.ids_2d,
-            &scratch.tpe_buf,
-            &mut scratch.up_out_stacked,
-            &scratch.gate_up_args_buf,
-            1,
-            top_k,
-            max_per_expert,
-            tokens,
-        )?;
-    } else {
-        B::gemm_quant_moe_id(
-            ctx,
-            &scratch.norm_out,
-            up_stacked,
-            &scratch.ids_2d,
-            &scratch.tpe_buf,
-            &mut scratch.up_out_stacked,
-            1,
-            top_k,
-            max_per_expert,
-            tokens,
-        )?;
-    }
+    moe_layer.experts.gemm_up(
+        ctx,
+        &scratch.norm_out,
+        &scratch.ids_2d,
+        &scratch.tpe_buf,
+        &mut scratch.up_out_stacked,
+        gate_up_args,
+        top_k,
+        max_per_expert,
+        tokens,
+    )?;
     stage_end(t0, ctx, &MOE_PREFILL_UP_US, &MOE_PREFILL_UP_CALLS);
 
     // 3. SiLU·gate over [tokens * top_k, expert_inter] flat layout.
@@ -430,34 +394,17 @@ pub(crate) fn moe_forward_batched_prefill_impl<B: QuantLlmBackend + BackendMoeFu
     // 4. Batched down gemm — src1 is [batch, top_k, expert_inter] from
     //    silu_stacked. ne11 = top_k → each pair reads its own row.
     let t0 = stage_t0();
-    if use_indirect_dispatch {
-        B::gemm_quant_moe_id_indirect(
-            ctx,
-            &scratch.silu_stacked,
-            down_stacked,
-            &scratch.ids_2d,
-            &scratch.tpe_buf,
-            &mut scratch.down_out_stacked,
-            &scratch.down_args_buf,
-            top_k, // ne11 = top_k: per-slot
-            top_k,
-            max_per_expert,
-            tokens,
-        )?;
-    } else {
-        B::gemm_quant_moe_id(
-            ctx,
-            &scratch.silu_stacked,
-            down_stacked,
-            &scratch.ids_2d,
-            &scratch.tpe_buf,
-            &mut scratch.down_out_stacked,
-            top_k,
-            top_k,
-            max_per_expert,
-            tokens,
-        )?;
-    }
+    moe_layer.experts.gemm_down(
+        ctx,
+        &scratch.silu_stacked,
+        &scratch.ids_2d,
+        &scratch.tpe_buf,
+        &mut scratch.down_out_stacked,
+        down_args,
+        top_k,
+        max_per_expert,
+        tokens,
+    )?;
     stage_end(t0, ctx, &MOE_PREFILL_DOWN_US, &MOE_PREFILL_DOWN_CALLS);
 
     // 5. Per-batch weighted sum: moe_out[b, h] = Σ_k w[b,k] · down[b,k,h]
@@ -542,20 +489,14 @@ pub(crate) fn moe_forward_batched_decode_impl<B: QuantLlmBackend + BackendMoeFus
     )?;
     stage_end(t0, ctx, &MOE_BATCHED_DECODE_ROUTE_US);
 
-    let gate_stacked = moe_layer.experts.gate_stacked.as_ref().unwrap();
-    let up_stacked = moe_layer.experts.up_stacked.as_ref().unwrap();
-    let down_stacked = moe_layer.experts.down_stacked.as_ref().unwrap();
-
     // 2+3+4. Fused gate+up+silu — single Metal dispatch covers all
     // m*top_k pairs. Falls back to the 3-dispatch sequence on backends
     // that don't have the fused-batched kernel.
     if B::supports_batched_moe_gate_up_silu() {
         let t0 = stage_t0();
-        B::gemv_quant_moe_id_gate_up_silu_batched(
+        moe_layer.experts.gemv_gate_up_silu_batched_fused(
             ctx,
             &scratch.norm_out,
-            gate_stacked,
-            up_stacked,
             &scratch.selected_ids_buf,
             &mut scratch.silu_stacked,
             tokens,
@@ -569,10 +510,9 @@ pub(crate) fn moe_forward_batched_decode_impl<B: QuantLlmBackend + BackendMoeFus
     } else {
         // 2. Batched gate gemv — one launch covers all m*top_k pairs.
         let t0 = stage_t0();
-        B::gemv_quant_moe_id_batched(
+        moe_layer.experts.gemv_gate_batched(
             ctx,
             &scratch.norm_out,
-            gate_stacked,
             &scratch.selected_ids_buf,
             &mut scratch.gate_out_stacked,
             tokens,
@@ -584,10 +524,9 @@ pub(crate) fn moe_forward_batched_decode_impl<B: QuantLlmBackend + BackendMoeFus
 
         // 3. Batched up gemv.
         let t0 = stage_t0();
-        B::gemv_quant_moe_id_batched(
+        moe_layer.experts.gemv_up_batched(
             ctx,
             &scratch.norm_out,
-            up_stacked,
             &scratch.selected_ids_buf,
             &mut scratch.up_out_stacked,
             tokens,
@@ -613,10 +552,9 @@ pub(crate) fn moe_forward_batched_decode_impl<B: QuantLlmBackend + BackendMoeFus
     // 5. Batched down gemv — src1 = silu_stacked [m, top_k, ffn]: each
     //    pair has its own row, outer = top_k * ffn, inner = ffn.
     let t0 = stage_t0();
-    B::gemv_quant_moe_id_batched(
+    moe_layer.experts.gemv_down_batched(
         ctx,
         &scratch.silu_stacked,
-        down_stacked,
         &scratch.selected_ids_buf,
         &mut scratch.down_out_stacked,
         tokens,


### PR DESCRIPTION
## Summary
Continues Phase 3c (#113). Replaces every remaining `B::gemm_quant_moe_id*` and `B::gemv_quant_moe_id*` call site with a method on `ExpertStack<B>`, so the MoE forward path no longer reaches into `gate_stacked` / `up_stacked` / `down_stacked` directly.

10 new methods on `ExpertStack`:
- prefill GEMM: `gemm_gate` / `gemm_up` / `gemm_down` (single method per role; `args_buf: Option<&B::Buffer>` selects between direct and indirect-grid dispatch; ne11 hardcoded by role)
- batched-decode GEMV: `gemv_gate_batched` / `gemv_up_batched` / `gemv_down_batched` / `gemv_gate_up_silu_batched_fused`
- per-item offset GEMV (qwen3_moe decode): `gemv_gate_offset` / `gemv_up_offset` / `gemv_down_offset`

Sites converted:
- `moe/forward.rs::moe_forward_batched_prefill_impl` (3 GEMM, 6 raw calls)
- `moe/forward.rs::moe_forward_batched_decode_impl` (3 GEMV + 1 fused, 4 raw calls)
- `models/qwen3_moe.rs` per-item batched-decode loop (3 offset + 3 fallback, 6 raw calls)

Net: 16 raw `B::*_moe_id*` calls in models/ → 0. The Backend supertraits still expose those methods because ExpertStack delegates to them; future Phase 3e/3f will move the impl bodies into `Linear<B>`.

No behavior change. ne11/strides match previous call sites exactly.

## Test plan
- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo test --workspace --features metal --lib` 457 passed
- [ ] CUDA bench (Vast 4090): Qwen3-0.6B / Llama-8B INT4 / 30B-A3B vLLM Marlin / 30B-A3B IST Marlin