### PR TITLE
refactor(engine): split InferenceEngine into per-modality traits (Phase 5a step 2)

### DIFF
--- a/crates/ferrum-cli/src/commands/bench.rs
+++ b/crates/ferrum-cli/src/commands/bench.rs
@@ -210,7 +210,7 @@ pub async fn execute(cmd: BenchCommand, config: CliConfig) -> Result<()> {
 // ── Sequential benchmark (existing behavior) ────────────────────────
 
 async fn run_sequential_bench(
-    engine: &(dyn ferrum_interfaces::InferenceEngine + Send + Sync),
+    engine: &(dyn ferrum_interfaces::engine::LlmInferenceEngine + Send + Sync),
     model_id: &str,
     prompt: &str,
     cmd: &BenchCommand,
@@ -263,7 +263,7 @@ async fn run_sequential_bench(
 // ── Concurrent benchmark (tests batch decode) ───────────────────────
 
 async fn run_concurrent_bench(
-    engine: &(dyn ferrum_interfaces::InferenceEngine + Send + Sync),
+    engine: &(dyn ferrum_interfaces::engine::LlmInferenceEngine + Send + Sync),
     model_id: &str,
     prompt: &str,
     cmd: &BenchCommand,
@@ -455,7 +455,7 @@ fn make_request(model_id: &str, prompt: &str, max_tokens: u32) -> InferenceReque
 }
 
 async fn run_single(
-    engine: &(dyn ferrum_interfaces::InferenceEngine + Send + Sync),
+    engine: &(dyn ferrum_interfaces::engine::LlmInferenceEngine + Send + Sync),
     model_id: &str,
     prompt: &str,
     max_tokens: u32,

--- a/crates/ferrum-cli/src/commands/serve.rs
+++ b/crates/ferrum-cli/src/commands/serve.rs
@@ -3,7 +3,6 @@
 use crate::config::CliConfig;
 use clap::Args;
 use colored::*;
-use ferrum_interfaces::InferenceEngine;
 use ferrum_models::source::ModelFormat;
 use ferrum_server::{AxumServer, HttpServer, ServerConfig};
 use ferrum_types::Result;
@@ -242,7 +241,7 @@ pub async fn execute(cmd: ServeCommand, config: CliConfig) -> Result<()> {
         Some(model_def.architecture)
     };
 
-    let engine: Arc<dyn InferenceEngine + Send + Sync> = match arch_for_dispatch {
+    let server = match arch_for_dispatch {
         Some(ferrum_models::Architecture::Clip) => {
             println!("{}", "Initializing CLIP embedding engine...".dimmed());
             let candle_device = candle_core::Device::Cpu;
@@ -253,10 +252,11 @@ pub async fn execute(cmd: ServeCommand, config: CliConfig) -> Result<()> {
             )?;
             let tokenizer = crate::commands::embed::load_tokenizer(&source.local_path)?;
             let engine_config = ferrum_engine::simple_engine_config(model_id.clone(), device);
-            Arc::new(
+            let engine: Arc<dyn ferrum_engine::EmbedEngine + Send + Sync> = Arc::new(
                 ferrum_engine::embedding_engine::EmbeddingEngine::new(executor, engine_config)
                     .with_tokenizer(tokenizer),
-            )
+            );
+            AxumServer::from_embed(engine)
         }
         Some(ferrum_models::Architecture::Whisper) => {
             println!("{}", "Initializing Whisper ASR engine...".dimmed());
@@ -267,12 +267,13 @@ pub async fn execute(cmd: ServeCommand, config: CliConfig) -> Result<()> {
                 candle_core::DType::F32,
             )?;
             let engine_config = ferrum_engine::simple_engine_config(model_id.clone(), device);
-            Arc::new(
+            let engine: Arc<dyn ferrum_engine::TranscribeEngine + Send + Sync> = Arc::new(
                 ferrum_engine::transcription_engine::TranscriptionEngine::new(
                     executor,
                     engine_config,
                 ),
-            )
+            );
+            AxumServer::from_transcribe(engine)
         }
         Some(ferrum_models::Architecture::Qwen3TTS) => {
             let n_slots = tts_slots.max(1);
@@ -298,10 +299,12 @@ pub async fn execute(cmd: ServeCommand, config: CliConfig) -> Result<()> {
                 }
                 executors.push(executor);
             }
-            Arc::new(ferrum_engine::tts_engine::TtsEngine::new_multi(
-                executors,
-                ferrum_types::ModelId(model_id.clone()),
-            ))
+            let engine: Arc<dyn ferrum_engine::TtsEngine + Send + Sync> =
+                Arc::new(ferrum_engine::tts_engine::TtsService::new_multi(
+                    executors,
+                    ferrum_types::ModelId(model_id.clone()),
+                ));
+            AxumServer::from_tts(engine)
         }
         _ => {
             println!(
@@ -311,8 +314,9 @@ pub async fn execute(cmd: ServeCommand, config: CliConfig) -> Result<()> {
             let mut engine_config = ferrum_engine::simple_engine_config(model_id.clone(), device);
             engine_config.scheduler.policy = ferrum_types::SchedulingPolicy::ContinuousBatch;
             engine_config.kv_cache.cache_type = ferrum_types::KvCacheType::Paged;
-            let engine = ferrum_engine::create_default_engine(engine_config).await?;
-            Arc::from(engine)
+            let engine: Arc<dyn ferrum_engine::LlmInferenceEngine + Send + Sync> =
+                Arc::from(ferrum_engine::create_default_engine(engine_config).await?);
+            AxumServer::from_llm(engine)
         }
     };
 
@@ -322,9 +326,6 @@ pub async fn execute(cmd: ServeCommand, config: CliConfig) -> Result<()> {
         port,
         ..Default::default()
     };
-
-    // Create server with engine
-    let server = AxumServer::new(engine);
 
     println!();
     println!(

--- a/crates/ferrum-engine/benches/engine_bench.rs
+++ b/crates/ferrum-engine/benches/engine_bench.rs
@@ -7,7 +7,7 @@
 //! and engine overhead, not model computation.
 
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
-use ferrum_engine::{ContinuousBatchEngine, InferenceEngineInterface};
+use ferrum_engine::{ContinuousBatchEngine, LlmInferenceEngine};
 use ferrum_scheduler::implementations::ContinuousBatchScheduler;
 use ferrum_testkit::{
     MockKvCacheManager, MockModelExecutor, MockSampler, MockTensorFactory, MockTokenizer,

--- a/crates/ferrum-engine/src/builder.rs
+++ b/crates/ferrum-engine/src/builder.rs
@@ -10,9 +10,10 @@
 
 use crate::registry::{ComponentConfig, ComponentRegistry};
 use crate::DefaultInferenceEngine;
+use ferrum_interfaces::engine::LlmInferenceEngine;
 use ferrum_interfaces::{
-    ComputeBackend, InferenceEngine, KvCacheManager, ModelExecutor, Sampler,
-    SchedulerInterface as Scheduler, TensorFactory, Tokenizer,
+    ComputeBackend, KvCacheManager, ModelExecutor, Sampler, SchedulerInterface as Scheduler,
+    TensorFactory, Tokenizer,
 };
 use ferrum_types::{EngineConfig, FerrumError, Result, SchedulingPolicy};
 use std::sync::Arc;
@@ -232,7 +233,7 @@ impl EngineBuilder {
     }
 
     /// Build the inference engine
-    pub async fn build(self) -> Result<Box<dyn InferenceEngine + Send + Sync>> {
+    pub async fn build(self) -> Result<Box<dyn LlmInferenceEngine + Send + Sync>> {
         info!(
             "Building inference engine for model: {}",
             self.config.model.model_id
@@ -444,7 +445,9 @@ impl EngineBuilder {
 }
 
 /// Create an engine with the default configuration and registry
-pub async fn create_engine(config: EngineConfig) -> Result<Box<dyn InferenceEngine + Send + Sync>> {
+pub async fn create_engine(
+    config: EngineConfig,
+) -> Result<Box<dyn LlmInferenceEngine + Send + Sync>> {
     EngineBuilder::new(config).build().await
 }
 

--- a/crates/ferrum-engine/src/continuous_engine.rs
+++ b/crates/ferrum-engine/src/continuous_engine.rs
@@ -7,8 +7,10 @@
 
 use async_trait::async_trait;
 use ferrum_interfaces::{
-    engine::InferenceEngine, kv_cache::AllocationRequest, KvCacheHandle, KvCacheManager,
-    ModelExecutor, Sampler, SchedulerInterface as Scheduler, TensorFactory, TensorRef, Tokenizer,
+    engine::{InferenceEngine, LlmInferenceEngine},
+    kv_cache::AllocationRequest,
+    KvCacheHandle, KvCacheManager, ModelExecutor, Sampler, SchedulerInterface as Scheduler,
+    TensorFactory, TensorRef, Tokenizer,
 };
 use ferrum_kv::cache::prefix::PrefixCache;
 use ferrum_sampler::json_mode::JsonModeProcessor;
@@ -1431,7 +1433,7 @@ impl ContinuousBatchEngine {
 }
 
 #[async_trait]
-impl InferenceEngine for ContinuousBatchEngine {
+impl LlmInferenceEngine for ContinuousBatchEngine {
     async fn infer(&self, request: InferenceRequest) -> Result<InferenceResponse> {
         let request_id = request.id.clone();
         let infer_start = Instant::now();
@@ -1515,7 +1517,10 @@ impl InferenceEngine for ContinuousBatchEngine {
 
         Ok(Box::pin(tokio_stream::wrappers::ReceiverStream::new(rx)))
     }
+}
 
+#[async_trait]
+impl InferenceEngine for ContinuousBatchEngine {
     async fn status(&self) -> EngineStatus {
         let metrics = self.inner.scheduler.metrics();
         EngineStatus {

--- a/crates/ferrum-engine/src/embedding_engine.rs
+++ b/crates/ferrum-engine/src/embedding_engine.rs
@@ -1,18 +1,14 @@
 //! Lightweight engine for embedding models (CLIP, BERT, etc.).
 //!
-//! Unlike the full inference engine, this doesn't need scheduling,
-//! KV cache management, or token generation. It just wraps an executor
-//! and provides embed_text / embed_image via the InferenceEngine trait.
+//! Wraps a `ClipModelExecutor` and implements `EmbedEngine` directly —
+//! no LLM-method stubs, no fake `InferenceEngine::infer` impls. The
+//! `InferenceEngine` supertrait covers lifecycle/status; the modality
+//! itself goes through `EmbedEngine`.
 
 use async_trait::async_trait;
-use ferrum_interfaces::engine::InferenceEngine;
+use ferrum_interfaces::engine::{EmbedEngine, InferenceEngine};
 use ferrum_models::ClipModelExecutor;
-use ferrum_types::{
-    EngineConfig, EngineMetrics, EngineStatus, FerrumError, InferenceRequest, InferenceResponse,
-    Result, StreamChunk,
-};
-use futures::Stream;
-use std::pin::Pin;
+use ferrum_types::{EngineConfig, EngineMetrics, EngineStatus, FerrumError, Result};
 use std::sync::Arc;
 
 /// Embedding-only engine wrapping a ClipModelExecutor.
@@ -40,40 +36,8 @@ impl EmbeddingEngine {
 
 #[async_trait]
 impl InferenceEngine for EmbeddingEngine {
-    async fn infer(&self, _request: InferenceRequest) -> Result<InferenceResponse> {
-        Err(FerrumError::model(
-            "Embedding models don't support text generation. Use /v1/embeddings instead.",
-        ))
-    }
-
-    async fn infer_stream(
-        &self,
-        _request: InferenceRequest,
-    ) -> Result<Pin<Box<dyn Stream<Item = Result<StreamChunk>> + Send>>> {
-        Err(FerrumError::model(
-            "Embedding models don't support streaming. Use /v1/embeddings instead.",
-        ))
-    }
-
     async fn status(&self) -> EngineStatus {
-        EngineStatus {
-            is_ready: true,
-            loaded_models: vec![],
-            active_requests: 0,
-            queued_requests: 0,
-            memory_usage: ferrum_types::MemoryUsage {
-                total_bytes: 0,
-                used_bytes: 0,
-                free_bytes: 0,
-                gpu_memory_bytes: None,
-                cpu_memory_bytes: None,
-                cache_memory_bytes: 0,
-                utilization_percent: 0.0,
-            },
-            uptime_seconds: 0,
-            last_heartbeat: chrono::Utc::now(),
-            version: env!("CARGO_PKG_VERSION").to_string(),
-        }
+        crate::modality_stubs::inert_status()
     }
 
     async fn shutdown(&self) -> Result<()> {
@@ -91,7 +55,10 @@ impl InferenceEngine for EmbeddingEngine {
     async fn health_check(&self) -> ferrum_types::HealthStatus {
         crate::modality_stubs::inert_health()
     }
+}
 
+#[async_trait]
+impl EmbedEngine for EmbeddingEngine {
     async fn embed_text(&self, text: &str) -> Result<Vec<f32>> {
         let tokenizer = self
             .tokenizer

--- a/crates/ferrum-engine/src/engine.rs
+++ b/crates/ferrum-engine/src/engine.rs
@@ -1,6 +1,7 @@
 //! Main inference engine - MVP implementation
 
 use async_trait::async_trait;
+use ferrum_interfaces::engine::LlmInferenceEngine;
 use ferrum_interfaces::sampler::{SamplingConfigBuilder, SamplingContext};
 use ferrum_interfaces::{
     engine::InferenceEngine, AllocationRequest, BatchHint, KvCacheHandle, KvCacheManager,
@@ -474,7 +475,7 @@ impl DefaultInferenceEngine {
 }
 
 #[async_trait]
-impl InferenceEngine for DefaultInferenceEngine {
+impl LlmInferenceEngine for DefaultInferenceEngine {
     async fn infer(&self, request: InferenceRequest) -> Result<InferenceResponse> {
         request.sampling_params.validate()?;
         let _inflight_guard = self.acquire_inflight_guard().await?;
@@ -716,7 +717,10 @@ impl InferenceEngine for DefaultInferenceEngine {
 
         Ok(Box::pin(tokio_stream::wrappers::ReceiverStream::new(rx)))
     }
+}
 
+#[async_trait]
+impl InferenceEngine for DefaultInferenceEngine {
     async fn status(&self) -> EngineStatus {
         EngineStatus {
             is_ready: true,

--- a/crates/ferrum-engine/src/lib.rs
+++ b/crates/ferrum-engine/src/lib.rs
@@ -63,6 +63,7 @@ pub mod tts_engine;
 pub mod metal;
 
 // Re-exports of interfaces
+pub use ferrum_interfaces::engine::{EmbedEngine, LlmInferenceEngine, TranscribeEngine, TtsEngine};
 pub use ferrum_interfaces::{
     IncrementalTokenizer, InferenceEngine as InferenceEngineInterface, KvCacheManager,
     ModelBuilder, ModelExecutor, Sampler, SchedulerInterface as Scheduler, Tokenizer, WeightLoader,
@@ -111,7 +112,7 @@ pub use parallel::{
 /// This is a convenience function that uses the default registry.
 pub async fn create_default_engine(
     config: EngineConfig,
-) -> Result<Box<dyn InferenceEngineInterface + Send + Sync>> {
+) -> Result<Box<dyn LlmInferenceEngine + Send + Sync>> {
     create_engine(config).await
 }
 

--- a/crates/ferrum-engine/src/transcription_engine.rs
+++ b/crates/ferrum-engine/src/transcription_engine.rs
@@ -1,14 +1,9 @@
 //! Lightweight engine for Whisper ASR transcription.
 
 use async_trait::async_trait;
-use ferrum_interfaces::engine::InferenceEngine;
+use ferrum_interfaces::engine::{InferenceEngine, TranscribeEngine};
 use ferrum_models::WhisperModelExecutor;
-use ferrum_types::{
-    EngineConfig, EngineMetrics, EngineStatus, FerrumError, InferenceRequest, InferenceResponse,
-    Result, StreamChunk,
-};
-use futures::Stream;
-use std::pin::Pin;
+use ferrum_types::{EngineConfig, EngineMetrics, EngineStatus, Result};
 use std::sync::Arc;
 
 pub struct TranscriptionEngine {
@@ -27,40 +22,8 @@ impl TranscriptionEngine {
 
 #[async_trait]
 impl InferenceEngine for TranscriptionEngine {
-    async fn infer(&self, _request: InferenceRequest) -> Result<InferenceResponse> {
-        Err(FerrumError::model(
-            "Whisper is an ASR model. Use /v1/audio/transcriptions instead.",
-        ))
-    }
-
-    async fn infer_stream(
-        &self,
-        _request: InferenceRequest,
-    ) -> Result<Pin<Box<dyn Stream<Item = Result<StreamChunk>> + Send>>> {
-        Err(FerrumError::model(
-            "Whisper is an ASR model. Use /v1/audio/transcriptions instead.",
-        ))
-    }
-
     async fn status(&self) -> EngineStatus {
-        EngineStatus {
-            is_ready: true,
-            loaded_models: vec![],
-            active_requests: 0,
-            queued_requests: 0,
-            memory_usage: ferrum_types::MemoryUsage {
-                total_bytes: 0,
-                used_bytes: 0,
-                free_bytes: 0,
-                gpu_memory_bytes: None,
-                cpu_memory_bytes: None,
-                cache_memory_bytes: 0,
-                utilization_percent: 0.0,
-            },
-            uptime_seconds: 0,
-            last_heartbeat: chrono::Utc::now(),
-            version: env!("CARGO_PKG_VERSION").to_string(),
-        }
+        crate::modality_stubs::inert_status()
     }
 
     async fn shutdown(&self) -> Result<()> {
@@ -78,7 +41,10 @@ impl InferenceEngine for TranscriptionEngine {
     async fn health_check(&self) -> ferrum_types::HealthStatus {
         crate::modality_stubs::inert_health()
     }
+}
 
+#[async_trait]
+impl TranscribeEngine for TranscriptionEngine {
     async fn transcribe_file(&self, path: &str, language: Option<&str>) -> Result<String> {
         self.executor.transcribe_file(path, language)
     }

--- a/crates/ferrum-engine/src/tts_engine.rs
+++ b/crates/ferrum-engine/src/tts_engine.rs
@@ -1,32 +1,33 @@
-//! TTS Engine — concurrent slot-based serving of TtsModelExecutor.
+//! TTS service — concurrent slot-based serving of TtsModelExecutor.
 //!
-//! Multiple TTS requests can be processed in parallel, each on its own executor slot.
-//! Slots share nothing (each has its own model weights + KV cache).
-//! Future: Phase 2 will share weights across slots to reduce memory.
+//! Multiple TTS requests can be processed in parallel, each on its own
+//! executor slot. Slots share nothing (each has its own model weights +
+//! KV cache). Future: Phase 2 will share weights across slots to reduce
+//! memory.
+//!
+//! The struct is named `TtsService` to free the `TtsEngine` identifier
+//! for the trait of the same name in `ferrum-interfaces`.
 
 use async_trait::async_trait;
-use ferrum_interfaces::engine::InferenceEngine;
+use ferrum_interfaces::engine::{InferenceEngine, TtsEngine};
 use ferrum_models::executor::tts_executor::TtsModelExecutor;
-use ferrum_types::{
-    EngineConfig, EngineMetrics, EngineStatus, FerrumError, InferenceRequest, InferenceResponse,
-    ModelId, Result, StreamChunk,
-};
-use futures::Stream;
+use ferrum_types::{EngineConfig, EngineMetrics, EngineStatus, FerrumError, ModelId, Result};
 use parking_lot::Mutex;
-use std::pin::Pin;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
-pub struct TtsEngine {
+/// Concurrent TTS service. Implements [`TtsEngine`] (the modality trait)
+/// and [`InferenceEngine`] (lifecycle).
+pub struct TtsService {
     slots: Vec<Arc<Mutex<TtsModelExecutor>>>,
-    /// Semaphore to limit concurrent slot usage
+    /// Semaphore to limit concurrent slot usage.
     semaphore: tokio::sync::Semaphore,
     config: EngineConfig,
     sample_rate: u32,
     active_requests: AtomicUsize,
 }
 
-impl TtsEngine {
+impl TtsService {
     /// Create with a single executor (backward compatible).
     pub fn new(executor: TtsModelExecutor, model_id: ModelId) -> Self {
         let sr = executor.sample_rate() as u32;
@@ -68,22 +69,7 @@ impl TtsEngine {
 }
 
 #[async_trait]
-impl InferenceEngine for TtsEngine {
-    async fn infer(&self, _request: InferenceRequest) -> Result<InferenceResponse> {
-        Err(FerrumError::model(
-            "TTS model. Use /v1/audio/speech instead.",
-        ))
-    }
-
-    async fn infer_stream(
-        &self,
-        _request: InferenceRequest,
-    ) -> Result<Pin<Box<dyn Stream<Item = Result<StreamChunk>> + Send>>> {
-        Err(FerrumError::model(
-            "TTS model. Use /v1/audio/speech instead.",
-        ))
-    }
-
+impl InferenceEngine for TtsService {
     async fn status(&self) -> EngineStatus {
         EngineStatus {
             is_ready: true,
@@ -120,14 +106,17 @@ impl InferenceEngine for TtsEngine {
     async fn health_check(&self) -> ferrum_types::HealthStatus {
         crate::modality_stubs::inert_health()
     }
+}
 
+#[async_trait]
+impl TtsEngine for TtsService {
     async fn synthesize_speech(
         &self,
         text: &str,
         language: Option<&str>,
         chunk_frames: usize,
     ) -> Result<Vec<Vec<f32>>> {
-        // Acquire a slot (waits if all slots busy)
+        // Acquire a slot (waits if all slots busy).
         let _permit = self
             .semaphore
             .acquire()
@@ -136,7 +125,7 @@ impl InferenceEngine for TtsEngine {
 
         self.active_requests.fetch_add(1, Ordering::Relaxed);
 
-        // Find an unlocked slot (semaphore guarantees at least one is available)
+        // Find an unlocked slot (semaphore guarantees at least one is available).
         let slot = self
             .slots
             .iter()
@@ -148,7 +137,7 @@ impl InferenceEngine for TtsEngine {
         let lang = language.unwrap_or("auto").to_string();
         let _active = &self.active_requests;
 
-        // Run TTS on blocking thread (model forward is CPU/GPU bound)
+        // Run TTS on blocking thread (model forward is CPU/GPU bound).
         let result = tokio::task::spawn_blocking(move || {
             let mut executor = slot.lock();
             executor.synthesize_streaming(&text, &lang, chunk_frames, |_, _| {})

--- a/crates/ferrum-engine/tests/backend_safety_test.rs
+++ b/crates/ferrum-engine/tests/backend_safety_test.rs
@@ -9,7 +9,7 @@
 //! - Multi-sequence concurrent decode
 //! - Error handling and cleanup
 
-use ferrum_engine::{ContinuousBatchEngine, InferenceEngineInterface};
+use ferrum_engine::{ContinuousBatchEngine, LlmInferenceEngine};
 use ferrum_scheduler::implementations::ContinuousBatchScheduler;
 use ferrum_testkit::{
     MockKvCacheManager, MockModelExecutor, MockSampler, MockTensorFactory, MockTokenizer,

--- a/crates/ferrum-engine/tests/chunked_prefill_test.rs
+++ b/crates/ferrum-engine/tests/chunked_prefill_test.rs
@@ -5,7 +5,7 @@
 //! advancing the scheduler's chunk offset, and that the final generated
 //! token sequence matches the non-chunked baseline.
 
-use ferrum_engine::{ContinuousBatchEngine, InferenceEngineInterface};
+use ferrum_engine::{ContinuousBatchEngine, LlmInferenceEngine};
 use ferrum_scheduler::implementations::ContinuousBatchScheduler;
 use ferrum_testkit::{
     ConfigurableModelExecutor, MockKvCacheManager, MockSampler, MockTensorFactory, MockTokenizer,

--- a/crates/ferrum-engine/tests/concurrency_stress_test.rs
+++ b/crates/ferrum-engine/tests/concurrency_stress_test.rs
@@ -2,7 +2,7 @@
 //!
 //! Uses mock executor with zero latency for fast execution.
 
-use ferrum_engine::{ContinuousBatchEngine, InferenceEngineInterface};
+use ferrum_engine::{ContinuousBatchEngine, LlmInferenceEngine};
 use ferrum_scheduler::implementations::ContinuousBatchScheduler;
 use ferrum_testkit::{
     MockKvCacheManager, MockModelExecutor, MockSampler, MockTensorFactory, MockTokenizer,

--- a/crates/ferrum-engine/tests/continuous_batch_test.rs
+++ b/crates/ferrum-engine/tests/continuous_batch_test.rs
@@ -1,7 +1,7 @@
 //! Integration tests for ContinuousBatchEngine using mock components.
 //! Runs on any platform — no GPU required.
 
-use ferrum_engine::{ContinuousBatchEngine, InferenceEngineInterface, Scheduler};
+use ferrum_engine::{ContinuousBatchEngine, LlmInferenceEngine, Scheduler};
 use ferrum_scheduler::implementations::ContinuousBatchScheduler;
 use ferrum_testkit::{
     MockKvCacheManager, MockModelExecutor, MockSampler, MockTensorFactory, MockTokenizer,

--- a/crates/ferrum-engine/tests/correctness_test.rs
+++ b/crates/ferrum-engine/tests/correctness_test.rs
@@ -2,7 +2,7 @@
 //!
 //! All use mock/configurable executors — no GPU required.
 
-use ferrum_engine::{ContinuousBatchEngine, InferenceEngineInterface};
+use ferrum_engine::{ContinuousBatchEngine, LlmInferenceEngine};
 use ferrum_scheduler::implementations::ContinuousBatchScheduler;
 use ferrum_testkit::{
     ConfigurableModelExecutor, MockKvCacheManager, MockModelExecutor, MockSampler,

--- a/crates/ferrum-engine/tests/latency_profile_test.rs
+++ b/crates/ferrum-engine/tests/latency_profile_test.rs
@@ -3,7 +3,7 @@
 //! Runs a batch of requests and reports TTFT, TPOT, and percentile latencies.
 //! Uses mock components with configurable latency to simulate realistic timing.
 
-use ferrum_engine::{ContinuousBatchEngine, InferenceEngineInterface};
+use ferrum_engine::{ContinuousBatchEngine, LlmInferenceEngine};
 use ferrum_scheduler::implementations::ContinuousBatchScheduler;
 use ferrum_testkit::{
     MockKvCacheManager, MockModelExecutor, MockSampler, MockTensorFactory, MockTokenizer,

--- a/crates/ferrum-engine/tests/paged_attention_test.rs
+++ b/crates/ferrum-engine/tests/paged_attention_test.rs
@@ -2,7 +2,7 @@
 //! Verifies end-to-end paged KV cache usage: block allocation, K/V storage,
 //! cross-block attention, and deallocation.
 
-use ferrum_engine::{ContinuousBatchEngine, InferenceEngineInterface, KvCacheManager};
+use ferrum_engine::{ContinuousBatchEngine, KvCacheManager, LlmInferenceEngine};
 use ferrum_kv::managers::paged::{PagedKvCacheConfig, PagedKvCacheManager};
 use ferrum_scheduler::implementations::ContinuousBatchScheduler;
 use ferrum_testkit::{

--- a/crates/ferrum-engine/tests/prefix_cache_test.rs
+++ b/crates/ferrum-engine/tests/prefix_cache_test.rs
@@ -5,7 +5,7 @@
 //! Uses the same mock-executor pattern as other correctness tests — no
 //! GPU required.
 
-use ferrum_engine::{ContinuousBatchEngine, InferenceEngineInterface};
+use ferrum_engine::{ContinuousBatchEngine, LlmInferenceEngine};
 use ferrum_scheduler::implementations::ContinuousBatchScheduler;
 use ferrum_testkit::{
     ConfigurableModelExecutor, MockKvCacheManager, MockSampler, MockTensorFactory, MockTokenizer,

--- a/crates/ferrum-engine/tests/qwen_concurrency.rs
+++ b/crates/ferrum-engine/tests/qwen_concurrency.rs
@@ -1,5 +1,5 @@
 use ferrum_engine::{create_default_engine, simple_engine_config};
-use ferrum_interfaces::InferenceEngine;
+use ferrum_interfaces::engine::LlmInferenceEngine;
 use ferrum_types::{Device, InferenceRequest, SamplingParams};
 use std::{path::Path, sync::Arc, time::Duration};
 
@@ -28,7 +28,7 @@ async fn qwen_25_05b_requests_are_serialized_for_correctness() {
     let mut config = simple_engine_config(QWEN_MODEL_ID, Device::CPU);
     config.scheduler.max_running_requests = 4;
 
-    let engine: Arc<dyn InferenceEngine + Send + Sync> =
+    let engine: Arc<dyn LlmInferenceEngine + Send + Sync> =
         Arc::from(create_default_engine(config).await.expect("create engine"));
 
     let monitor_engine = engine.clone();

--- a/crates/ferrum-engine/tests/regex_guided_test.rs
+++ b/crates/ferrum-engine/tests/regex_guided_test.rs
@@ -14,7 +14,7 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use ferrum_engine::{ContinuousBatchEngine, InferenceEngineInterface};
+use ferrum_engine::{ContinuousBatchEngine, LlmInferenceEngine};
 use ferrum_interfaces::tokenizer::{ChatMessage, Tokenizer, TokenizerInfo, TokenizerType};
 use ferrum_scheduler::implementations::ContinuousBatchScheduler;
 use ferrum_testkit::{

--- a/crates/ferrum-engine/tests/spec_decode_test.rs
+++ b/crates/ferrum-engine/tests/spec_decode_test.rs
@@ -13,7 +13,7 @@
 use std::sync::Arc;
 
 use ferrum_engine::{
-    speculative::SpeculativeDecodingConfig, ContinuousBatchEngine, InferenceEngineInterface,
+    speculative::SpeculativeDecodingConfig, ContinuousBatchEngine, LlmInferenceEngine,
 };
 use ferrum_scheduler::implementations::ContinuousBatchScheduler;
 use ferrum_testkit::{

--- a/crates/ferrum-interfaces/src/engine.rs
+++ b/crates/ferrum-interfaces/src/engine.rs
@@ -1,137 +1,146 @@
-//! Inference engine interface with streaming and batch support
+//! Inference engine interfaces — split per modality.
 //!
-//! This module provides the top-level inference engine interface that
-//! orchestrates all other components: tokenizer, model executor, scheduler,
-//! and sampler.
+//! Phase 5a step 2 splits the historical mega-trait (which mixed LLM
+//! generation, embedding, transcription, and TTS in one) into a base
+//! lifecycle trait and four modality-specific supertraits. Each
+//! engine impl now implements exactly the trait its modality needs;
+//! no more inert "unsupported" stubs.
 
 use async_trait::async_trait;
 use ferrum_types::{EngineConfig, InferenceRequest, InferenceResponse, Result, StreamChunk};
 use futures::Stream;
 use std::pin::Pin;
 
-/// Core inference engine trait
+/// Lifecycle / status methods shared by every engine kind.
+///
+/// LLM engines, embedders, transcribers, and TTS services all expose
+/// the same minimal status/metrics surface to the server / CLI. The
+/// modality-specific traits below extend this base.
 #[async_trait]
 pub trait InferenceEngine: Send + Sync {
-    /// Execute single inference request
+    /// Get current engine status.
+    async fn status(&self) -> ferrum_types::EngineStatus;
+
+    /// Shutdown engine gracefully.
+    async fn shutdown(&self) -> Result<()>;
+
+    /// Get engine configuration.
+    fn config(&self) -> &EngineConfig;
+
+    /// Get engine metrics.
+    fn metrics(&self) -> ferrum_types::EngineMetrics;
+
+    /// Health check.
+    async fn health_check(&self) -> ferrum_types::HealthStatus;
+}
+
+/// LLM text-generation engine.
+///
+/// Implemented by `ContinuousBatchEngine` (the production path) and
+/// `DefaultInferenceEngine` (legacy reference path). Backs
+/// `/v1/chat/completions` and `/v1/completions`.
+#[async_trait]
+pub trait LlmInferenceEngine: InferenceEngine {
+    /// Execute single inference request.
     async fn infer(&self, request: InferenceRequest) -> Result<InferenceResponse>;
 
-    /// Execute streaming inference request
+    /// Execute streaming inference request.
     async fn infer_stream(
         &self,
         request: InferenceRequest,
     ) -> Result<Pin<Box<dyn Stream<Item = Result<StreamChunk>> + Send>>>;
-
-    /// Get current engine status
-    async fn status(&self) -> ferrum_types::EngineStatus;
-
-    /// Shutdown engine gracefully
-    async fn shutdown(&self) -> Result<()>;
-
-    /// Get engine configuration
-    fn config(&self) -> &EngineConfig;
-
-    /// Get engine metrics
-    fn metrics(&self) -> ferrum_types::EngineMetrics;
-
-    /// Health check
-    async fn health_check(&self) -> ferrum_types::HealthStatus;
-
-    /// Embed raw text string → float vector (engine handles tokenization).
-    async fn embed_text(&self, _text: &str) -> Result<Vec<f32>> {
-        Err(ferrum_types::FerrumError::model(
-            "This engine does not support text embedding",
-        ))
-    }
-
-    /// Embed image (file path or base64) → float vector. Default: not supported.
-    async fn embed_image(&self, _image: &str) -> Result<Vec<f32>> {
-        Err(ferrum_types::FerrumError::model(
-            "This engine does not support image embedding",
-        ))
-    }
-
-    /// Get embedding dimension. Default: 0 (not an embedding model).
-    fn embedding_dim(&self) -> usize {
-        0
-    }
-
-    /// Transcribe audio file → text. Default: not supported.
-    async fn transcribe_file(&self, _path: &str, _language: Option<&str>) -> Result<String> {
-        Err(ferrum_types::FerrumError::model(
-            "This engine does not support audio transcription",
-        ))
-    }
-
-    /// Transcribe audio bytes (WAV) → text. Default: not supported.
-    async fn transcribe_bytes(&self, _data: &[u8], _language: Option<&str>) -> Result<String> {
-        Err(ferrum_types::FerrumError::model(
-            "This engine does not support audio transcription",
-        ))
-    }
-
-    /// Synthesize speech → PCM audio chunks (streaming).
-    /// Returns Vec of (chunk_index, PCM f32 samples).
-    /// Default: not supported.
-    async fn synthesize_speech(
-        &self,
-        _text: &str,
-        _language: Option<&str>,
-        _chunk_frames: usize,
-    ) -> Result<Vec<Vec<f32>>> {
-        Err(ferrum_types::FerrumError::model(
-            "This engine does not support speech synthesis",
-        ))
-    }
-
-    /// Get TTS sample rate (default 24000).
-    fn tts_sample_rate(&self) -> u32 {
-        24000
-    }
 }
 
-/// Advanced engine capabilities
+/// Embedding engine (CLIP, BERT, etc.).
+///
+/// Backs `/v1/embeddings`. Distinct from LLM engines — no token
+/// generation, no scheduling, no KV cache.
 #[async_trait]
-pub trait AdvancedInferenceEngine: InferenceEngine {
-    /// Execute batch inference
+pub trait EmbedEngine: InferenceEngine {
+    /// Embed raw text string → float vector (engine handles tokenization).
+    async fn embed_text(&self, text: &str) -> Result<Vec<f32>>;
+
+    /// Embed image (file path or base64) → float vector.
+    async fn embed_image(&self, image: &str) -> Result<Vec<f32>>;
+
+    /// Get embedding dimension.
+    fn embedding_dim(&self) -> usize;
+}
+
+/// Speech-to-text (Whisper) engine.
+///
+/// Backs `/v1/audio/transcriptions`.
+#[async_trait]
+pub trait TranscribeEngine: InferenceEngine {
+    /// Transcribe audio file → text.
+    async fn transcribe_file(&self, path: &str, language: Option<&str>) -> Result<String>;
+
+    /// Transcribe audio bytes (WAV / etc.) → text.
+    async fn transcribe_bytes(&self, data: &[u8], language: Option<&str>) -> Result<String>;
+}
+
+/// Text-to-speech (Qwen3-TTS, etc.) engine.
+///
+/// Backs `/v1/audio/speech`.
+#[async_trait]
+pub trait TtsEngine: InferenceEngine {
+    /// Synthesize speech → PCM audio chunks (streaming).
+    /// Returns Vec of PCM f32 samples per chunk.
+    async fn synthesize_speech(
+        &self,
+        text: &str,
+        language: Option<&str>,
+        chunk_frames: usize,
+    ) -> Result<Vec<Vec<f32>>>;
+
+    /// Get TTS sample rate.
+    fn tts_sample_rate(&self) -> u32;
+}
+
+/// Advanced engine capabilities — opt-in addition to LLM engines that
+/// support batching / speculation / runtime reconfig / diagnostics.
+#[async_trait]
+pub trait AdvancedInferenceEngine: LlmInferenceEngine {
+    /// Execute batch inference.
     async fn infer_batch(
         &self,
         requests: Vec<InferenceRequest>,
     ) -> Result<Vec<Result<InferenceResponse>>>;
 
-    /// Execute speculative inference
+    /// Execute speculative inference.
     async fn infer_speculative(
         &self,
         request: InferenceRequest,
         speculation_config: ferrum_types::SpeculationConfig,
     ) -> Result<InferenceResponse>;
 
-    /// Warm up engine with sample requests
+    /// Warm up engine with sample requests.
     async fn warmup(
         &mut self,
         warmup_requests: Vec<InferenceRequest>,
     ) -> Result<ferrum_types::WarmupResult>;
 
-    /// Configure engine at runtime
+    /// Configure engine at runtime.
     async fn reconfigure(&mut self, config: EngineConfig) -> Result<()>;
 
-    /// Get detailed diagnostics
+    /// Get detailed diagnostics.
     async fn diagnostics(&self) -> ferrum_types::DiagnosticsReport;
 
-    /// Export engine state for debugging
+    /// Export engine state for debugging.
     async fn export_state(&self) -> Result<ferrum_types::EngineState>;
 
-    /// Import engine state for debugging/testing
+    /// Import engine state for debugging/testing.
     async fn import_state(&mut self, state: ferrum_types::EngineState) -> Result<()>;
 }
 
-/// Speculation configuration for speculative decoding
+/// Speculation configuration for speculative decoding.
 pub type SpeculationConfig = ferrum_types::SpeculationConfig;
 
-/// Hardware constraints alias
+/// Hardware constraints alias.
 pub type HardwareConstraints = ferrum_types::HardwareConstraints;
 
-/// Request characteristics alias
+/// Request characteristics alias.
 pub type RequestCharacteristics = ferrum_types::RequestCharacteristics;
 
-/// Latency requirements alias
+/// Latency requirements alias.
 pub type LatencyRequirements = ferrum_types::LatencyRequirements;

--- a/crates/ferrum-server/src/axum_server.rs
+++ b/crates/ferrum-server/src/axum_server.rs
@@ -12,10 +12,10 @@ use axum::{
     routing::{get, post},
     Json, Router,
 };
-use ferrum_interfaces::engine::InferenceEngine;
+use ferrum_interfaces::engine::{EmbedEngine, LlmInferenceEngine, TranscribeEngine, TtsEngine};
 use ferrum_types::{
-    FerrumError as Error, FinishReason, InferenceRequest, ModelId, Priority, RequestId,
-    SamplingParams,
+    EngineMetrics, EngineStatus, FerrumError as Error, FinishReason, InferenceRequest, ModelId,
+    Priority, RequestId, SamplingParams,
 };
 use std::sync::Arc;
 use tokio::sync::mpsc;
@@ -44,26 +44,49 @@ pub fn init_prometheus_recorder() {
     });
 }
 
-/// Axum-based server implementation
+/// Axum-based server implementation.
+///
+/// The server is built around [`AppState`], which holds an optional
+/// engine per modality. Handlers fault to 501 when the modality they
+/// need isn't loaded, instead of running stub error logic.
 pub struct AxumServer {
-    engine: Arc<dyn InferenceEngine + Send + Sync>,
+    state: AppState,
     config: ServerConfig,
 }
 
 impl AxumServer {
-    /// Create a new Axum server
-    pub fn new(engine: Arc<dyn InferenceEngine + Send + Sync>) -> Self {
+    /// Create a server with a fully populated AppState.
+    pub fn from_state(state: AppState) -> Self {
         Self {
-            engine,
+            state,
             config: ServerConfig::default(),
         }
     }
 
+    /// Convenience constructor for an LLM-only server (chat / completions).
+    pub fn from_llm(engine: Arc<dyn LlmInferenceEngine + Send + Sync>) -> Self {
+        Self::from_state(AppState::default().with_llm(engine))
+    }
+
+    /// Convenience constructor for an embedding-only server (`/v1/embeddings`).
+    pub fn from_embed(engine: Arc<dyn EmbedEngine + Send + Sync>) -> Self {
+        Self::from_state(AppState::default().with_embed(engine))
+    }
+
+    /// Convenience constructor for a transcription-only server
+    /// (`/v1/audio/transcriptions`).
+    pub fn from_transcribe(engine: Arc<dyn TranscribeEngine + Send + Sync>) -> Self {
+        Self::from_state(AppState::default().with_transcribe(engine))
+    }
+
+    /// Convenience constructor for a TTS-only server (`/v1/audio/speech`).
+    pub fn from_tts(engine: Arc<dyn TtsEngine + Send + Sync>) -> Self {
+        Self::from_state(AppState::default().with_tts(engine))
+    }
+
     /// Build the router with all routes
     fn build_router(&self) -> Router {
-        let app_state = AppState {
-            engine: self.engine.clone(),
-        };
+        let app_state = self.state.clone();
 
         Router::new()
             // OpenAI API routes
@@ -87,10 +110,98 @@ impl AxumServer {
     }
 }
 
-/// Application state shared across handlers
-#[derive(Clone)]
-struct AppState {
-    engine: Arc<dyn InferenceEngine + Send + Sync>,
+/// Application state shared across handlers — one optional engine per
+/// modality. Handlers reach into the field they need and 501 when it's
+/// not loaded.
+#[derive(Clone, Default)]
+pub struct AppState {
+    pub llm: Option<Arc<dyn LlmInferenceEngine + Send + Sync>>,
+    pub embed: Option<Arc<dyn EmbedEngine + Send + Sync>>,
+    pub transcribe: Option<Arc<dyn TranscribeEngine + Send + Sync>>,
+    pub tts: Option<Arc<dyn TtsEngine + Send + Sync>>,
+}
+
+impl AppState {
+    pub fn with_llm(mut self, engine: Arc<dyn LlmInferenceEngine + Send + Sync>) -> Self {
+        self.llm = Some(engine);
+        self
+    }
+    pub fn with_embed(mut self, engine: Arc<dyn EmbedEngine + Send + Sync>) -> Self {
+        self.embed = Some(engine);
+        self
+    }
+    pub fn with_transcribe(mut self, engine: Arc<dyn TranscribeEngine + Send + Sync>) -> Self {
+        self.transcribe = Some(engine);
+        self
+    }
+    pub fn with_tts(mut self, engine: Arc<dyn TtsEngine + Send + Sync>) -> Self {
+        self.tts = Some(engine);
+        self
+    }
+
+    /// Async aggregated status across whichever modality is loaded.
+    /// In single-modality deployments (current CLI), exactly one is Some.
+    async fn status(&self) -> EngineStatus {
+        if let Some(e) = &self.llm {
+            return e.status().await;
+        }
+        if let Some(e) = &self.embed {
+            return e.status().await;
+        }
+        if let Some(e) = &self.transcribe {
+            return e.status().await;
+        }
+        if let Some(e) = &self.tts {
+            return e.status().await;
+        }
+        EngineStatus {
+            is_ready: false,
+            loaded_models: vec![],
+            active_requests: 0,
+            queued_requests: 0,
+            memory_usage: ferrum_types::MemoryUsage {
+                total_bytes: 0,
+                used_bytes: 0,
+                free_bytes: 0,
+                gpu_memory_bytes: None,
+                cpu_memory_bytes: None,
+                cache_memory_bytes: 0,
+                utilization_percent: 0.0,
+            },
+            uptime_seconds: 0,
+            last_heartbeat: chrono::Utc::now(),
+            version: env!("CARGO_PKG_VERSION").to_string(),
+        }
+    }
+
+    fn metrics(&self) -> EngineMetrics {
+        if let Some(e) = &self.llm {
+            return e.metrics();
+        }
+        if let Some(e) = &self.embed {
+            return e.metrics();
+        }
+        if let Some(e) = &self.transcribe {
+            return e.metrics();
+        }
+        if let Some(e) = &self.tts {
+            return e.metrics();
+        }
+        EngineMetrics {
+            total_requests: 0,
+            successful_requests: 0,
+            failed_requests: 0,
+            avg_request_latency_ms: 0.0,
+            p95_request_latency_ms: 0.0,
+            p99_request_latency_ms: 0.0,
+            throughput_rps: 0.0,
+            tokens_per_second: 0.0,
+            queue_metrics: Default::default(),
+            resource_utilization: Default::default(),
+            error_stats: Default::default(),
+            performance_breakdown: Default::default(),
+        }
+    }
 }
 
 #[async_trait]
@@ -203,7 +314,9 @@ async fn handle_chat_completions_stream(
     let (tx, rx) = mpsc::unbounded_channel::<std::result::Result<Event, axum::Error>>();
 
     // Spawn task to generate tokens
-    let engine = state.engine.clone();
+    let engine = state.llm.clone().ok_or_else(|| {
+        ServerError::NotImplemented("LLM engine not loaded; chat unavailable".into())
+    })?;
     let request_id = Uuid::new_v4().to_string();
     let prompt_tokens = inference_request.prompt.split_whitespace().count() as u32;
 
@@ -324,7 +437,10 @@ async fn handle_chat_completions_sync(
     info!("Processing non-streaming chat completion");
 
     let prompt_tokens = inference_request.prompt.split_whitespace().count() as u32;
-    match state.engine.infer(inference_request).await {
+    let engine = state.llm.clone().ok_or_else(|| {
+        ServerError::NotImplemented("LLM engine not loaded; chat unavailable".into())
+    })?;
+    match engine.infer(inference_request).await {
         Ok(output) => {
             let response = ChatCompletionsResponse {
                 id: Uuid::new_v4().to_string(),
@@ -450,17 +566,18 @@ async fn embeddings_handler(
     let mut data = Vec::with_capacity(items.len());
     let mut total_tokens = 0u32;
 
+    let engine = state.embed.as_ref().ok_or_else(|| {
+        ServerError::NotImplemented("Embed engine not loaded; embeddings unavailable".into())
+    })?;
     for (idx, item) in items.iter().enumerate() {
         let embedding = if let Some(ref image) = item.image {
-            state
-                .engine
+            engine
                 .embed_image(image)
                 .await
                 .map_err(|e| ServerError::InternalError(format!("embed_image: {e}")))?
         } else if let Some(ref text) = item.text {
             total_tokens += text.len() as u32;
-            state
-                .engine
+            engine
                 .embed_text(text)
                 .await
                 .map_err(|e| ServerError::InternalError(format!("embed_text: {e}")))?
@@ -526,8 +643,10 @@ async fn transcriptions_handler(
 
     let data = file_data.ok_or_else(|| ServerError::BadRequest("missing 'file' field".into()))?;
 
-    let text = state
-        .engine
+    let engine = state.transcribe.as_ref().ok_or_else(|| {
+        ServerError::NotImplemented("Transcribe engine not loaded; ASR unavailable".into())
+    })?;
+    let text = engine
         .transcribe_bytes(&data, language.as_deref())
         .await
         .map_err(|e| ServerError::InternalError(format!("transcribe: {e}")))?;
@@ -550,14 +669,17 @@ async fn speech_handler(
     };
 
     let chunk_frames = 10usize;
-    let sample_rate = state.engine.tts_sample_rate();
+    let tts = state.tts.as_ref().ok_or_else(|| {
+        ServerError::NotImplemented("TTS engine not loaded; speech unavailable".into())
+    })?;
+    let sample_rate = tts.tts_sample_rate();
 
     if request.stream {
         // Streaming: chunked transfer encoding with WAV audio
         let (tx, rx) =
             mpsc::unbounded_channel::<std::result::Result<axum::body::Bytes, std::io::Error>>();
 
-        let engine = state.engine.clone();
+        let engine = tts.clone();
         let text = request.input.clone();
         let lang = request.language.clone();
 
@@ -592,8 +714,7 @@ async fn speech_handler(
             .unwrap())
     } else {
         // Non-streaming: return complete WAV
-        let chunks = state
-            .engine
+        let chunks = tts
             .synthesize_speech(&request.input, language, chunk_frames)
             .await
             .map_err(|e| ServerError::InternalError(format!("TTS: {e}")))?;
@@ -643,7 +764,7 @@ fn pcm_to_wav_bytes(samples: &[f32], sample_rate: u32) -> Vec<u8> {
 async fn models_handler(
     State(state): State<AppState>,
 ) -> std::result::Result<Response, ServerError> {
-    let status = state.engine.status().await;
+    let status = state.status().await;
     let now = chrono::Utc::now().timestamp() as u64;
     let data = status
         .loaded_models
@@ -670,8 +791,8 @@ async fn models_handler(
 async fn health_handler(
     State(state): State<AppState>,
 ) -> std::result::Result<Response, ServerError> {
-    let engine_status = state.engine.status().await;
-    let scheduler_metrics = state.engine.metrics();
+    let engine_status = state.status().await;
+    let scheduler_metrics = state.metrics();
 
     let health = serde_json::json!({
         "status": "healthy",


### PR DESCRIPTION
## Summary
Replaces the single mega-trait that mixed LLM, embedding, ASR, and TTS methods (with `Err(unsupported)` defaults for the modalities each engine didn't implement) with a base lifecycle trait + 4 modality supertraits.

**ferrum-interfaces:**
- `InferenceEngine` is now lifecycle-only: `status` / `shutdown` / `config` / `metrics` / `health_check`
- `LlmInferenceEngine: InferenceEngine` → `infer + infer_stream`
- `EmbedEngine: InferenceEngine` → `embed_text + embed_image + embedding_dim`
- `TranscribeEngine: InferenceEngine` → `transcribe_file + transcribe_bytes`
- `TtsEngine: InferenceEngine` → `synthesize_speech + tts_sample_rate`

**ferrum-engine:**
- `ContinuousBatchEngine` and `DefaultInferenceEngine` impl `InferenceEngine` (lifecycle) + `LlmInferenceEngine` (LLM methods) in separate blocks. No more `Err`-stub embed/transcribe/tts methods.
- `EmbeddingEngine` impls `EmbedEngine` (drops fake LLM stubs).
- `TranscriptionEngine` impls `TranscribeEngine` (drops fake LLM stubs).
- `TtsEngine` struct renamed to `TtsService` to free the trait name; impls the `TtsEngine` trait.
- Builder + `create_default_engine` return `Box<dyn LlmInferenceEngine>`.

**ferrum-server:**
- `AppState` now holds `Option<Arc<dyn ModalityTrait>>` per modality (llm / embed / transcribe / tts).
- `AxumServer::from_llm` / `from_embed` / `from_transcribe` / `from_tts` constructors replace the old single-engine `new`.
- Each handler unwraps the field its modality needs and returns 501 ("not loaded") instead of relying on the trait's `Err` defaults.

**ferrum-cli:**
- `commands/serve.rs` builds the server via `AxumServer::from_<modality>` per architecture branch.
- `commands/bench.rs` switches its `dyn InferenceEngine` to `dyn LlmInferenceEngine`.

Net: the audit's "3 fake engine wrappers" no longer have fake `Err`-stub LLM methods at all — each implements only the modality trait it serves.

## Test plan
- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo test --workspace --features metal --lib` 457 passed
- [x] `cargo fmt --all -- --check` clean