### PR TITLE
refactor(kernels): cutover GGUF Linear — delete gemm_quant trait method (Phase 3e/3, closes Dim 2/3)

### DIFF
--- a/crates/ferrum-kernels/src/backend/cpu.rs
+++ b/crates/ferrum-kernels/src/backend/cpu.rs
@@ -854,9 +854,9 @@ impl crate::backend::BackendQuantGguf for CpuBackend {
         bytes: &[u8],
         n_rows: usize,
         n_cols: usize,
-    ) -> Result<Self::QuantStore> {
+    ) -> Result<Box<dyn crate::Linear<Self> + Send + Sync>> {
         use super::GgufQuantType;
-        match kind {
+        let store = match kind {
             GgufQuantType::Q4K => {
                 let total_elems = n_rows * n_cols;
                 if total_elems % Q4_K_QK != 0 {
@@ -873,34 +873,25 @@ impl crate::backend::BackendQuantGguf for CpuBackend {
                         expected
                     )));
                 }
-                Ok(CpuQuantStore::Q4K {
+                CpuQuantStore::Q4K {
                     weights: dequant_q4_k_cpu(bytes, n_blocks),
                     n_rows,
                     n_cols,
-                })
+                }
             }
-            other => Err(FerrumError::unsupported(format!(
-                "CPU load_quant: {other:?} not yet implemented"
-            ))),
-        }
-    }
-    fn gemm_quant(
-        ctx: &mut Self::Context,
-        a: &Self::Buffer,
-        weight: &Self::QuantStore,
-        out: &mut Self::Buffer,
-        m: usize,
-    ) -> Result<()> {
-        match weight {
-            CpuQuantStore::Q4K {
-                weights,
-                n_rows,
-                n_cols,
-            } => {
-                Self::gemm(ctx, a, weights, out, m, *n_rows, *n_cols);
-                Ok(())
+            other => {
+                return Err(FerrumError::unsupported(format!(
+                    "CPU load_quant: {other:?} not yet implemented"
+                )));
             }
-        }
+        };
+        // Phase 3e/3: dispatch via CpuGgufLinear::forward instead of
+        // a trait method.
+        Ok(Box::new(crate::quant_linear::cpu_gguf::CpuGgufLinear {
+            store,
+            in_features: n_cols,
+            out_features: n_rows,
+        }))
     }
 }
 

--- a/crates/ferrum-kernels/src/backend/metal.rs
+++ b/crates/ferrum-kernels/src/backend/metal.rs
@@ -1549,72 +1549,91 @@ impl crate::backend::BackendCollective for MetalBackend {}
 // Metal does not ship Marlin INT4 kernels; inherit unsupported defaults.
 impl crate::backend::BackendQuantMarlin for MetalBackend {}
 
+/// Internal helper: build a `MetalQuantStore` from raw GGUF block bytes.
+/// Phase 3e/3 extracted from the old `load_quant` body so `load_quant_fused`
+/// can compose multiple stores into a `Fused` variant without going
+/// through the `Box<dyn Linear>` wrapper.
+fn metal_load_quant_store_helper(
+    kind: super::GgufQuantType,
+    bytes: &[u8],
+    n_rows: usize,
+    n_cols: usize,
+) -> Result<MetalQuantStore> {
+    use super::GgufQuantType;
+    const QK_K: usize = 256;
+    match kind {
+        GgufQuantType::Q4K => {
+            const BLOCK_BYTES: usize = 144;
+            let total_elems = n_rows * n_cols;
+            if total_elems % QK_K != 0 {
+                return Err(FerrumError::model(format!(
+                    "load_quant Q4K: elements {total_elems} not multiple of {QK_K}"
+                )));
+            }
+            let n_blocks = total_elems / QK_K;
+            let expected = n_blocks * BLOCK_BYTES;
+            if bytes.len() != expected {
+                return Err(FerrumError::model(format!(
+                    "load_quant Q4K: bytes {} != expected {} ({n_blocks} blocks)",
+                    bytes.len(),
+                    expected
+                )));
+            }
+            let (blocks, byte_offset) = buffer_for_quant_bytes(bytes);
+            Ok(MetalQuantStore::Q4K {
+                blocks,
+                byte_offset,
+                n_rows,
+                n_cols,
+                n_blocks,
+            })
+        }
+        GgufQuantType::Q6K => {
+            const BLOCK_BYTES: usize = crate::q6_k_gemv::Q6_K_BLOCK_BYTES; // 210
+            let total_elems = n_rows * n_cols;
+            if total_elems % QK_K != 0 {
+                return Err(FerrumError::model(format!(
+                    "load_quant Q6K: elements {total_elems} not multiple of {QK_K}"
+                )));
+            }
+            let n_blocks = total_elems / QK_K;
+            let expected = n_blocks * BLOCK_BYTES;
+            if bytes.len() != expected {
+                return Err(FerrumError::model(format!(
+                    "load_quant Q6K: bytes {} != expected {} ({n_blocks} blocks)",
+                    bytes.len(),
+                    expected
+                )));
+            }
+            let (blocks, byte_offset) = buffer_for_quant_bytes(bytes);
+            Ok(MetalQuantStore::Q6K {
+                blocks,
+                byte_offset,
+                n_rows,
+                n_cols,
+                n_blocks,
+            })
+        }
+        other => Err(FerrumError::unsupported(format!(
+            "Metal load_quant: {other:?} not yet implemented"
+        ))),
+    }
+}
+
 impl crate::backend::BackendQuantGguf for MetalBackend {
     fn load_quant(
         kind: super::GgufQuantType,
         bytes: &[u8],
         n_rows: usize,
         n_cols: usize,
-    ) -> Result<Self::QuantStore> {
-        use super::GgufQuantType;
-        const QK_K: usize = 256;
-        match kind {
-            GgufQuantType::Q4K => {
-                const BLOCK_BYTES: usize = 144;
-                let total_elems = n_rows * n_cols;
-                if total_elems % QK_K != 0 {
-                    return Err(FerrumError::model(format!(
-                        "load_quant Q4K: elements {total_elems} not multiple of {QK_K}"
-                    )));
-                }
-                let n_blocks = total_elems / QK_K;
-                let expected = n_blocks * BLOCK_BYTES;
-                if bytes.len() != expected {
-                    return Err(FerrumError::model(format!(
-                        "load_quant Q4K: bytes {} != expected {} ({n_blocks} blocks)",
-                        bytes.len(),
-                        expected
-                    )));
-                }
-                let (blocks, byte_offset) = buffer_for_quant_bytes(bytes);
-                Ok(MetalQuantStore::Q4K {
-                    blocks,
-                    byte_offset,
-                    n_rows,
-                    n_cols,
-                    n_blocks,
-                })
-            }
-            GgufQuantType::Q6K => {
-                const BLOCK_BYTES: usize = crate::q6_k_gemv::Q6_K_BLOCK_BYTES; // 210
-                let total_elems = n_rows * n_cols;
-                if total_elems % QK_K != 0 {
-                    return Err(FerrumError::model(format!(
-                        "load_quant Q6K: elements {total_elems} not multiple of {QK_K}"
-                    )));
-                }
-                let n_blocks = total_elems / QK_K;
-                let expected = n_blocks * BLOCK_BYTES;
-                if bytes.len() != expected {
-                    return Err(FerrumError::model(format!(
-                        "load_quant Q6K: bytes {} != expected {} ({n_blocks} blocks)",
-                        bytes.len(),
-                        expected
-                    )));
-                }
-                let (blocks, byte_offset) = buffer_for_quant_bytes(bytes);
-                Ok(MetalQuantStore::Q6K {
-                    blocks,
-                    byte_offset,
-                    n_rows,
-                    n_cols,
-                    n_blocks,
-                })
-            }
-            other => Err(FerrumError::unsupported(format!(
-                "Metal load_quant: {other:?} not yet implemented"
-            ))),
-        }
+    ) -> Result<Box<dyn crate::Linear<Self> + Send + Sync>> {
+        let store = metal_load_quant_store_helper(kind, bytes, n_rows, n_cols)?;
+        // Phase 3e/3: dispatch via MetalGgufLinear::forward.
+        Ok(Box::new(crate::quant_linear::metal_gguf::MetalGgufLinear {
+            store,
+            in_features: n_cols,
+            out_features: n_rows,
+        }))
     }
     fn load_quant_experts(
         kind: super::GgufQuantType,
@@ -2046,11 +2065,14 @@ impl crate::backend::BackendQuantGguf for MetalBackend {
     fn load_quant_fused(
         parts: &[(super::GgufQuantType, &[u8], usize)],
         n_cols: usize,
-    ) -> Result<Self::QuantStore> {
+    ) -> Result<Box<dyn crate::Linear<Self> + Send + Sync>> {
         let mut sub_stores: Vec<MetalQuantStore> = Vec::with_capacity(parts.len());
         let mut total_rows = 0;
         for (kind, bytes, n_rows) in parts {
-            let store = Self::load_quant(*kind, bytes, *n_rows, n_cols)?;
+            // Phase 3e/3: use the helper to get the raw QuantStore (the
+            // trait method now returns Box<dyn Linear>, which we can't
+            // unwrap into Fused).
+            let store = metal_load_quant_store_helper(*kind, bytes, *n_rows, n_cols)?;
             // Only leaf (Q4K / Q6K) parts are valid; nested Fused isn't.
             if matches!(store, MetalQuantStore::Fused { .. }) {
                 return Err(FerrumError::model(
@@ -2060,221 +2082,232 @@ impl crate::backend::BackendQuantGguf for MetalBackend {
             total_rows += n_rows;
             sub_stores.push(store);
         }
-        Ok(MetalQuantStore::Fused {
+        let fused = MetalQuantStore::Fused {
             parts: sub_stores,
             total_rows,
             n_cols,
-        })
+        };
+        Ok(Box::new(crate::quant_linear::metal_gguf::MetalGgufLinear {
+            store: fused,
+            in_features: n_cols,
+            out_features: total_rows,
+        }))
     }
-    fn gemm_quant(
-        ctx: &mut Self::Context,
-        a: &Self::Buffer,
-        weight: &Self::QuantStore,
-        out: &mut Self::Buffer,
-        m: usize,
-    ) -> Result<()> {
-        // Fused path: row-concatenation of mixed-quant parts (used for
-        // Qwen3 qkv_proj where q+k are Q4_K but v is Q6_K). For m=1
-        // dispatch each part with the right output offset; for m>1
-        // currently bail (prefill of mixed-fused matmuls is rare and
-        // would need a strided per-row inner loop).
-        if let MetalQuantStore::Fused {
-            parts,
-            total_rows,
-            n_cols,
-        } = weight
-        {
-            if m != 1 {
-                // **Fused mul_mm path** for prefill. Each part dispatches
-                // one mul_mm into a [m, part_rows] slice of the
-                // [m, total_rows] fused output via the strided variant
-                // (kernel uses `strideC = total_rows`, write width = part_rows,
-                // dst pre-offset to part column). Replaces the previous
-                // m × per-part gemv loop which scaled linearly with prompt
-                // length and was the dominant remaining prefill bottleneck
-                // on Qwen3 (mixed Q4+Q6 qkv).
-                let a_buf = a.expect_f32("gemm_quant a (fused)");
-                let out_buf = out.expect_f32_mut("gemm_quant out (fused)");
-                let enc = ctx.compute_encoder();
-                let mut col_off = 0usize;
-                for part in parts {
-                    let part_rows = part.n_rows();
-                    dispatch_part_gemm(
-                        enc,
-                        a_buf,
-                        part,
-                        out_buf,
-                        col_off,
-                        m,
-                        part_rows,
-                        *total_rows,
-                        *n_cols,
-                    )?;
-                    col_off += part_rows;
-                }
-                return Ok(());
-            }
-            // m == 1 — single output row of length total_rows.
-            let a_buf = a.expect_f32("gemm_quant a (fused m=1)");
-            let out_buf = out.expect_f32_mut("gemm_quant out (fused m=1)");
+}
+
+/// Metal GGUF k-quant matmul dispatcher — extracted from the old
+/// `BackendQuantGguf::gemm_quant` impl in Phase 3e/3 so the new
+/// `MetalGgufLinear::forward` (in `quant_linear::metal_gguf`) can call
+/// it from outside the trait. Trait method `gemm_quant` itself is
+/// gone; this free fn is the sole entry point now.
+pub fn metal_gemm_quant_dispatch(
+    ctx: &mut <MetalBackend as crate::backend::Backend>::Context,
+    a: &<MetalBackend as crate::backend::Backend>::Buffer,
+    weight: &<MetalBackend as crate::backend::Backend>::QuantStore,
+    out: &mut <MetalBackend as crate::backend::Backend>::Buffer,
+    m: usize,
+) -> Result<()> {
+    // Fused path: row-concatenation of mixed-quant parts (used for
+    // Qwen3 qkv_proj where q+k are Q4_K but v is Q6_K). For m=1
+    // dispatch each part with the right output offset; for m>1
+    // currently bail (prefill of mixed-fused matmuls is rare and
+    // would need a strided per-row inner loop).
+    if let MetalQuantStore::Fused {
+        parts,
+        total_rows,
+        n_cols,
+    } = weight
+    {
+        if m != 1 {
+            // **Fused mul_mm path** for prefill. Each part dispatches
+            // one mul_mm into a [m, part_rows] slice of the
+            // [m, total_rows] fused output via the strided variant
+            // (kernel uses `strideC = total_rows`, write width = part_rows,
+            // dst pre-offset to part column). Replaces the previous
+            // m × per-part gemv loop which scaled linearly with prompt
+            // length and was the dominant remaining prefill bottleneck
+            // on Qwen3 (mixed Q4+Q6 qkv).
+            let a_buf = a.expect_f32("gemm_quant a (fused)");
+            let out_buf = out.expect_f32_mut("gemm_quant out (fused)");
             let enc = ctx.compute_encoder();
-            let mut row_off_elems = 0usize;
+            let mut col_off = 0usize;
             for part in parts {
                 let part_rows = part.n_rows();
-                let c_off = (row_off_elems * 4) as u64;
-                dispatch_part_gemv_offset(enc, a_buf, 0, part, out_buf, c_off, *n_cols)?;
-                row_off_elems += part_rows;
+                dispatch_part_gemm(
+                    enc,
+                    a_buf,
+                    part,
+                    out_buf,
+                    col_off,
+                    m,
+                    part_rows,
+                    *total_rows,
+                    *n_cols,
+                )?;
+                col_off += part_rows;
             }
             return Ok(());
         }
-
-        // Borrow checker: `cmd` / `compute_encoder` need `&mut ctx` while
-        // we hold a borrow into `weight` for `blocks`. Snapshot the
-        // primitive fields out of `weight` first; `blocks` is a `Buffer`
-        // ref that is independent of ctx.
-        let (blocks, blocks_off, n_rows, n_cols, n_blocks, is_q6k) = match weight {
-            MetalQuantStore::Q4K {
-                blocks,
-                byte_offset,
-                n_rows,
-                n_cols,
-                n_blocks,
-            } => (blocks, *byte_offset, *n_rows, *n_cols, *n_blocks, false),
-            MetalQuantStore::Q6K {
-                blocks,
-                byte_offset,
-                n_rows,
-                n_cols,
-                n_blocks,
-            } => (blocks, *byte_offset, *n_rows, *n_cols, *n_blocks, true),
-            MetalQuantStore::Fused { .. } => unreachable!("handled above"),
-            MetalQuantStore::Q4KExperts { .. } | MetalQuantStore::Q6KExperts { .. } => {
-                return Err(FerrumError::model(
-                    "gemm_quant: ExpertsStacked must be dispatched via gemv_moe_id".to_string(),
-                ));
-            }
-        };
-
-        let _t0 = if debug_per_call_flush() {
-            Some(std::time::Instant::now())
-        } else {
-            None
-        };
-
-        let a_buf = a.expect_f32("gemm_quant a");
-        let out_buf = out.expect_f32_mut("gemm_quant out");
-
-        if m == 1 {
-            // **Fused path** for decode (m=1): one kernel reads the
-            // Q4_K / Q6_K super-blocks, decodes them inline, and reduces
-            // against `A`. No transient fp16 buffer materialised.
-            //
-            // All variants use N_R0=2, N_SG=2 layout from llama.cpp:
-            // 64 threads/threadgroup, 4 output rows/threadgroup. Requires
-            // N divisible by 4. Q6_K has no v1 fallback yet — Qwen3 /
-            // Llama always satisfy the constraint, so we just panic if
-            // not.
-            let enc = ctx.compute_encoder();
-            if is_q6k {
-                if n_rows % 4 != 0 {
-                    return Err(FerrumError::model(format!(
-                        "gemm_quant Q6K: n_rows={n_rows} not divisible by 4"
-                    )));
-                }
-                crate::q6_k_gemv::dispatch_gemv_q6k_v2_on_encoder(
-                    &st().pipes.device,
-                    enc,
-                    a_buf,
-                    blocks,
-                    blocks_off,
-                    out_buf,
-                    n_rows,
-                    n_cols,
-                );
-            } else if n_rows % 4 == 0 {
-                crate::q4_k_gemv_v2::dispatch_gemv_q4k_v2_on_encoder(
-                    &st().pipes.device,
-                    enc,
-                    a_buf,
-                    blocks,
-                    blocks_off,
-                    out_buf,
-                    n_rows,
-                    n_cols,
-                );
-            } else {
-                crate::q4_k_gemv::dispatch_gemv_q4k_on_encoder(
-                    &st().pipes.device,
-                    enc,
-                    a_buf,
-                    blocks,
-                    blocks_off,
-                    out_buf,
-                    n_rows,
-                    n_cols,
-                );
-            }
-        } else if is_q6k {
-            // **Q6_K m>1 fused mul_mm path** — ported from llama.cpp's
-            // `kernel_mul_mm_q6_K_f32`. Same 64×32 simdgroup-matmul
-            // tile + inline dequant as the Q4_K version. Replaces the
-            // prior per-row gemv loop which scaled linearly with m
-            // and was the dominant prefill bottleneck on Q4_K_M models
-            // where down_proj / lm_head live as Q6_K.
-            let enc = ctx.compute_encoder();
-            crate::q6_k_gemm::dispatch_gemm_q6k_on_encoder(
-                &st().pipes.device,
-                enc,
-                a_buf,
-                blocks,
-                blocks_off,
-                out_buf,
-                m,
-                n_rows,
-                n_cols,
-            );
-        } else {
-            // **Fused mul_mm path** for prefill (m > 1) Q4_K — ported
-            // from llama.cpp's `kernel_mul_mm_q4_K_f32`. Inlines Q4_K
-            // dequant into the threadgroup-memory load and uses
-            // `simdgroup_half8x8` matmul, eliminating both the fp16
-            // transient buffer (~2× memory traffic) and the scalar
-            // gemm_v2_f16w inner loop.
-            let enc = ctx.compute_encoder();
-            crate::q4_k_gemm::dispatch_gemm_q4k_on_encoder(
-                &st().pipes.device,
-                enc,
-                a_buf,
-                blocks,
-                blocks_off,
-                out_buf,
-                m,
-                n_rows,
-                n_cols,
-            );
-            let _ = n_blocks; // not consumed by mul_mm path; kept for the load-time block accounting
+        // m == 1 — single output row of length total_rows.
+        let a_buf = a.expect_f32("gemm_quant a (fused m=1)");
+        let out_buf = out.expect_f32_mut("gemm_quant out (fused m=1)");
+        let enc = ctx.compute_encoder();
+        let mut row_off_elems = 0usize;
+        for part in parts {
+            let part_rows = part.n_rows();
+            let c_off = (row_off_elems * 4) as u64;
+            dispatch_part_gemv_offset(enc, a_buf, 0, part, out_buf, c_off, *n_cols)?;
+            row_off_elems += part_rows;
         }
-
-        // Optional per-call timing: commit + wait the cmd buffer right
-        // here so we measure the GPU work for *this* matmul. Off by
-        // default (would serialize the whole pipeline).
-        if let Some(t0) = _t0 {
-            ctx.flush();
-            let elapsed_us = t0.elapsed().as_micros();
-            QUANT_GEMM_TIME_US.fetch_add(elapsed_us as u64, std::sync::atomic::Ordering::Relaxed);
-            QUANT_GEMM_CALLS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-            QUANT_GEMM_LAST_M.store(m as u64, std::sync::atomic::Ordering::Relaxed);
-            QUANT_GEMM_LAST_N.store(n_rows as u64, std::sync::atomic::Ordering::Relaxed);
-            QUANT_GEMM_LAST_K.store(n_cols as u64, std::sync::atomic::Ordering::Relaxed);
-            if QUANT_GEMM_CALLS.load(std::sync::atomic::Ordering::Relaxed) <= 16 {
-                eprintln!(
-                    "[gemm_quant] m={} n={} k={} took {} us",
-                    m, n_rows, n_cols, elapsed_us
-                );
-            }
-        }
-        Ok(())
+        return Ok(());
     }
+
+    // Borrow checker: `cmd` / `compute_encoder` need `&mut ctx` while
+    // we hold a borrow into `weight` for `blocks`. Snapshot the
+    // primitive fields out of `weight` first; `blocks` is a `Buffer`
+    // ref that is independent of ctx.
+    let (blocks, blocks_off, n_rows, n_cols, n_blocks, is_q6k) = match weight {
+        MetalQuantStore::Q4K {
+            blocks,
+            byte_offset,
+            n_rows,
+            n_cols,
+            n_blocks,
+        } => (blocks, *byte_offset, *n_rows, *n_cols, *n_blocks, false),
+        MetalQuantStore::Q6K {
+            blocks,
+            byte_offset,
+            n_rows,
+            n_cols,
+            n_blocks,
+        } => (blocks, *byte_offset, *n_rows, *n_cols, *n_blocks, true),
+        MetalQuantStore::Fused { .. } => unreachable!("handled above"),
+        MetalQuantStore::Q4KExperts { .. } | MetalQuantStore::Q6KExperts { .. } => {
+            return Err(FerrumError::model(
+                "gemm_quant: ExpertsStacked must be dispatched via gemv_moe_id".to_string(),
+            ));
+        }
+    };
+
+    let _t0 = if debug_per_call_flush() {
+        Some(std::time::Instant::now())
+    } else {
+        None
+    };
+
+    let a_buf = a.expect_f32("gemm_quant a");
+    let out_buf = out.expect_f32_mut("gemm_quant out");
+
+    if m == 1 {
+        // **Fused path** for decode (m=1): one kernel reads the
+        // Q4_K / Q6_K super-blocks, decodes them inline, and reduces
+        // against `A`. No transient fp16 buffer materialised.
+        //
+        // All variants use N_R0=2, N_SG=2 layout from llama.cpp:
+        // 64 threads/threadgroup, 4 output rows/threadgroup. Requires
+        // N divisible by 4. Q6_K has no v1 fallback yet — Qwen3 /
+        // Llama always satisfy the constraint, so we just panic if
+        // not.
+        let enc = ctx.compute_encoder();
+        if is_q6k {
+            if n_rows % 4 != 0 {
+                return Err(FerrumError::model(format!(
+                    "gemm_quant Q6K: n_rows={n_rows} not divisible by 4"
+                )));
+            }
+            crate::q6_k_gemv::dispatch_gemv_q6k_v2_on_encoder(
+                &st().pipes.device,
+                enc,
+                a_buf,
+                blocks,
+                blocks_off,
+                out_buf,
+                n_rows,
+                n_cols,
+            );
+        } else if n_rows % 4 == 0 {
+            crate::q4_k_gemv_v2::dispatch_gemv_q4k_v2_on_encoder(
+                &st().pipes.device,
+                enc,
+                a_buf,
+                blocks,
+                blocks_off,
+                out_buf,
+                n_rows,
+                n_cols,
+            );
+        } else {
+            crate::q4_k_gemv::dispatch_gemv_q4k_on_encoder(
+                &st().pipes.device,
+                enc,
+                a_buf,
+                blocks,
+                blocks_off,
+                out_buf,
+                n_rows,
+                n_cols,
+            );
+        }
+    } else if is_q6k {
+        // **Q6_K m>1 fused mul_mm path** — ported from llama.cpp's
+        // `kernel_mul_mm_q6_K_f32`. Same 64×32 simdgroup-matmul
+        // tile + inline dequant as the Q4_K version. Replaces the
+        // prior per-row gemv loop which scaled linearly with m
+        // and was the dominant prefill bottleneck on Q4_K_M models
+        // where down_proj / lm_head live as Q6_K.
+        let enc = ctx.compute_encoder();
+        crate::q6_k_gemm::dispatch_gemm_q6k_on_encoder(
+            &st().pipes.device,
+            enc,
+            a_buf,
+            blocks,
+            blocks_off,
+            out_buf,
+            m,
+            n_rows,
+            n_cols,
+        );
+    } else {
+        // **Fused mul_mm path** for prefill (m > 1) Q4_K — ported
+        // from llama.cpp's `kernel_mul_mm_q4_K_f32`. Inlines Q4_K
+        // dequant into the threadgroup-memory load and uses
+        // `simdgroup_half8x8` matmul, eliminating both the fp16
+        // transient buffer (~2× memory traffic) and the scalar
+        // gemm_v2_f16w inner loop.
+        let enc = ctx.compute_encoder();
+        crate::q4_k_gemm::dispatch_gemm_q4k_on_encoder(
+            &st().pipes.device,
+            enc,
+            a_buf,
+            blocks,
+            blocks_off,
+            out_buf,
+            m,
+            n_rows,
+            n_cols,
+        );
+        let _ = n_blocks; // not consumed by mul_mm path; kept for the load-time block accounting
+    }
+
+    // Optional per-call timing: commit + wait the cmd buffer right
+    // here so we measure the GPU work for *this* matmul. Off by
+    // default (would serialize the whole pipeline).
+    if let Some(t0) = _t0 {
+        ctx.flush();
+        let elapsed_us = t0.elapsed().as_micros();
+        QUANT_GEMM_TIME_US.fetch_add(elapsed_us as u64, std::sync::atomic::Ordering::Relaxed);
+        QUANT_GEMM_CALLS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        QUANT_GEMM_LAST_M.store(m as u64, std::sync::atomic::Ordering::Relaxed);
+        QUANT_GEMM_LAST_N.store(n_rows as u64, std::sync::atomic::Ordering::Relaxed);
+        QUANT_GEMM_LAST_K.store(n_cols as u64, std::sync::atomic::Ordering::Relaxed);
+        if QUANT_GEMM_CALLS.load(std::sync::atomic::Ordering::Relaxed) <= 16 {
+            eprintln!(
+                "[gemm_quant] m={} n={} k={} took {} us",
+                m, n_rows, n_cols, elapsed_us
+            );
+        }
+    }
+    Ok(())
 }
 
 impl crate::backend::BackendPagedKv for MetalBackend {

--- a/crates/ferrum-kernels/src/backend/traits.rs
+++ b/crates/ferrum-kernels/src/backend/traits.rs
@@ -1220,40 +1220,26 @@ pub trait BackendQuantGguf: Backend {
         _bytes: &[u8],
         _n_rows: usize,
         _n_cols: usize,
-    ) -> Result<Self::QuantStore> {
+    ) -> Result<Box<dyn crate::Linear<Self> + Send + Sync>> {
         Err(FerrumError::unsupported(
             "load_quant not implemented for this backend",
         ))
     }
-    /// Build a fused `QuantStore` from multiple `(kind, bytes, n_rows)`
+    /// Build a fused linear from multiple `(kind, bytes, n_rows)`
     /// parts that share `n_cols`. Used by `GgufLoader::load_fused` when
     /// parts have heterogeneous quant kinds (e.g. Qwen3 qkv_proj where
     /// q+k are Q4_K but v is Q6_K) — byte-concatenation isn't possible,
     /// so each part stays as its own QuantStore and the gemm dispatches
     /// one matvec per part with output offsets.
     ///
-    /// Default: not supported. Backends that have a `Fused`-like variant
-    /// override.
+    /// Phase 3e/3: returns `Box<dyn Linear<Self>>` directly (Metal:
+    /// `MetalGgufLinear` over a `Fused` MetalQuantStore variant).
     fn load_quant_fused(
         _parts: &[(GgufQuantType, &[u8], usize)],
         _n_cols: usize,
-    ) -> Result<Self::QuantStore> {
+    ) -> Result<Box<dyn crate::Linear<Self> + Send + Sync>> {
         Err(FerrumError::unsupported(
             "load_quant_fused not implemented for this backend",
-        ))
-    }
-    /// GEMM with k-quant weights. Mirrors `gemm` / `gemm_gptq` shape:
-    /// `out[m, n] = a[m, k] @ dequant(weight)^T`. The dispatch on the
-    /// quant flavour happens inside the backend's `QuantStore` enum.
-    fn gemm_quant(
-        _ctx: &mut Self::Context,
-        _a: &Self::Buffer,
-        _weight: &Self::QuantStore,
-        _out: &mut Self::Buffer,
-        _m: usize,
-    ) -> Result<()> {
-        Err(FerrumError::unsupported(
-            "gemm_quant not implemented for this backend",
         ))
     }
     /// Build a stacked-experts `QuantStore` from a contiguous 3-D weight

--- a/crates/ferrum-kernels/src/quant_linear.rs
+++ b/crates/ferrum-kernels/src/quant_linear.rs
@@ -13,6 +13,10 @@
 //! weight-format parser layer; backend-specific Linear impls live here.
 
 pub mod cpu_dequant;
+pub mod cpu_gguf;
 
 #[cfg(feature = "cuda")]
 pub mod cuda_marlin;
+
+#[cfg(all(target_os = "macos", feature = "metal"))]
+pub mod metal_gguf;

--- a/crates/ferrum-kernels/src/quant_linear/cpu_gguf.rs
+++ b/crates/ferrum-kernels/src/quant_linear/cpu_gguf.rs
@@ -1,0 +1,46 @@
+//! `Linear<CpuBackend>` impl for GGUF k-quant weights.
+//!
+//! Phase 3e/3: replaces the old `BackendQuantGguf::gemm_quant` impl on
+//! CpuBackend. The kernel call (Q4_K dequant + `Self::gemm`) lives
+//! inside `CpuGgufLinear::forward` instead of the trait method body.
+
+use crate::backend::cpu::{CpuBackend, CpuQuantStore};
+use crate::Linear;
+
+/// CPU GGUF Linear: holds a `CpuQuantStore` (currently Q4_K-dequantised
+/// weights) plus shape, dispatches via `CpuBackend::gemm`.
+pub struct CpuGgufLinear {
+    pub store: CpuQuantStore,
+    pub in_features: usize,
+    pub out_features: usize,
+}
+
+impl Linear<CpuBackend> for CpuGgufLinear {
+    fn in_features(&self) -> usize {
+        self.in_features
+    }
+
+    fn out_features(&self) -> usize {
+        self.out_features
+    }
+
+    fn forward(
+        &self,
+        ctx: &mut <CpuBackend as crate::backend::Backend>::Context,
+        input: &<CpuBackend as crate::backend::Backend>::Buffer,
+        out: &mut <CpuBackend as crate::backend::Backend>::Buffer,
+        m: usize,
+    ) {
+        match &self.store {
+            CpuQuantStore::Q4K {
+                weights,
+                n_rows,
+                n_cols,
+            } => {
+                <CpuBackend as crate::backend::Backend>::gemm(
+                    ctx, input, weights, out, m, *n_rows, *n_cols,
+                );
+            }
+        }
+    }
+}

--- a/crates/ferrum-kernels/src/quant_linear/metal_gguf.rs
+++ b/crates/ferrum-kernels/src/quant_linear/metal_gguf.rs
@@ -1,0 +1,39 @@
+//! `Linear<MetalBackend>` impl for GGUF k-quant weights (Q4_K / Q6_K).
+//!
+//! Phase 3e/3: replaces the old `BackendQuantGguf::gemm_quant` impl on
+//! MetalBackend. The kernel dispatch (decode/prefill split, fused-store
+//! handling, q4_k / q6_k mul_mm + gemv variants) lives inside
+//! `crate::backend::metal::metal_gemm_quant_dispatch` (the body that
+//! used to be the trait method, now `pub fn`).
+
+use crate::backend::metal::{metal_gemm_quant_dispatch, MetalBackend, MetalQuantStore};
+use crate::Linear;
+
+/// Metal GGUF Linear: holds a `MetalQuantStore` (Q4_K / Q6_K /
+/// Fused-mixed) plus shape, dispatches via `metal_gemm_quant_dispatch`.
+pub struct MetalGgufLinear {
+    pub store: MetalQuantStore,
+    pub in_features: usize,
+    pub out_features: usize,
+}
+
+impl Linear<MetalBackend> for MetalGgufLinear {
+    fn in_features(&self) -> usize {
+        self.in_features
+    }
+
+    fn out_features(&self) -> usize {
+        self.out_features
+    }
+
+    fn forward(
+        &self,
+        ctx: &mut <MetalBackend as crate::backend::Backend>::Context,
+        input: &<MetalBackend as crate::backend::Backend>::Buffer,
+        out: &mut <MetalBackend as crate::backend::Backend>::Buffer,
+        m: usize,
+    ) {
+        metal_gemm_quant_dispatch(ctx, input, &self.store, out, m)
+            .unwrap_or_else(|e| panic!("MetalGgufLinear forward failed: {e}"));
+    }
+}

--- a/crates/ferrum-quantization/src/quant_linear.rs
+++ b/crates/ferrum-quantization/src/quant_linear.rs
@@ -1,42 +1,24 @@
-//! `QuantLinear<B>` — keeps Q4_K_M (or future k-quant) weights quantised
-//! in backend memory and dequants on-demand per `forward` call.
+//! `QuantLinear<B>` — thin wrapper that delegates to the boxed
+//! `Linear<B>` returned by `B::load_quant` / `B::load_quant_fused`.
 //!
-//! Contrast with `GgufLinear<B>` which **eagerly** dequants Q4_K_M to
-//! fp32/fp16 at load time. That eager path inflates an 8B model from
-//! ~5 GB on disk to 16-32 GB in RAM — fine for safetensors-fp16 sources
-//! but wasteful for GGUF Q4_K_M and a non-starter for 30B-A3B on a
-//! 32 GB Mac.
-//!
-//! The Q4 → fp16 conversion happens inside `Backend::gemm_q4_k`, into a
-//! transient buffer that's freed after the matmul. Memory footprint is
-//! the on-disk Q4 size + a per-call transient ~= one weight matrix's
-//! worth of fp16.
-//!
-//! Phase 1D scope: direct (un-fused) Q4_K_M projections only —
-//! `o_proj`, `down_proj`, `lm_head`, `embed_tokens`, etc. Fused
-//! projections (`qkv_proj`, `gate_up_proj`) keep falling through to
-//! `GgufLinear`'s eager-dequant path; the loader's split-fusion logic
-//! already concatenates the dequanted parts into one dense weight.
+//! Phase 3e/3: backend-specific kernel dispatch (Metal Q4_K/Q6_K
+//! mul_mm, CPU dequant + gemm) lives inside the boxed Linear's
+//! `forward()` body, not in a Backend trait method. The historical
+//! `QuantLinear<B>` constructors (`from_gguf_bytes`, `from_gguf_fused`)
+//! stay so callers don't have to change shape — they just route through
+//! the new factory.
 
 use ferrum_kernels::backend::{Backend, BackendQuantGguf, GgufQuantType};
 use ferrum_kernels::Linear;
 use ferrum_types::Result;
 
-/// Linear projection backed by a GGUF k-quant weight kept quantised in
-/// backend memory.
+/// Linear projection backed by a GGUF k-quant weight.
 ///
-/// `forward` calls into `Backend::gemm_quant`, which dequants the
-/// weight into a transient fp16 buffer (Metal) or pre-dequanted fp32
-/// weights (CPU) and then runs the matmul. See `B::QuantStore` per
-/// backend for the storage format details.
-///
-/// Future k-quant flavours (Q5_K, Q6_K, Q8_0) plug in via the
-/// [`GgufQuantType`] discriminator passed to the constructor — no new
-/// `QuantLinear` type required.
+/// `forward()` is a tail-call to the inner backend-specific Linear
+/// (Metal: `MetalGgufLinear`, CPU: `CpuGgufLinear`). LTO inlines through
+/// the dispatch.
 pub struct QuantLinear<B: Backend + BackendQuantGguf> {
-    store: B::QuantStore,
-    in_features: usize,
-    out_features: usize,
+    inner: Box<dyn Linear<B> + Send + Sync>,
 }
 
 impl<B: Backend + BackendQuantGguf> QuantLinear<B> {
@@ -50,12 +32,8 @@ impl<B: Backend + BackendQuantGguf> QuantLinear<B> {
         out_features: usize,
         in_features: usize,
     ) -> Result<Self> {
-        let store = B::load_quant(kind, bytes, out_features, in_features)?;
-        Ok(Self {
-            store,
-            in_features,
-            out_features,
-        })
+        let inner = B::load_quant(kind, bytes, out_features, in_features)?;
+        Ok(Self { inner })
     }
 
     /// Build a fused projection from multiple `(kind, bytes, rows)`
@@ -68,43 +46,21 @@ impl<B: Backend + BackendQuantGguf> QuantLinear<B> {
         parts: &[(GgufQuantType, &[u8], usize)],
         in_features: usize,
     ) -> Result<Self> {
-        let store = B::load_quant_fused(parts, in_features)?;
-        let out_features = parts.iter().map(|(_, _, n)| *n).sum();
-        Ok(Self {
-            store,
-            in_features,
-            out_features,
-        })
-    }
-
-    /// For tests / advanced callers that have already constructed a
-    /// `B::QuantStore` (e.g. through the Backend's own ingestion path).
-    pub fn from_store(store: B::QuantStore, out_features: usize, in_features: usize) -> Self {
-        Self {
-            store,
-            in_features,
-            out_features,
-        }
-    }
-
-    pub fn store(&self) -> &B::QuantStore {
-        &self.store
+        let inner = B::load_quant_fused(parts, in_features)?;
+        Ok(Self { inner })
     }
 }
 
 impl<B: Backend + BackendQuantGguf> Linear<B> for QuantLinear<B> {
     fn in_features(&self) -> usize {
-        self.in_features
+        self.inner.in_features()
     }
 
     fn out_features(&self) -> usize {
-        self.out_features
+        self.inner.out_features()
     }
 
     fn forward(&self, ctx: &mut B::Context, input: &B::Buffer, out: &mut B::Buffer, m: usize) {
-        // Trait-level dispatch — the kernel choice (Metal compute kernel vs
-        // CPU dequant+gemm, and which k-quant flavour) is encapsulated in
-        // the backend's `QuantStore` enum.
-        B::gemm_quant(ctx, input, &self.store, out, m).expect("gemm_quant");
+        self.inner.forward(ctx, input, out, m);
     }
 }


### PR DESCRIPTION
## Summary
Mirrors Phase 3e/2 for the GGUF k-quant path (Metal Q4_K/Q6_K, CPU dequant). **Closes Dim 2 + Dim 3 fully** in the architecture status doc — `Backend` trait no longer owns the kernel dispatch for any Linear-shaped quantized op; all routes go through `Linear<B>` impls in `ferrum-kernels::quant_linear`.

### Trait surface change (`BackendQuantGguf`)
- `load_quant(...)` returns `Box<dyn Linear<Self>>` (was `Result<Self::QuantStore>`).
- `load_quant_fused(...)` similarly.
- **Deleted:** `gemm_quant`. Kernel dispatch lives in the new boxed Linear.

### New concrete types in `ferrum-kernels::quant_linear/`
- `cpu_gguf::CpuGgufLinear` — wraps `CpuQuantStore`, dispatches via `CpuBackend::gemm` on dequantised f32 weights.
- `metal_gguf::MetalGgufLinear` — wraps `MetalQuantStore` (Q4_K / Q6_K / Fused-mixed), dispatches via the new pub free fn `metal_gemm_quant_dispatch` (the 209-line trait method body, extracted verbatim).

### Backend impl changes
- `MetalBackend::load_quant` / `load_quant_fused`: build the `MetalQuantStore` via the new private helper `metal_load_quant_store_helper`, then wrap in `MetalGgufLinear`.
- `CpuBackend::load_quant`: same pattern, wraps in `CpuGgufLinear`.
- `MetalQuantStore` associated type still in use (load_quant_experts for MoE returns it; gemv_quant_moe_id_* methods take it). Only the Linear-shaped methods went away.

### ferrum-quantization (`quant_linear.rs`)
- `QuantLinear<B>` shrinks to `pub struct QuantLinear<B>(Box<dyn Linear<B>>)` — pure delegating wrapper. `from_gguf_bytes` / `from_gguf_fused` signatures unchanged so callers don't switch.

### Net effect on dim status
- **Dim 2 (compute precision): 🟡 → ✅.** Both INT4 (GPTQ-Marlin in #123) and Q4_K/Q6_K (GGUF here) now dispatch through `Linear<B>` impls rather than Backend trait methods.
- **Dim 3 (weight format): 🟡 → ✅.** The new Linear types live in `ferrum-kernels::quant_linear/`, sized for adding more formats (AWQ, EXL2, HQQ) without touching the Backend trait.

## Test plan
- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo test --workspace --features metal --lib` clean (118 ferrum-engine tests)
- [x] `cargo fmt --all -- --check` clean
- [ ] CUDA pod: `cargo check --workspace --features cuda` (running)