### PR TITLE
refactor(kernels): cutover GPTQ-Marlin Linear — delete gemm_gptq trait method (Phase 3e/2)

### DIFF
--- a/crates/ferrum-kernels/src/backend/cpu.rs
+++ b/crates/ferrum-kernels/src/backend/cpu.rs
@@ -678,88 +678,125 @@ impl crate::backend::BackendGraph for CpuBackend {}
 // CPU has no multi-rank collectives; inherit BackendCollective defaults.
 impl crate::backend::BackendCollective for CpuBackend {}
 
+/// Dequant raw GPTQ tensors → row-major `[n, k]` f32. Shared between
+/// the per-tensor `load_gptq` and the MoE `load_gptq_stacked` impls.
+fn cpu_dequant_gptq(
+    qweight: &[i32],
+    scales: &[f32],
+    qzeros: &[i32],
+    bits: u32,
+    group_size: usize,
+    k: usize,
+    n: usize,
+) -> Result<Vec<f32>> {
+    if bits != 4 {
+        return Err(FerrumError::unsupported(format!(
+            "CPU GPTQ: only bits=4 supported (got {bits})"
+        )));
+    }
+    let mut w = vec![0.0f32; n * k];
+    let packed_rows = k / 8;
+    for pr in 0..packed_rows {
+        for col in 0..n {
+            let packed = qweight[pr * n + col] as u32;
+            for bi in 0..8 {
+                let ki = pr * 8 + bi;
+                let q = ((packed >> (bi * 4)) & 0xF) as i32;
+                let grp = ki / group_size;
+                let scale = scales[grp * n + col];
+                let z_packed = qzeros[grp * (n / 8) + (col / 8)] as u32;
+                let zero = (((z_packed >> ((col % 8) * 4)) & 0xF) as i32) + 1;
+                let val = (q - zero) as f32 * scale;
+                w[col * k + ki] = val;
+            }
+        }
+    }
+    Ok(w)
+}
+
 impl crate::backend::BackendQuantMarlin for CpuBackend {
     fn load_gptq(
         qweight: &[i32],
         scales: &[f32],
         qzeros: &[i32],
         _g_idx: Option<&[i32]>,
+        bias_host: Option<&[f32]>,
         bits: u32,
         group_size: usize,
         k: usize,
         n: usize,
+    ) -> Result<Box<dyn crate::Linear<Self> + Send + Sync>> {
+        let w = cpu_dequant_gptq(qweight, scales, qzeros, bits, group_size, k, n)?;
+        // Phase 3e/2: dequantized weights become a CpuGptqLinear that
+        // owns the (out_features, in_features) f32 matrix and runs
+        // through the existing Self::gemm CPU path.
+        Ok(Box::new(crate::quant_linear::cpu_dequant::CpuGptqLinear {
+            weight_f32: w,
+            bias: bias_host.map(|b| b.to_vec()),
+            in_features: k,
+            out_features: n,
+        }))
+    }
+    fn load_gptq_stacked(
+        qweights: &[&[i32]],
+        scales: &[&[f32]],
+        qzeros: &[&[i32]],
+        _g_idx: Option<&[i32]>,
+        bits: u32,
+        group_size: usize,
+        k: usize,
+        n_per_expert: usize,
     ) -> Result<Self::GptqStore> {
-        if bits != 4 {
-            return Err(FerrumError::unsupported(format!(
-                "CPU GPTQ: only bits=4 supported (got {bits})"
+        // Phase 3e/2 addition: dequant each expert independently, concat
+        // along N (rows in [n, k] layout). Used by MoE parity tests.
+        let num_experts = qweights.len();
+        if scales.len() != num_experts || qzeros.len() != num_experts {
+            return Err(FerrumError::model(format!(
+                "load_gptq_stacked: input slice lengths disagree (qw {num_experts}, sc {}, qz {})",
+                scales.len(),
+                qzeros.len()
             )));
         }
-        let num_groups = k / group_size;
-        // Unpack GPTQ [K/8, N] i32 → int4 values, dequantize per-group:
-        //   w_f16 = (q - zero) * scale
-        // Write to [n, k] row-major (matches DenseLinear convention).
-        let mut w = vec![0.0f32; n * k];
-        let packed_rows = k / 8;
-        for pr in 0..packed_rows {
-            for col in 0..n {
-                let packed = qweight[pr * n + col] as u32;
-                for bi in 0..8 {
-                    let ki = pr * 8 + bi;
-                    let q = ((packed >> (bi * 4)) & 0xF) as i32;
-                    let grp = ki / group_size;
-                    let scale = scales[grp * n + col];
-                    // qzeros [num_groups, N/8] i32 packs 8 zero-values per int32
-                    let z_packed = qzeros[grp * (n / 8) + (col / 8)] as u32;
-                    let zero = (((z_packed >> ((col % 8) * 4)) & 0xF) as i32) + 1;
-                    let val = (q - zero) as f32 * scale;
-                    w[col * k + ki] = val;
-                }
-            }
+        let total_n = num_experts * n_per_expert;
+        let mut all_w = Vec::with_capacity(total_n * k);
+        for ((qw_e, sc_e), qz_e) in qweights.iter().zip(scales.iter()).zip(qzeros.iter()) {
+            let w_e = cpu_dequant_gptq(qw_e, sc_e, qz_e, bits, group_size, k, n_per_expert)?;
+            all_w.extend_from_slice(&w_e);
         }
-        let _ = num_groups; // informational only
         Ok(CpuGptqStore {
-            weight_f32: w,
+            weight_f32: all_w,
             k,
-            n,
+            n: total_n,
         })
     }
-    fn gemm_gptq(
-        ctx: &mut Self::Context,
-        a: &Self::Buffer,
-        weight: &Self::GptqStore,
-        out: &mut Self::Buffer,
-        m: usize,
-    ) -> Result<()> {
-        // Just run normal GEMM with dequantized weights.
-        // out[m, n] = a[m, k] @ w[n, k]^T — same contract as B::gemm.
-        Self::gemm(ctx, a, &weight.weight_f32, out, m, weight.n, weight.k);
-        Ok(())
-    }
-    fn gemm_gptq_with_offset(
-        ctx: &mut Self::Context,
-        a: &Self::Buffer,
-        weight: &Self::GptqStore,
+    fn make_stacked_expert_linear(
+        store: std::sync::Arc<Self::GptqStore>,
         expert_offset: usize,
         expert_n: usize,
-        out: &mut Self::Buffer,
-        m: usize,
-    ) -> Result<()> {
-        if expert_offset + expert_n > weight.n {
+        k: usize,
+        bias_host: Option<&[f32]>,
+    ) -> Result<Box<dyn crate::Linear<Self> + Send + Sync>> {
+        if expert_offset + expert_n > store.n {
             return Err(FerrumError::model(format!(
-                "gemm_gptq_with_offset OOB: offset {expert_offset} + n {expert_n} > stacked_n {}",
-                weight.n
+                "make_stacked_expert_linear OOB: offset {expert_offset} + n {expert_n} > stacked_n {}",
+                store.n
             )));
         }
-        // weight_f32 layout is [N, K] row-major; copy the
-        // [expert_offset .. expert_offset + expert_n) row range into
-        // a Vec (CPU path isn't perf-critical for MoE — Marlin owns
-        // that on CUDA).
-        let k = weight.k;
+        if k != store.k {
+            return Err(FerrumError::model(format!(
+                "make_stacked_expert_linear k mismatch: arg {k} vs store.k {}",
+                store.k
+            )));
+        }
         let row_start = expert_offset * k;
         let row_end = (expert_offset + expert_n) * k;
-        let slice = weight.weight_f32[row_start..row_end].to_vec();
-        Self::gemm(ctx, a, &slice, out, m, expert_n, k);
-        Ok(())
+        let slice = store.weight_f32[row_start..row_end].to_vec();
+        Ok(Box::new(crate::quant_linear::cpu_dequant::CpuGptqLinear {
+            weight_f32: slice,
+            bias: bias_host.map(|b| b.to_vec()),
+            in_features: k,
+            out_features: expert_n,
+        }))
     }
     fn gemm_gptq_with_offset_strided(
         _ctx: &mut Self::Context,

--- a/crates/ferrum-kernels/src/backend/cuda.rs
+++ b/crates/ferrum-kernels/src/backend/cuda.rs
@@ -3150,11 +3150,12 @@ impl BackendQuantMarlin for CudaBackend {
         scales: &[f32],
         qzeros: &[i32],
         g_idx: Option<&[i32]>,
+        bias_host: Option<&[f32]>,
         bits: u32,
         group_size: usize,
         k: usize,
         n: usize,
-    ) -> Result<Self::GptqStore> {
+    ) -> Result<Box<dyn crate::Linear<Self> + Send + Sync>> {
         if bits != 4 {
             return Err(FerrumError::unsupported(format!(
                 "CUDA GPTQ: only bits=4 supported (got {bits})"
@@ -3179,14 +3180,21 @@ impl BackendQuantMarlin for CudaBackend {
                 .clone_htod(qzeros)
                 .map_err(|e| FerrumError::model(format!("triton qzeros htod: {e}")))?;
             tracing::info!("GPTQ load (triton-rs w4a16): K={k}, N={n}, gs={group_size}");
-            return Ok(GptqStoreCuda::Triton(
-                crate::triton_w4a16::TritonGptqWeight {
-                    qweight: qweight_dev,
-                    scales: scales_dev,
-                    qzeros: qzeros_dev,
-                    k,
-                    n,
-                    group_size: group_size as i32,
+            let store = GptqStoreCuda::Triton(crate::triton_w4a16::TritonGptqWeight {
+                qweight: qweight_dev,
+                scales: scales_dev,
+                qzeros: qzeros_dev,
+                k,
+                n,
+                group_size: group_size as i32,
+            });
+            let bias = bias_host.map(<Self as crate::backend::Backend>::from_slice);
+            return Ok(Box::new(
+                crate::quant_linear::cuda_marlin::CudaMarlinLinear {
+                    store,
+                    bias,
+                    in_features: k,
+                    out_features: n,
                 },
             ));
         }
@@ -3260,15 +3268,23 @@ impl BackendQuantMarlin for CudaBackend {
             perm: perm_dev_opt,
         };
 
-        // Wrap in the Marlin variant (or pass through, depending on cfg).
+        // Wrap in the Marlin variant (or pass through, depending on cfg)
+        // and box as a Linear<Self>. Phase 3e/2: kernel dispatch lives
+        // inside CudaMarlinLinear::forward, not the trait method.
         #[cfg(feature = "triton-kernels")]
-        {
-            Ok(GptqStoreCuda::Marlin(marlin_weight))
-        }
+        let store = GptqStoreCuda::Marlin(marlin_weight);
         #[cfg(not(feature = "triton-kernels"))]
-        {
-            Ok(marlin_weight)
-        }
+        let store: GptqStoreCuda = marlin_weight;
+
+        let bias = bias_host.map(<Self as crate::backend::Backend>::from_slice);
+        Ok(Box::new(
+            crate::quant_linear::cuda_marlin::CudaMarlinLinear {
+                store,
+                bias,
+                in_features: k,
+                out_features: n,
+            },
+        ))
     }
     fn load_gptq_stacked(
         qweights: &[&[i32]],
@@ -3441,121 +3457,23 @@ impl BackendQuantMarlin for CudaBackend {
             Ok(marlin_weight)
         }
     }
-    #[cfg(feature = "marlin")]
-    fn gemm_gptq(
-        ctx: &mut Self::Context,
-        a: &Self::Buffer,
-        weight: &Self::GptqStore,
-        out: &mut Self::Buffer,
-        m: usize,
-    ) -> Result<()> {
-        // Branch on store variant (only present when triton-kernels is on).
-        #[cfg(feature = "triton-kernels")]
-        match weight {
-            GptqStoreCuda::Marlin(mw) => marlin_gemm_with_perm(ctx, a, mw, out, m),
-            GptqStoreCuda::Triton(tw) => {
-                // Pre-load (and cache) the CudaFunction once per CudaState.
-                // Subsequent calls hit the HashMap and skip the PTX parse.
-                let func = ctx.func(
-                    "triton_w4a16_gptq",
-                    crate::triton_ptx::w4a16_gptq_f16::PTX,
-                    crate::triton_w4a16::fn_name(),
-                );
-                let stream = ctx.stream.clone();
-                crate::triton_w4a16::launch_w4a16_gptq_triton(&stream, &func, a, tw, out, m as i32)
-                    .map_err(|e| FerrumError::model(format!("triton w4a16: {e}")))
-            }
-        }
-        #[cfg(not(feature = "triton-kernels"))]
-        {
-            marlin_gemm_with_perm(ctx, a, weight, out, m)
-        }
-    }
-    #[cfg(all(not(feature = "marlin"), feature = "triton-kernels"))]
-    fn gemm_gptq(
-        ctx: &mut Self::Context,
-        a: &Self::Buffer,
-        weight: &Self::GptqStore,
-        out: &mut Self::Buffer,
-        m: usize,
-    ) -> Result<()> {
-        // Marlin compiled out → only Triton path is callable. The Marlin
-        // variant should never be constructed in this configuration
-        // (load_gptq currently still builds a MarlinWeight even with
-        // triton-kernels — but its `gemm_gptq` would have nothing to call,
-        // so we error explicitly for traceability instead of silently
-        // failing inside the FFI stub).
-        match weight {
-            GptqStoreCuda::Marlin(_) => Err(FerrumError::unsupported(
-                "cargo feature `marlin` disabled — Marlin variant unusable; \
-                 set FERRUM_TRITON_INT4=1 to force the triton path",
-            )),
-            GptqStoreCuda::Triton(tw) => {
-                let func = ctx.func(
-                    "triton_w4a16_gptq",
-                    crate::triton_ptx::w4a16_gptq_f16::PTX,
-                    crate::triton_w4a16::fn_name(),
-                );
-                let stream = ctx.stream.clone();
-                crate::triton_w4a16::launch_w4a16_gptq_triton(&stream, &func, a, tw, out, m as i32)
-                    .map_err(|e| FerrumError::model(format!("triton w4a16: {e}")))
-            }
-        }
-    }
-    #[cfg(all(not(feature = "marlin"), not(feature = "triton-kernels")))]
-    fn gemm_gptq(
-        _ctx: &mut Self::Context,
-        _a: &Self::Buffer,
-        _weight: &Self::GptqStore,
-        _out: &mut Self::Buffer,
-        _m: usize,
-    ) -> Result<()> {
-        Err(FerrumError::unsupported(
-            "cargo features `marlin` and `triton-kernels` both disabled — \
-             GPTQ not available",
-        ))
-    }
-    /// MoE expert dispatch: GEMM over a column-slice of a stacked Marlin
-    /// store. Lets all 128 experts share one Marlin repack; the runtime
-    /// dispatch picks one expert by `expert_offset`.
-    ///
-    /// Currently Marlin-only (the Triton w4a16 variant doesn't support
-    /// strided access on the on-disk layout). When triton-kernels is on
-    /// and the store is Triton, returns Unsupported — caller should ensure
-    /// MoE models load through the Marlin path (default).
-    #[cfg(feature = "marlin")]
-    fn gemm_gptq_with_offset(
-        ctx: &mut Self::Context,
-        a: &Self::Buffer,
-        weight: &Self::GptqStore,
+    fn make_stacked_expert_linear(
+        store: std::sync::Arc<Self::GptqStore>,
         expert_offset: usize,
         expert_n: usize,
-        out: &mut Self::Buffer,
-        m: usize,
-    ) -> Result<()> {
-        #[cfg(feature = "triton-kernels")]
-        let mw = match weight {
-            GptqStoreCuda::Marlin(mw) => mw,
-            GptqStoreCuda::Triton(_) => {
-                return Err(FerrumError::unsupported(
-                    "gemm_gptq_with_offset: Triton w4a16 store has no \
-                     stride-aware variant; load MoE via Marlin (default)",
-                ));
-            }
-        };
-        #[cfg(not(feature = "triton-kernels"))]
-        let mw: &crate::marlin::MarlinWeight = weight;
-        let stream = ctx.stream.clone();
-        crate::marlin::marlin_gemm_with_offset(
-            &stream,
-            a,
-            mw,
-            out,
-            m as i32,
-            expert_offset as i32,
-            expert_n as i32,
-        )
-        .map_err(|e| FerrumError::model(format!("marlin offset gemm: {e}")))
+        k: usize,
+        bias_host: Option<&[f32]>,
+    ) -> Result<Box<dyn crate::Linear<Self> + Send + Sync>> {
+        let bias = bias_host.map(<Self as crate::backend::Backend>::from_slice);
+        Ok(Box::new(
+            crate::quant_linear::cuda_marlin::CudaMarlinStackedExpertLinear {
+                store,
+                expert_offset,
+                expert_n,
+                k,
+                bias,
+            },
+        ))
     }
     #[cfg(feature = "marlin")]
     fn moe_gemm_phase_batched(

--- a/crates/ferrum-kernels/src/backend/traits.rs
+++ b/crates/ferrum-kernels/src/backend/traits.rs
@@ -980,24 +980,31 @@ pub trait BackendCollective: Backend {
 /// CUDA wires this to the Marlin (or vLLM marlin_moe_wna16) tile kernels;
 /// other backends inherit defaults that error or no-op.
 pub trait BackendQuantMarlin: Backend {
-    /// Repack raw GPTQ tensors into the backend's preferred format.
+    /// Repack raw GPTQ tensors into a backend-specific `Linear<Self>` impl.
     /// Called once per layer at model load time.
     ///
     /// Inputs are host-side slices (CPU memory) — the loader reads from
     /// safetensors and hands them off; each backend uploads + repacks
     /// per its own strategy. `bits` is typically 4; `group_size` is
-    /// typically 128.
+    /// typically 128. `bias_host` is optional `[out_features]` f32 (when
+    /// the model has fused bias, e.g. Qwen2.5 attention projections).
+    ///
+    /// Phase 3e/2: returns `Box<dyn Linear<Self>>` directly (CUDA:
+    /// `CudaMarlinLinear`, CPU: `CpuGptqLinear`). Kernel dispatch lives
+    /// inside the boxed Linear's `forward` — the old `gemm_gptq` trait
+    /// method is gone.
     #[allow(clippy::too_many_arguments)]
     fn load_gptq(
         _qweight: &[i32],
         _scales: &[f32],
         _qzeros: &[i32],
         _g_idx: Option<&[i32]>,
+        _bias_host: Option<&[f32]>,
         _bits: u32,
         _group_size: usize,
         _k: usize,
         _n: usize,
-    ) -> Result<Self::GptqStore> {
+    ) -> Result<Box<dyn crate::Linear<Self> + Send + Sync>> {
         Err(FerrumError::unsupported(
             "load_gptq not implemented for this backend",
         ))
@@ -1034,40 +1041,29 @@ pub trait BackendQuantMarlin: Backend {
             "load_gptq_stacked not implemented for this backend",
         ))
     }
-    /// GEMM with pre-loaded GPTQ weights.
-    /// `out[m, n] = a[m, k] @ dequant(weight)^T`
-    fn gemm_gptq(
-        _ctx: &mut Self::Context,
-        _a: &Self::Buffer,
-        _weight: &Self::GptqStore,
-        _out: &mut Self::Buffer,
-        _m: usize,
-    ) -> Result<()> {
-        Err(FerrumError::unsupported(
-            "gemm_gptq not implemented for this backend",
-        ))
-    }
-    /// GEMM on a column-slice of a stacked GPTQ store. Used for MoE
-    /// expert dispatch where one big stacked weight tile holds all
-    /// experts' weights along N; per-expert calls process columns
-    /// `[expert_offset .. expert_offset + expert_n)` only.
-    ///
-    /// Output is written to `out[m, expert_n]` (NOT the full stacked N).
-    /// Caller is responsible for sizing `out` correctly.
+    /// Build a per-expert column-slice `Linear<Self>` view on top of a
+    /// stacked GPTQ store. The store concatenates all experts' weights
+    /// along N; this factory selects columns
+    /// `[expert_offset .. expert_offset + expert_n)` for one expert.
     ///
     /// `expert_offset` and `expert_n` MUST be multiples of the backend's
-    /// natural N tile size (Marlin: 64). Default returns Err(unsupported).
-    fn gemm_gptq_with_offset(
-        _ctx: &mut Self::Context,
-        _a: &Self::Buffer,
-        _weight: &Self::GptqStore,
+    /// natural N tile size (Marlin: 64). `bias_host` is per-expert.
+    /// Default returns Err(unsupported).
+    ///
+    /// Phase 3e/2: replaces the old `gemm_gptq_with_offset` trait
+    /// method dispatched from `StackedExpertLinear<B>::forward`. The
+    /// kernel call now lives inside the returned boxed Linear's
+    /// `forward` (CUDA: `CudaMarlinStackedExpertLinear`).
+    #[allow(clippy::too_many_arguments)]
+    fn make_stacked_expert_linear(
+        _store: std::sync::Arc<Self::GptqStore>,
         _expert_offset: usize,
         _expert_n: usize,
-        _out: &mut Self::Buffer,
-        _m: usize,
-    ) -> Result<()> {
+        _k: usize,
+        _bias_host: Option<&[f32]>,
+    ) -> Result<Box<dyn crate::Linear<Self> + Send + Sync>> {
         Err(FerrumError::unsupported(
-            "gemm_gptq_with_offset not implemented for this backend",
+            "make_stacked_expert_linear not implemented for this backend",
         ))
     }
     /// Bulk-zero the per-expert Marlin workspace mutex slots for a

--- a/crates/ferrum-kernels/src/quant_linear.rs
+++ b/crates/ferrum-kernels/src/quant_linear.rs
@@ -12,5 +12,7 @@
 //! → quantization → kernels). ferrum-quantization stays as the
 //! weight-format parser layer; backend-specific Linear impls live here.
 
+pub mod cpu_dequant;
+
 #[cfg(feature = "cuda")]
 pub mod cuda_marlin;

--- a/crates/ferrum-kernels/src/quant_linear/cpu_dequant.rs
+++ b/crates/ferrum-kernels/src/quant_linear/cpu_dequant.rs
@@ -1,0 +1,53 @@
+//! `Linear<CpuBackend>` impl for GPTQ weights, dequantized at load time.
+//!
+//! Phase 3e/2: replaces the old `BackendQuantMarlin::gemm_gptq` impl on
+//! CpuBackend. The kernel call (`Self::gemm` on dequantized weights)
+//! lives inside `CpuGptqLinear::forward` instead of the trait method
+//! body.
+
+use crate::backend::cpu::CpuBackend;
+use crate::Linear;
+
+/// CPU GPTQ Linear: holds dequantized fp32 weights `[out_features, in_features]`
+/// row-major, optional bias `[out_features]`, dispatches via `CpuBackend::gemm`.
+///
+/// The dequantization happens once in `BackendQuantMarlin::load_gptq` —
+/// inference is just a regular f32 GEMM.
+pub struct CpuGptqLinear {
+    pub weight_f32: Vec<f32>,
+    pub bias: Option<Vec<f32>>,
+    pub in_features: usize,
+    pub out_features: usize,
+}
+
+impl Linear<CpuBackend> for CpuGptqLinear {
+    fn in_features(&self) -> usize {
+        self.in_features
+    }
+
+    fn out_features(&self) -> usize {
+        self.out_features
+    }
+
+    fn forward(
+        &self,
+        ctx: &mut <CpuBackend as crate::backend::Backend>::Context,
+        input: &<CpuBackend as crate::backend::Backend>::Buffer,
+        out: &mut <CpuBackend as crate::backend::Backend>::Buffer,
+        m: usize,
+    ) {
+        // out[m, n] = a[m, k] @ w[n, k]^T — same contract as `B::gemm`.
+        <CpuBackend as crate::backend::Backend>::gemm(
+            ctx,
+            input,
+            &self.weight_f32,
+            out,
+            m,
+            self.out_features,
+            self.in_features,
+        );
+        if let Some(bias) = &self.bias {
+            <CpuBackend as crate::backend::Backend>::add_bias(ctx, out, bias, m, self.out_features);
+        }
+    }
+}

--- a/crates/ferrum-models/src/models/qwen3_moe.rs
+++ b/crates/ferrum-models/src/models/qwen3_moe.rs
@@ -646,7 +646,7 @@ impl<B: MoeLlmBackend> Qwen3MoeModel<B> {
                         e * gate_up_n_per_expert,
                         gate_up_n_per_expert,
                         gate_up_k,
-                    ),
+                    )?,
                 ));
                 down.push(Box::new(
                     ferrum_quantization::StackedExpertLinear::<B>::new(
@@ -654,7 +654,7 @@ impl<B: MoeLlmBackend> Qwen3MoeModel<B> {
                         e * down_n_per_expert,
                         down_n_per_expert,
                         down_k,
-                    ),
+                    )?,
                 ));
             }
             let experts = crate::moe::ExpertStack::<B> {

--- a/crates/ferrum-models/tests/moe_bucketed_parity_test.rs
+++ b/crates/ferrum-models/tests/moe_bucketed_parity_test.rs
@@ -46,8 +46,9 @@ fn synth_gptq(k: usize, n: usize, group_size: usize, seed: u64) -> (Vec<i32>, Ve
 }
 
 /// Build a stacked GPTQ store covering `num_experts` experts × N cols
-/// each, row-major-concatenated along the N dimension (expert-major
-/// like load_stacked_gptq_experts).
+/// each. Phase 3e/2: uses the proper `BackendQuantMarlin::load_gptq_stacked`
+/// API (which CpuBackend now implements) instead of abusing `load_gptq`
+/// on a hand-concatenated tensor.
 fn build_stacked(
     k: usize,
     n_per_expert: usize,
@@ -58,37 +59,20 @@ fn build_stacked(
     let parts: Vec<_> = (0..num_experts)
         .map(|e| synth_gptq(k, n_per_expert, group_size, base_seed + e as u64))
         .collect();
-
-    let total_n = num_experts * n_per_expert;
-    let qw_rows = k / 8;
-    let sc_rows = k / group_size;
-    let qz_rows = k / group_size;
-    let total_n_zeros = num_experts * (n_per_expert / 8);
-
-    let mut qw_acc = Vec::<i32>::with_capacity(qw_rows * total_n);
-    for r in 0..qw_rows {
-        for e in 0..num_experts {
-            qw_acc.extend_from_slice(&parts[e].0[r * n_per_expert..(r + 1) * n_per_expert]);
-        }
-    }
-    let mut sc_acc = Vec::<f32>::with_capacity(sc_rows * total_n);
-    for r in 0..sc_rows {
-        for e in 0..num_experts {
-            sc_acc.extend_from_slice(&parts[e].1[r * n_per_expert..(r + 1) * n_per_expert]);
-        }
-    }
-    let mut qz_acc = Vec::<i32>::with_capacity(qz_rows * total_n_zeros);
-    for r in 0..qz_rows {
-        for e in 0..num_experts {
-            qz_acc.extend_from_slice(
-                &parts[e].2[r * (n_per_expert / 8)..(r + 1) * (n_per_expert / 8)],
-            );
-        }
-    }
-    let store = <CpuBackend as BackendQuantMarlin>::load_gptq(
-        &qw_acc, &sc_acc, &qz_acc, None, 4, group_size, k, total_n,
+    let qweights: Vec<&[i32]> = parts.iter().map(|p| p.0.as_slice()).collect();
+    let scales: Vec<&[f32]> = parts.iter().map(|p| p.1.as_slice()).collect();
+    let qzeros: Vec<&[i32]> = parts.iter().map(|p| p.2.as_slice()).collect();
+    let store = <CpuBackend as BackendQuantMarlin>::load_gptq_stacked(
+        &qweights,
+        &scales,
+        &qzeros,
+        None,
+        4,
+        group_size,
+        k,
+        n_per_expert,
     )
-    .expect("CPU stacked load_gptq");
+    .expect("CPU stacked load_gptq_stacked");
     Arc::new(store)
 }
 
@@ -112,18 +96,19 @@ fn bucketed_matches_per_pair_dispatch() {
     let mut gate_up_per_expert: Vec<Box<dyn Linear<CpuBackend>>> = Vec::with_capacity(num_experts);
     let mut down_per_expert: Vec<Box<dyn Linear<CpuBackend>>> = Vec::with_capacity(num_experts);
     for e in 0..num_experts {
-        gate_up_per_expert.push(Box::new(StackedExpertLinear::<CpuBackend>::new(
-            gate_up_arc.clone(),
-            e * 2 * inter,
-            2 * inter,
-            hidden,
-        )));
-        down_per_expert.push(Box::new(StackedExpertLinear::<CpuBackend>::new(
-            down_arc.clone(),
-            e * hidden,
-            hidden,
-            inter,
-        )));
+        gate_up_per_expert.push(Box::new(
+            StackedExpertLinear::<CpuBackend>::new(
+                gate_up_arc.clone(),
+                e * 2 * inter,
+                2 * inter,
+                hidden,
+            )
+            .expect("gate_up StackedExpertLinear"),
+        ));
+        down_per_expert.push(Box::new(
+            StackedExpertLinear::<CpuBackend>::new(down_arc.clone(), e * hidden, hidden, inter)
+                .expect("down StackedExpertLinear"),
+        ));
     }
     let experts = ExpertStack::<CpuBackend> {
         gate_up: gate_up_per_expert,

--- a/crates/ferrum-quantization/src/gptq.rs
+++ b/crates/ferrum-quantization/src/gptq.rs
@@ -1,141 +1,109 @@
-//! GPTQ linear projection.
+//! GPTQ linear projection — thin factory wrapper.
 //!
-//! GPTQ packs f16 weights as int4 groups, each group sharing a scale +
-//! zero_point. On-disk layout from AutoGPTQ / gptq-for-llama:
-//!
-//!   qweight:  `[in_features / 8, out_features]`  i32 — 8 int4s per int32
-//!   qzeros:   `[in_features / group_size, out_features / 8]`  i32
-//!   scales:   `[in_features / group_size, out_features]`      f16
-//!   g_idx:    `[in_features]` i32 — per-row scale-group map (desc_act only)
-//!
-//! `GptqLinear<B>` stores a backend-specific `B::GptqStore` produced by
-//! `Backend::load_gptq`. The store holds whatever format the backend
-//! needs (CUDA: Marlin-repacked tiles; CPU: dequantized f32 weights;
-//! Metal: unsupported).
+//! Phase 3e/2: the actual kernel dispatch lives inside the boxed
+//! `Linear<B>` returned by `B::load_gptq` (`CudaMarlinLinear` on
+//! CUDA, `CpuGptqLinear` on CPU). This module just re-exposes the
+//! historical constructor names so callers don't have to switch.
 
 use ferrum_kernels::backend::{Backend, BackendQuantMarlin};
 use ferrum_kernels::Linear;
 use ferrum_types::Result;
+use std::sync::Arc;
 
+/// GPTQ-format Linear projection, polymorphic over backend.
+///
+/// Holds a boxed backend-specific `Linear<B>` produced by `B::load_gptq`.
+/// `forward()` delegates straight through.
 pub struct GptqLinear<B: Backend + BackendQuantMarlin> {
-    store: B::GptqStore,
-    bias: Option<B::Buffer>,
-    in_features: usize,
-    out_features: usize,
+    inner: Box<dyn Linear<B> + Send + Sync>,
 }
 
 impl<B: Backend + BackendQuantMarlin> GptqLinear<B> {
     /// Build from raw host-side GPTQ tensors. The Backend repacks into
-    /// its preferred format once; inference uses the repacked store.
+    /// its preferred format once (Marlin tiles on CUDA, dequant on CPU)
+    /// and returns a boxed Linear; inference uses the boxed forward.
     ///
     /// `qweight`: `[k/8, n]` i32 (packed int4)
     /// `scales`:  `[k/group_size, n]` f32 (converted from f16 by caller)
     /// `qzeros`:  `[k/group_size, n/8]` i32
     /// `g_idx`:   `[k]` i32 — optional, only used for desc_act=true
+    /// `bias`:    `[n]` f32 — optional fused bias (Qwen2.5 attention)
     #[allow(clippy::too_many_arguments)]
     pub fn from_raw(
         qweight: &[i32],
         scales: &[f32],
         qzeros: &[i32],
         g_idx: Option<&[i32]>,
+        bias: Option<&[f32]>,
         bits: u32,
         group_size: usize,
         in_features: usize,
         out_features: usize,
     ) -> Result<Self> {
-        let store = B::load_gptq(
+        let inner = B::load_gptq(
             qweight,
             scales,
             qzeros,
             g_idx,
+            bias,
             bits,
             group_size,
             in_features,
             out_features,
         )?;
-        Ok(Self {
-            store,
-            bias: None,
-            in_features,
-            out_features,
-        })
-    }
-
-    /// Construct directly from a pre-built backend store (e.g. tests).
-    pub fn from_store(store: B::GptqStore, in_features: usize, out_features: usize) -> Self {
-        Self {
-            store,
-            bias: None,
-            in_features,
-            out_features,
-        }
-    }
-
-    /// Attach a bias vector (`[out_features]` f32 on host, uploaded to backend).
-    /// Qwen2.5 / Llama-with-bias variants require this.
-    pub fn with_bias(mut self, bias: &[f32]) -> Self {
-        debug_assert_eq!(
-            bias.len(),
-            self.out_features,
-            "GptqLinear bias length mismatch"
-        );
-        self.bias = Some(B::from_slice(bias));
-        self
-    }
-
-    pub fn store(&self) -> &B::GptqStore {
-        &self.store
+        Ok(Self { inner })
     }
 }
 
 impl<B: Backend + BackendQuantMarlin> Linear<B> for GptqLinear<B> {
     fn in_features(&self) -> usize {
-        self.in_features
+        self.inner.in_features()
     }
 
     fn out_features(&self) -> usize {
-        self.out_features
+        self.inner.out_features()
     }
 
     fn forward(&self, ctx: &mut B::Context, input: &B::Buffer, out: &mut B::Buffer, m: usize) {
-        B::gemm_gptq(ctx, input, &self.store, out, m)
-            .unwrap_or_else(|e| panic!("GPTQ forward failed: {e}"));
-        if let Some(bias) = &self.bias {
-            B::add_bias(ctx, out, bias, m, self.out_features);
-        }
+        self.inner.forward(ctx, input, out, m);
     }
 }
 
 /// View into a single column-slice of a shared stacked GPTQ store.
-/// All MoE experts in a layer share one big repacked Marlin tile that
-/// concatenates `num_experts × n_per_expert` columns; each
-/// `StackedExpertLinear` knows its expert's offset and width and
-/// dispatches to `B::gemm_gptq_with_offset` at forward time.
 ///
-/// The store itself is `Arc<B::GptqStore>` so cloning a view is cheap;
-/// dropping all views drops the underlying store.
+/// Phase 3e/2: backed by a `Box<dyn Linear<B>>` produced by
+/// `B::make_stacked_expert_linear` (CUDA: `CudaMarlinStackedExpertLinear`;
+/// CPU: `CpuGptqLinear` over a sliced row range). The store itself is
+/// `Arc<B::GptqStore>` so cloning a view is cheap; dropping all views
+/// drops the underlying store.
 pub struct StackedExpertLinear<B: Backend + BackendQuantMarlin> {
-    pub store: std::sync::Arc<B::GptqStore>,
-    pub expert_offset: usize,
-    pub expert_n: usize,
-    pub k: usize,
-    pub bias: Option<B::Buffer>,
+    inner: Box<dyn Linear<B> + Send + Sync>,
+    /// Kept for in_features() reporting.
+    k: usize,
+    /// Kept for out_features() reporting.
+    expert_n: usize,
 }
 
 impl<B: Backend + BackendQuantMarlin> StackedExpertLinear<B> {
     pub fn new(
-        store: std::sync::Arc<B::GptqStore>,
+        store: Arc<B::GptqStore>,
         expert_offset: usize,
         expert_n: usize,
         k: usize,
-    ) -> Self {
-        Self {
-            store,
-            expert_offset,
-            expert_n,
-            k,
-            bias: None,
-        }
+    ) -> Result<Self> {
+        let inner = B::make_stacked_expert_linear(store, expert_offset, expert_n, k, None)?;
+        Ok(Self { inner, k, expert_n })
+    }
+
+    pub fn new_with_bias(
+        store: Arc<B::GptqStore>,
+        expert_offset: usize,
+        expert_n: usize,
+        k: usize,
+        bias: &[f32],
+    ) -> Result<Self> {
+        let inner = B::make_stacked_expert_linear(store, expert_offset, expert_n, k, Some(bias))?;
+        Ok(Self { inner, k, expert_n })
     }
 }
 
@@ -143,22 +111,12 @@ impl<B: Backend + BackendQuantMarlin> Linear<B> for StackedExpertLinear<B> {
     fn in_features(&self) -> usize {
         self.k
     }
+
     fn out_features(&self) -> usize {
         self.expert_n
     }
+
     fn forward(&self, ctx: &mut B::Context, input: &B::Buffer, out: &mut B::Buffer, m: usize) {
-        B::gemm_gptq_with_offset(
-            ctx,
-            input,
-            &self.store,
-            self.expert_offset,
-            self.expert_n,
-            out,
-            m,
-        )
-        .unwrap_or_else(|e| panic!("StackedExpert forward failed: {e}"));
-        if let Some(bias) = &self.bias {
-            B::add_bias(ctx, out, bias, m, self.expert_n);
-        }
+        self.inner.forward(ctx, input, out, m);
     }
 }

--- a/crates/ferrum-quantization/src/native_safetensors.rs
+++ b/crates/ferrum-quantization/src/native_safetensors.rs
@@ -686,28 +686,33 @@ impl<B: Backend + BackendQuantMarlin> NativeSafetensorsLoader<B> {
             )));
         }
 
-        let mut linear = GptqLinear::<B>::from_raw(
-            &qweight,
-            &scales_f32,
-            &qzeros,
-            g_idx.as_deref(),
-            qcfg.bits,
-            qcfg.group_size,
-            in_features,
-            out_features,
-        )?;
-
-        // Bias (Qwen2.5 attention projections, some Llama variants).
+        // Read optional bias FIRST (Qwen2.5 attention projections, some
+        // Llama variants). Phase 3e/2: load_gptq takes the bias eagerly
+        // because the boxed Linear bakes it in.
         let bias_key = format!("{name}.bias");
-        if self.has(&bias_key) {
+        let bias_vec = if self.has(&bias_key) {
             let (bias, bias_shape) = self.read_f32(&bias_key)?;
             if bias_shape != [out_features] {
                 return Err(FerrumError::model(format!(
                     "'{bias_key}' {bias_shape:?} != [{out_features}]"
                 )));
             }
-            linear = linear.with_bias(&bias);
-        }
+            Some(bias)
+        } else {
+            None
+        };
+
+        let linear = GptqLinear::<B>::from_raw(
+            &qweight,
+            &scales_f32,
+            &qzeros,
+            g_idx.as_deref(),
+            bias_vec.as_deref(),
+            qcfg.bits,
+            qcfg.group_size,
+            in_features,
+            out_features,
+        )?;
         Ok(Box::new(linear))
     }
 
@@ -849,19 +854,9 @@ impl<B: Backend + BackendQuantMarlin> NativeSafetensorsLoader<B> {
         #[cfg(feature = "cuda")]
         let _ = is_desc_act;
 
-        let mut linear = GptqLinear::<B>::from_raw(
-            &qw_acc,
-            &sc_acc,
-            &qz_acc,
-            g_idx.as_deref(),
-            qcfg.bits,
-            qcfg.group_size,
-            in_features,
-            out_features,
-        )?;
-
-        // Biases: concatenate `<part>.bias` across parts in the same order as
-        // qweights. All-or-none; if any part has a bias, all must.
+        // Biases: concatenate `<part>.bias` across parts in the same
+        // order as qweights. All-or-none; if any part has a bias, all
+        // must. Phase 3e/2: read first, pass into load_gptq.
         let bias_keys: Vec<String> = parts.iter().map(|p| format!("{p}.bias")).collect();
         let any = bias_keys.iter().any(|k| self.has(k));
         let all = bias_keys.iter().all(|k| self.has(k));
@@ -870,7 +865,7 @@ impl<B: Backend + BackendQuantMarlin> NativeSafetensorsLoader<B> {
                 "GPTQ fusion: inconsistent bias presence across parts".to_string(),
             ));
         }
-        if all {
+        let fused_bias = if all {
             let mut fused: Vec<f32> = Vec::with_capacity(out_features);
             for k in &bias_keys {
                 let (b, _) = self.read_f32(k)?;
@@ -882,8 +877,23 @@ impl<B: Backend + BackendQuantMarlin> NativeSafetensorsLoader<B> {
                     fused.len()
                 )));
             }
-            linear = linear.with_bias(&fused);
-        }
+            Some(fused)
+        } else {
+            None
+        };
+
+        let linear = GptqLinear::<B>::from_raw(
+            &qw_acc,
+            &sc_acc,
+            &qz_acc,
+            g_idx.as_deref(),
+            fused_bias.as_deref(),
+            qcfg.bits,
+            qcfg.group_size,
+            in_features,
+            out_features,
+        )?;
+
         Ok(Box::new(linear))
     }
 

--- a/crates/ferrum-quantization/tests/gptq_parity_test.rs
+++ b/crates/ferrum-quantization/tests/gptq_parity_test.rs
@@ -91,6 +91,7 @@ fn cpu_selfcheck() {
         &syn.scales,
         &syn.qzeros,
         None,
+        None,
         syn.bits,
         syn.group_size,
         syn.k,
@@ -160,6 +161,7 @@ fn cuda_vs_cpu() {
         &syn.scales,
         &syn.qzeros,
         None,
+        None,
         syn.bits,
         syn.group_size,
         syn.k,
@@ -172,6 +174,7 @@ fn cuda_vs_cpu() {
         &syn.qweight,
         &syn.scales,
         &syn.qzeros,
+        None,
         None,
         syn.bits,
         syn.group_size,
@@ -255,6 +258,7 @@ fn cuda_stacked_offset_vs_per_expert() {
                 &syn.scales,
                 &syn.qzeros,
                 None,
+                None,
                 syn.bits,
                 syn.group_size,
                 syn.k,
@@ -280,6 +284,7 @@ fn cuda_stacked_offset_vs_per_expert() {
     let mut ctx = <CudaBackend as Backend>::new_context();
 
     // Run per-expert reference + offset variant for each expert; compare.
+    let stacked_arc = std::sync::Arc::new(stacked);
     for (e, lin) in per_expert.iter().enumerate() {
         let input_dev = CudaBackend::from_slice(&input);
         let mut ref_out_dev = CudaBackend::alloc(m * n_per);
@@ -289,16 +294,22 @@ fn cuda_stacked_offset_vs_per_expert() {
 
         let input_dev_off = CudaBackend::from_slice(&input);
         let mut off_out_dev = CudaBackend::alloc(m * n_per);
-        <CudaBackend as BackendQuantMarlin>::gemm_gptq_with_offset(
-            &mut ctx,
-            &input_dev_off,
-            &stacked,
+        // Phase 3e/2: gemm_gptq_with_offset is gone; per-expert dispatch
+        // lives inside StackedExpertLinear<CudaBackend>::forward.
+        let off_lin = ferrum_quantization::StackedExpertLinear::<CudaBackend>::new(
+            stacked_arc.clone(),
             e * n_per,
             n_per,
+            k,
+        )
+        .expect("StackedExpertLinear::new");
+        ferrum_kernels::Linear::<CudaBackend>::forward(
+            &off_lin,
+            &mut ctx,
+            &input_dev_off,
             &mut off_out_dev,
             m,
-        )
-        .expect("gemm_gptq_with_offset");
+        );
         <CudaBackend as Backend>::sync(&mut ctx);
         let off_out = CudaBackend::to_vec(&off_out_dev, m * n_per);
 
@@ -355,6 +366,7 @@ fn cpu_stacked_vs_per_expert_parity() {
             &syn.scales,
             &syn.qzeros,
             None,
+            None,
             syn.bits,
             syn.group_size,
             syn.k,
@@ -367,54 +379,38 @@ fn cpu_stacked_vs_per_expert_parity() {
         per_expert_outs.push(out);
     }
 
-    // (b) Stacked path: row-major concat with expert-major ordering
-    //     (matches load_stacked_gptq_experts behavior — proj_names
-    //     length = 1 here).
-    let total_n = num_experts * n_per;
-    let qw_rows = k / 8;
-    let sc_rows = k / gs;
-    let qz_rows = k / gs;
-    let total_n_zeros = num_experts * (n_per / 8);
-
-    let mut qw_acc = Vec::<i32>::with_capacity(qw_rows * total_n);
-    for r in 0..qw_rows {
-        for e in 0..num_experts {
-            qw_acc.extend_from_slice(&experts[e].qweight[r * n_per..(r + 1) * n_per]);
-        }
-    }
-    let mut sc_acc = Vec::<f32>::with_capacity(sc_rows * total_n);
-    for r in 0..sc_rows {
-        for e in 0..num_experts {
-            sc_acc.extend_from_slice(&experts[e].scales[r * n_per..(r + 1) * n_per]);
-        }
-    }
-    let mut qz_acc = Vec::<i32>::with_capacity(qz_rows * total_n_zeros);
-    for r in 0..qz_rows {
-        for e in 0..num_experts {
-            qz_acc.extend_from_slice(&experts[e].qzeros[r * (n_per / 8)..(r + 1) * (n_per / 8)]);
-        }
-    }
-
-    let stacked_store = <CpuBackend as BackendQuantMarlin>::load_gptq(
-        &qw_acc, &sc_acc, &qz_acc, None, 4, gs, k, total_n,
+    // (b) Stacked path: Phase 3e/2 uses the proper
+    //     `load_gptq_stacked` API rather than abusing `load_gptq` on
+    //     hand-concatenated tensors.
+    let qweights: Vec<&[i32]> = experts.iter().map(|s| s.qweight.as_slice()).collect();
+    let scales: Vec<&[f32]> = experts.iter().map(|s| s.scales.as_slice()).collect();
+    let qzeros: Vec<&[i32]> = experts.iter().map(|s| s.qzeros.as_slice()).collect();
+    let stacked_store = <CpuBackend as BackendQuantMarlin>::load_gptq_stacked(
+        &qweights, &scales, &qzeros, None, 4, gs, k, n_per,
     )
-    .expect("stacked load_gptq");
+    .expect("stacked load_gptq_stacked");
 
-    // Slice-and-compare: for each expert, `gemm_gptq_with_offset` on
-    // the stacked store must equal the per-expert dedicated GEMM.
+    // Slice-and-compare: for each expert, the stacked-store sliced view
+    // must equal the per-expert dedicated GEMM. Phase 3e/2: per-expert
+    // dispatch goes through `StackedExpertLinear<CpuBackend>::forward`.
+    let stacked_arc = std::sync::Arc::new(stacked_store);
     for (e, ref_out) in per_expert_outs.iter().enumerate() {
         let mut stacked_out = vec![0.0f32; m * n_per];
         let mut ctx = <CpuBackend as Backend>::new_context();
-        <CpuBackend as BackendQuantMarlin>::gemm_gptq_with_offset(
-            &mut ctx,
-            &input,
-            &stacked_store,
+        let stacked_lin = ferrum_quantization::StackedExpertLinear::<CpuBackend>::new(
+            stacked_arc.clone(),
             e * n_per,
             n_per,
+            k,
+        )
+        .expect("StackedExpertLinear::new");
+        ferrum_kernels::Linear::<CpuBackend>::forward(
+            &stacked_lin,
+            &mut ctx,
+            &input,
             &mut stacked_out,
             m,
-        )
-        .expect("gemm_gptq_with_offset");
+        );
         let max_diff = ref_out
             .iter()
             .zip(&stacked_out)


### PR DESCRIPTION
## Summary
Completes Phase 3e for the GPTQ-Marlin path (CUDA + CPU). **Closes the Dim 2 / Dim 3 gap** in the architecture status doc — `Backend` trait no longer owns the kernel dispatch for Linear-shaped GPTQ ops.

### Trait surface change (`BackendQuantMarlin`)
- `load_gptq(...)` signature: takes `bias_host: Option<&[f32]>` and returns `Box<dyn Linear<Self>>` (was `Result<Self::GptqStore>`). Each backend's impl wraps weights in a concrete `Linear<Self>` whose `forward()` body owns the kernel dispatch.
- New `make_stacked_expert_linear(...)` factory for MoE column-slice views — replaces the old `gemm_gptq_with_offset` trait method, symmetric in design.
- **Deleted:** `gemm_gptq` (3 cfg variants on CudaBackend, 1 on CpuBackend) and `gemm_gptq_with_offset` (1 each). Their bodies now live inside `CudaMarlinLinear` / `CudaMarlinStackedExpertLinear` (CUDA, added in #122) and `CpuGptqLinear` (CPU, added here).

### Backend impls
- `CudaBackend::load_gptq` constructs `CudaMarlinLinear { store, bias, … }` and boxes it. Triton-kernels feature path preserved verbatim.
- `CudaBackend::make_stacked_expert_linear` constructs `CudaMarlinStackedExpertLinear` over an `Arc<GptqStoreCuda>`.
- `CpuBackend::load_gptq` dequants → `CpuGptqLinear` (new).
- `CpuBackend::load_gptq_stacked` (new): dequants each expert independently, concats along N. Used by MoE parity tests.
- `CpuBackend::make_stacked_expert_linear` (new): row-slices the stacked store into a per-expert `CpuGptqLinear`.

### ferrum-quantization (`gptq.rs`)
- `GptqLinear<B>` shrinks to `pub struct GptqLinear<B>(Box<dyn Linear<B>>)` — pure delegating wrapper.
- `from_raw()` now takes `bias: Option<&[f32]>` and calls `B::load_gptq` directly. Post-construction `with_bias()` is gone because the loader bakes the bias into the boxed Linear.
- `StackedExpertLinear<B>` similarly wraps `Box<dyn Linear<B>>`; `new()` returns `Result<Self>` since the underlying factory can fail.

### Caller updates
- `native_safetensors.rs` (2 sites): read bias FIRST, pass into `from_raw`, drop `with_bias` chain.
- `qwen3_moe.rs`: `StackedExpertLinear::new` call sites add `?`.
- `gptq_parity_test.rs`: bias-None added to `from_raw` calls; one `gemm_gptq_with_offset` direct test rewritten to use `StackedExpertLinear<CudaBackend>::forward`; abused `load_gptq` stacked-fake replaced with proper `load_gptq_stacked`.
- `moe_bucketed_parity_test.rs`: same — switch from `load_gptq` (8 args, returned store) to `load_gptq_stacked`, `StackedExpertLinear::new` adds `.expect()`.

### Net effect on dim status
- **Dim 2 (compute precision): 🟡 → ✅** for the GPTQ-Marlin (INT4) path. Backend trait no longer owns Marlin kernel dispatch; `Linear<B>` is the polymorphism point.
- **Dim 3 (weight format): same.** The new Linear types live in `ferrum-kernels::quant_linear/`, sized for adding more formats (AWQ, EXL2) without touching the Backend trait.
- GGUF still partial — Phase 3e/3 (separate PR).

## Test plan
- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo test --workspace --features metal --lib` clean (118 ferrum-engine tests)
- [x] `cargo fmt --all -- --check` clean
- [ ] CUDA pod: `cargo check --workspace --features cuda` (running)
- [ ] CUDA pod bench: Llama-8B INT4 Marlin baseline 60.6 tok/s — perf-neutral expected (LTO inlines through Box<dyn Linear>)