### PR TITLE
refactor(kernels): add CudaMarlinLinear concrete Linear types (Phase 3e/1, additive)

### DIFF
--- a/crates/ferrum-kernels/src/backend/cuda.rs
+++ b/crates/ferrum-kernels/src/backend/cuda.rs
@@ -2927,7 +2927,12 @@ fn moe_gemm_phase_fused_impl(
     Ok(())
 }
 
-fn marlin_gemm_with_perm(
+/// Marlin GEMM dispatcher that handles act-order permutation if present.
+///
+/// Made `pub` in Phase 3e/1 so the new `CudaMarlinLinear` impl can call
+/// it from outside the trait method body. Same dispatch logic the
+/// `BackendQuantMarlin::gemm_gptq` impl used to wrap.
+pub fn marlin_gemm_with_perm(
     ctx: &mut CudaState,
     a: &CudaSlice<f16>,
     weight: &crate::marlin::MarlinWeight,
@@ -2984,7 +2989,7 @@ fn marlin_gemm_with_perm(
 }
 
 #[cfg(feature = "vllm-marlin")]
-fn launch_vllm_marlin(
+pub fn launch_vllm_marlin(
     stream: &Arc<cudarc::driver::CudaStream>,
     a: &CudaSlice<f16>,
     weight: &crate::marlin::MarlinWeight,

--- a/crates/ferrum-kernels/src/lib.rs
+++ b/crates/ferrum-kernels/src/lib.rs
@@ -9,6 +9,8 @@ pub mod backend;
 pub mod linear;
 pub use linear::Linear;
 
+pub mod quant_linear;
+
 pub mod moe_host;
 
 #[cfg(all(target_os = "macos", feature = "metal"))]

--- a/crates/ferrum-kernels/src/quant_linear.rs
+++ b/crates/ferrum-kernels/src/quant_linear.rs
@@ -1,0 +1,16 @@
+//! Concrete `Linear<B>` impls for quantized weights.
+//!
+//! Phase 3e moves the per-backend kernel-dispatch logic out of the
+//! `BackendQuantMarlin` / `BackendQuantGguf` trait method bodies and
+//! into these concrete `Linear<B>` types. Each impl owns the
+//! cudarc / metal / cpu kernel call directly — no more `B::gemm_gptq`
+//! indirection.
+//!
+//! Why these live in `ferrum-kernels` rather than `ferrum-quantization`:
+//! the `forward()` body needs cudarc / metal-rs types, and pulling
+//! those into ferrum-quantization would create a dep cycle (kernels
+//! → quantization → kernels). ferrum-quantization stays as the
+//! weight-format parser layer; backend-specific Linear impls live here.
+
+#[cfg(feature = "cuda")]
+pub mod cuda_marlin;

--- a/crates/ferrum-kernels/src/quant_linear/cuda_marlin.rs
+++ b/crates/ferrum-kernels/src/quant_linear/cuda_marlin.rs
@@ -1,0 +1,197 @@
+//! `Linear<CudaBackend>` impls for GPTQ weights routed through Marlin.
+//!
+//! Two concrete types:
+//! - [`CudaMarlinLinear`] — single-tensor projection (the GPTQ analogue
+//!   of `DenseLinear`).
+//! - [`CudaMarlinStackedExpertLinear`] — column-slice view into a stacked
+//!   Marlin tile (the MoE analogue; one per expert).
+//!
+//! Each type's `forward()` body owns the kernel dispatch directly —
+//! the old `BackendQuantMarlin::gemm_gptq` / `gemm_gptq_with_offset`
+//! trait methods are now redundant and will be deleted in 3e/2.
+
+use crate::backend::cuda::{CudaBackend, GptqStoreCuda};
+use crate::Linear;
+use cudarc::driver::CudaSlice;
+use ferrum_types::{FerrumError, Result};
+use half::f16;
+use std::sync::Arc;
+
+/// Single-tensor GPTQ-Marlin Linear projection.
+///
+/// Holds a `GptqStoreCuda` (Marlin tiles, optionally Triton view) plus
+/// an optional bias. `forward()` dispatches to the Marlin kernel via
+/// `crate::backend::cuda::marlin_gemm_with_perm` (made `pub` in 3e/1)
+/// or to the Triton w4a16 launcher when the store is `Triton(_)`.
+pub struct CudaMarlinLinear {
+    pub store: GptqStoreCuda,
+    pub bias: Option<CudaSlice<f16>>,
+    pub in_features: usize,
+    pub out_features: usize,
+}
+
+impl Linear<CudaBackend> for CudaMarlinLinear {
+    fn in_features(&self) -> usize {
+        self.in_features
+    }
+
+    fn out_features(&self) -> usize {
+        self.out_features
+    }
+
+    #[allow(clippy::needless_return)]
+    fn forward(
+        &self,
+        ctx: &mut <CudaBackend as crate::backend::Backend>::Context,
+        input: &<CudaBackend as crate::backend::Backend>::Buffer,
+        out: &mut <CudaBackend as crate::backend::Backend>::Buffer,
+        m: usize,
+    ) {
+        // Body migrated from `BackendQuantMarlin::gemm_gptq` impl on
+        // CudaBackend (cuda.rs:3440). cfg branches preserved verbatim.
+        let res: Result<()> = {
+            #[cfg(feature = "marlin")]
+            {
+                #[cfg(feature = "triton-kernels")]
+                {
+                    match &self.store {
+                        GptqStoreCuda::Marlin(mw) => {
+                            crate::backend::cuda::marlin_gemm_with_perm(ctx, input, mw, out, m)
+                        }
+                        GptqStoreCuda::Triton(tw) => {
+                            let func = ctx.func(
+                                "triton_w4a16_gptq",
+                                crate::triton_ptx::w4a16_gptq_f16::PTX,
+                                crate::triton_w4a16::fn_name(),
+                            );
+                            let stream = ctx.stream.clone();
+                            crate::triton_w4a16::launch_w4a16_gptq_triton(
+                                &stream, &func, input, tw, out, m as i32,
+                            )
+                            .map_err(|e| FerrumError::model(format!("triton w4a16: {e}")))
+                        }
+                    }
+                }
+                #[cfg(not(feature = "triton-kernels"))]
+                {
+                    crate::backend::cuda::marlin_gemm_with_perm(ctx, input, &self.store, out, m)
+                }
+            }
+            #[cfg(all(not(feature = "marlin"), feature = "triton-kernels"))]
+            {
+                match &self.store {
+                    GptqStoreCuda::Marlin(_) => Err(FerrumError::unsupported(
+                        "cargo feature `marlin` disabled — Marlin variant unusable; \
+                         set FERRUM_TRITON_INT4=1 to force the triton path",
+                    )),
+                    GptqStoreCuda::Triton(tw) => {
+                        let func = ctx.func(
+                            "triton_w4a16_gptq",
+                            crate::triton_ptx::w4a16_gptq_f16::PTX,
+                            crate::triton_w4a16::fn_name(),
+                        );
+                        let stream = ctx.stream.clone();
+                        crate::triton_w4a16::launch_w4a16_gptq_triton(
+                            &stream, &func, input, tw, out, m as i32,
+                        )
+                        .map_err(|e| FerrumError::model(format!("triton w4a16: {e}")))
+                    }
+                }
+            }
+            #[cfg(all(not(feature = "marlin"), not(feature = "triton-kernels")))]
+            {
+                let _ = (ctx, input, out, m);
+                Err(FerrumError::unsupported(
+                    "cargo features `marlin` and `triton-kernels` both disabled — \
+                     GPTQ not available",
+                ))
+            }
+        };
+        res.unwrap_or_else(|e| panic!("CudaMarlinLinear forward failed: {e}"));
+
+        if let Some(bias) = &self.bias {
+            <CudaBackend as crate::backend::Backend>::add_bias(
+                ctx,
+                out,
+                bias,
+                m,
+                self.out_features,
+            );
+        }
+    }
+}
+
+/// View into one expert's column slab of a shared stacked Marlin tile.
+///
+/// `store` is an `Arc` of the shared tile (one big repacked Marlin
+/// tensor concatenating all experts' weights). `expert_offset` selects
+/// which expert's columns to dispatch via `marlin_gemm_with_offset`.
+pub struct CudaMarlinStackedExpertLinear {
+    pub store: Arc<GptqStoreCuda>,
+    pub expert_offset: usize,
+    pub expert_n: usize,
+    pub k: usize,
+    pub bias: Option<CudaSlice<f16>>,
+}
+
+impl Linear<CudaBackend> for CudaMarlinStackedExpertLinear {
+    fn in_features(&self) -> usize {
+        self.k
+    }
+
+    fn out_features(&self) -> usize {
+        self.expert_n
+    }
+
+    fn forward(
+        &self,
+        ctx: &mut <CudaBackend as crate::backend::Backend>::Context,
+        input: &<CudaBackend as crate::backend::Backend>::Buffer,
+        out: &mut <CudaBackend as crate::backend::Backend>::Buffer,
+        m: usize,
+    ) {
+        // Body migrated from `BackendQuantMarlin::gemm_gptq_with_offset`
+        // impl on CudaBackend (cuda.rs:3522).
+        let res: Result<()> = {
+            #[cfg(feature = "marlin")]
+            {
+                #[cfg(feature = "triton-kernels")]
+                let mw = match self.store.as_ref() {
+                    GptqStoreCuda::Marlin(mw) => mw,
+                    GptqStoreCuda::Triton(_) => {
+                        panic!(
+                            "CudaMarlinStackedExpertLinear: Triton w4a16 store has no \
+                             stride-aware variant; load MoE via Marlin (default)"
+                        );
+                    }
+                };
+                #[cfg(not(feature = "triton-kernels"))]
+                let mw: &crate::marlin::MarlinWeight = self.store.as_ref();
+                let stream = ctx.stream.clone();
+                crate::marlin::marlin_gemm_with_offset(
+                    &stream,
+                    input,
+                    mw,
+                    out,
+                    m as i32,
+                    self.expert_offset as i32,
+                    self.expert_n as i32,
+                )
+                .map_err(|e| FerrumError::model(format!("marlin offset gemm: {e}")))
+            }
+            #[cfg(not(feature = "marlin"))]
+            {
+                let _ = (ctx, input, out, m);
+                Err(FerrumError::unsupported(
+                    "cargo feature `marlin` disabled — \
+                     CudaMarlinStackedExpertLinear unavailable",
+                ))
+            }
+        };
+        res.unwrap_or_else(|e| panic!("CudaMarlinStackedExpertLinear forward failed: {e}"));
+
+        if let Some(bias) = &self.bias {
+            <CudaBackend as crate::backend::Backend>::add_bias(ctx, out, bias, m, self.expert_n);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Sets up Phase 3e — moves GPTQ-Marlin kernel dispatch out of the `BackendQuantMarlin` trait method bodies and into concrete `Linear<B>` impls. **This first PR is additive** — adds the new types alongside the existing trait dispatch. The cutover (changing `BackendQuantMarlin::load_gptq` to return `Box<dyn Linear<Self>>` and deleting `gemm_gptq` / `gemm_gptq_with_offset` from the trait) is **Phase 3e/2** and ships next.

**Adds:**
- `crates/ferrum-kernels/src/quant_linear.rs` — module hub.
- `crates/ferrum-kernels/src/quant_linear/cuda_marlin.rs`:
  - `CudaMarlinLinear` (single-tensor projection)
  - `CudaMarlinStackedExpertLinear` (MoE column-slice view)

  Both implement `Linear<CudaBackend>`. Their `forward()` bodies are **literal copies** of the corresponding `BackendQuantMarlin::gemm_gptq` / `gemm_gptq_with_offset` impl bodies on CudaBackend, with cfg-branching preserved verbatim (Marlin / Triton / unsupported).

**Visibility flips** (in `cuda.rs`) so the new types can call them:
- `marlin_gemm_with_perm` (was `fn`, now `pub fn`) — Marlin GEMM with optional act-order column gather.
- `launch_vllm_marlin` (was `fn`, now `pub fn`) — vLLM Marlin wrapper for `FERRUM_VLLM_MARLIN=1`.

**No behaviour change** for any existing call site:
- `BackendQuantMarlin::gemm_gptq` and friends still exist on the trait with the same impl bodies.
- `ferrum-quantization::GptqLinear<B>` / `StackedExpertLinear<B>` still delegate via `B::gemm_gptq*` on the hot path.

## Why ship the additive step alone
1. Documents the target shape in code reviewers can see.
2. Lets the rest of Phase 3e (signature change + trait method delete + ferrum-quantization rewire + ferrum-models cutover) ship as separate PRs with smaller bench surfaces.
3. Each step can be perf-validated independently against the same-pod baseline (Llama-8B INT4 = 60.6 tok/s, 30B-A3B vLLM c=4 = 55.9 tok/s).

## Phase 3e/2 plan (next PR)
- Change `BackendQuantMarlin::load_gptq` signature: takes `bias: Option<&[f32]>` parameter, returns `Box<dyn Linear<Self> + Send + Sync>` instead of `Self::GptqStore`.
- Add `BackendQuantMarlin::make_stacked_expert_linear` for the MoE `StackedExpertLinear` factory.
- CudaBackend impl wraps in `CudaMarlinLinear` / `CudaMarlinStackedExpertLinear`.
- CpuBackend impl: dequant + wrap in a new `CpuDequantGptqLinear` (or reuse `DenseLinear<CpuBackend>`).
- ferrum-quantization::GptqLinear<B> shrinks to `pub struct GptqLinear<B>(Box<dyn Linear<B>>)` — just a delegating wrapper.
- Delete `BackendQuantMarlin::gemm_gptq` + `gemm_gptq_with_offset` from the trait.
- Closes Dim 2 + Dim 3.

## Test plan
- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo test --workspace --features metal --lib` clean
- [x] `cargo fmt --all -- --check` clean