### PR TITLE
refactor(kv): add K: KvDtypeKind type param to KvCache (Phase 4 wire-up, type-only)

### DIFF
--- a/crates/ferrum-kernels/src/backend/traits.rs
+++ b/crates/ferrum-kernels/src/backend/traits.rs
@@ -156,7 +156,10 @@ impl Default for AttnConfig {
 // model can carry exactly the architecture parameters it cares about.
 // Backend trait stays model-agnostic.
 
-/// Per-layer KV cache. Each model owns its own `Vec<KvCache<B>>` per sequence.
+/// Per-layer KV cache. Each model owns its own `Vec<KvCache<B, K>>` per
+/// sequence. The `K: KvDtypeKind` parameter selects the cache element
+/// type — defaults to [`KvFp16`] so existing call sites that wrote
+/// `KvCache<B>` keep compiling unchanged.
 ///
 /// Two layouts are supported, selected at allocation time:
 /// 1. **Contiguous** (default): `k`/`v` are `[num_kv_heads, capacity, head_dim]`
@@ -169,7 +172,13 @@ impl Default for AttnConfig {
 ///    (`u32[1]` single-seq for now) are populated. Multi-seq sharing
 ///    is a Phase 4 concern; today every paged cache_id has its own
 ///    pool but the kernel-level indirection works.
-pub struct KvCache<B: Backend> {
+///
+/// The `K` parameter is currently a phantom-type marker — the buffer
+/// fields stay `B::Buffer` regardless. Future PRs will switch backends
+/// to `BackendKvDtype<KvInt8>` etc. and the kernel dispatch will read
+/// `K::NAME` / `K::BYTES_PER_ELEM` to pick the right append / attention
+/// kernel without any `KvCache` struct change.
+pub struct KvCache<B: Backend, K: KvDtypeKind = KvFp16> {
     pub k: B::Buffer,
     pub v: B::Buffer,
     pub len: usize,
@@ -186,6 +195,8 @@ pub struct KvCache<B: Backend> {
     /// this cache. Lets the model's release path return blocks to the
     /// shared allocator without reading them back from device.
     pub paged_block_indices: Vec<u32>,
+    /// Marker — KV cache element type. Zero-sized.
+    pub _kv_dtype: std::marker::PhantomData<K>,
 }
 
 /// The core abstraction over CUDA / Metal / CPU.

--- a/crates/ferrum-models/src/models/llama_family.rs
+++ b/crates/ferrum-models/src/models/llama_family.rs
@@ -892,6 +892,7 @@ impl<B: MoeLlmBackend> LlamaFamilyModel<B> {
                             block_table: Some(block_table),
                             context_lens: Some(context_lens),
                             paged_block_indices: Vec::new(),
+                            _kv_dtype: std::marker::PhantomData,
                         }
                     } else {
                         KvCache {
@@ -905,6 +906,7 @@ impl<B: MoeLlmBackend> LlamaFamilyModel<B> {
                             block_table: None,
                             context_lens: None,
                             paged_block_indices: Vec::new(),
+                            _kv_dtype: std::marker::PhantomData,
                         }
                     }
                 })

--- a/crates/ferrum-models/src/models/qwen3_moe.rs
+++ b/crates/ferrum-models/src/models/qwen3_moe.rs
@@ -807,6 +807,7 @@ impl<B: MoeLlmBackend> Qwen3MoeModel<B> {
                             block_table: Some(block_table),
                             context_lens: Some(context_lens),
                             paged_block_indices: Vec::new(),
+                            _kv_dtype: std::marker::PhantomData,
                         }
                     } else {
                         KvCache {
@@ -820,6 +821,7 @@ impl<B: MoeLlmBackend> Qwen3MoeModel<B> {
                             block_table: None,
                             context_lens: None,
                             paged_block_indices: Vec::new(),
+                            _kv_dtype: std::marker::PhantomData,
                         }
                     }
                 })


### PR DESCRIPTION
## Summary
Threads `K: KvDtypeKind` through `KvCache<B>` via a phantom-type field. Default `K = KvFp16` keeps every existing call site (`KvCache<B>` in qwen3_moe.rs / llama_family.rs) compiling unchanged.

Currently the K parameter is purely a marker — buffer fields stay `B::Buffer` regardless of K. The kernel-level dispatch (rope, kv-append, paged attention) doesn't read K yet; that's the follow-up PR that implements `BackendKvDtype<KvInt8>` for CUDA and adds the actual quant KV kernels.

The point of doing this now is to lock in the type-system shape: future INT8/FP8 KV impls will look like
```rust
where B: BackendCore + BackendPagedKv + BackendKvDtype<KvInt8>
```
on the model side, and the cache will just spell `KvCache<B, KvInt8>`. No more implicit-FP16 assumption baked into the cache type.

**Constructors:**
- 4 `KvCache { ... }` literals in `qwen3_moe.rs` + `llama_family.rs` gain a `_kv_dtype: PhantomData` field. With type inference the K parameter resolves to `KvFp16` (the default), matching the existing FP16 cache behaviour byte-for-byte.

## Test plan
- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo test --workspace --features metal --lib` clean
- [x] `cargo fmt --all -- --check` clean