### PR TITLE
refactor(interfaces): move KvDtypeKind markers to ferrum-interfaces (Dim 5 cleanup)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1383,6 +1383,7 @@ dependencies = [
  "candle-core",
  "cudarc 0.19.4",
  "ferrum-attention",
+ "ferrum-interfaces",
  "ferrum-types",
  "half",
  "metal 0.31.0",

--- a/crates/ferrum-interfaces/src/kv_dtype.rs
+++ b/crates/ferrum-interfaces/src/kv_dtype.rs
@@ -1,0 +1,49 @@
+//! KV cache element-type markers (Dim 5 of the 5-dimension architecture).
+//!
+//! These are pure marker types with no GPU dependencies, so they live
+//! in `ferrum-interfaces` rather than `ferrum-kernels`. The capability
+//! trait that links them to a backend (`BackendKvDtype<K>: BackendPagedKv`)
+//! does need GPU types, so it stays in `ferrum-kernels::backend`.
+//!
+//! Each model's KV cache has its own precision independent of the
+//! model's compute precision. vLLM 0.6+ ships INT8 / FP8 KV caches that
+//! halve KV memory at small (<1%) accuracy hit. ferrum's type system
+//! exposes this axis via the `K: KvDtypeKind` parameter on
+//! `KvCache<B, K>` (default `K = KvFp16`).
+
+/// Marker trait + metadata for a KV cache element type.
+pub trait KvDtypeKind: Send + Sync + 'static {
+    /// Stable name for logging / debug (e.g. "fp16", "int8").
+    const NAME: &'static str;
+    /// Bytes per element on disk + in cache memory.
+    const BYTES_PER_ELEM: usize;
+}
+
+/// FP16 KV cache (the existing default on CUDA + Metal).
+pub struct KvFp16;
+impl KvDtypeKind for KvFp16 {
+    const NAME: &'static str = "fp16";
+    const BYTES_PER_ELEM: usize = 2;
+}
+
+/// BF16 KV cache (drop-in replacement for FP16 on Ampere+ / Apple Silicon).
+pub struct KvBf16;
+impl KvDtypeKind for KvBf16 {
+    const NAME: &'static str = "bf16";
+    const BYTES_PER_ELEM: usize = 2;
+}
+
+/// INT8 KV cache — half the memory of FP16 with per-token / per-channel
+/// scale factors. CUDA path planned via vLLM's quant_kv kernels.
+pub struct KvInt8;
+impl KvDtypeKind for KvInt8 {
+    const NAME: &'static str = "int8";
+    const BYTES_PER_ELEM: usize = 1;
+}
+
+/// FP8 KV cache — E4M3 by default. Hopper+ on CUDA, future on Metal.
+pub struct KvFp8;
+impl KvDtypeKind for KvFp8 {
+    const NAME: &'static str = "fp8";
+    const BYTES_PER_ELEM: usize = 1;
+}

--- a/crates/ferrum-interfaces/src/lib.rs
+++ b/crates/ferrum-interfaces/src/lib.rs
@@ -18,6 +18,7 @@ pub mod backend;
 pub mod engine;
 pub mod kernel_ops;
 pub mod kv_cache;
+pub mod kv_dtype;
 pub mod memory;
 pub mod model_builder;
 pub mod model_executor;
@@ -33,6 +34,7 @@ pub use engine::InferenceEngine;
 pub use kv_cache::{
     AllocationRequest, BlockTable, CacheHandleStats, KvCacheHandle, KvCacheManager,
 };
+pub use kv_dtype::{KvBf16, KvDtypeKind, KvFp16, KvFp8, KvInt8};
 pub use memory::{DeviceMemoryManager, MemoryHandle, StreamHandle};
 pub use model_builder::{BuildOptions, ModelBuilder};
 pub use model_executor::{DecodeInput, DecodeOutput, ModelExecutor, PrefillInput, PrefillOutput};

--- a/crates/ferrum-kernels/Cargo.toml
+++ b/crates/ferrum-kernels/Cargo.toml
@@ -9,6 +9,7 @@ readme = "../../README.md"
 
 [dependencies]
 ferrum-types = { workspace = true }
+ferrum-interfaces = { workspace = true }
 candle-core = { workspace = true }
 half = { workspace = true }
 tracing = { workspace = true }

--- a/crates/ferrum-kernels/src/backend/traits.rs
+++ b/crates/ferrum-kernels/src/backend/traits.rs
@@ -2153,42 +2153,11 @@ impl<T> MoeLlmBackend for T where T: QuantLlmBackend + BackendMoeFused {}
 // Future PR: implement BackendKvDtype<KvInt8> on CUDA + a new model
 // type-parameter `K: KvDtypeKind` to wire it through.
 
-/// Marker trait + metadata for a KV cache element type.
-pub trait KvDtypeKind: Send + Sync + 'static {
-    /// Stable name for logging / debug (e.g. "fp16", "int8").
-    const NAME: &'static str;
-    /// Bytes per element on disk + in cache memory.
-    const BYTES_PER_ELEM: usize;
-}
-
-/// FP16 KV cache (the existing default on CUDA + Metal).
-pub struct KvFp16;
-impl KvDtypeKind for KvFp16 {
-    const NAME: &'static str = "fp16";
-    const BYTES_PER_ELEM: usize = 2;
-}
-
-/// BF16 KV cache (drop-in replacement for FP16 on Ampere+ / Apple Silicon).
-pub struct KvBf16;
-impl KvDtypeKind for KvBf16 {
-    const NAME: &'static str = "bf16";
-    const BYTES_PER_ELEM: usize = 2;
-}
-
-/// INT8 KV cache — half the memory of FP16 with per-token / per-channel
-/// scale factors. CUDA path planned via vLLM's quant_kv kernels.
-pub struct KvInt8;
-impl KvDtypeKind for KvInt8 {
-    const NAME: &'static str = "int8";
-    const BYTES_PER_ELEM: usize = 1;
-}
-
-/// FP8 KV cache — E4M3 by default. Hopper+ on CUDA, future on Metal.
-pub struct KvFp8;
-impl KvDtypeKind for KvFp8 {
-    const NAME: &'static str = "fp8";
-    const BYTES_PER_ELEM: usize = 1;
-}
+// `KvDtypeKind` + `KvFp16` / `KvBf16` / `KvInt8` / `KvFp8` markers moved
+// to `ferrum_interfaces::kv_dtype` (no GPU deps, so the right place is
+// the contract crate). Re-exported here so existing callers keep
+// compiling against `crate::backend::KvFp16` etc.
+pub use ferrum_interfaces::kv_dtype::{KvBf16, KvDtypeKind, KvFp16, KvFp8, KvInt8};
 
 /// Capability-trait for backends that can store + read a KV cache of
 /// type `K`. Methods come in a follow-up PR; today this is a marker


### PR DESCRIPTION
## Summary
Cleanup pass on the 5-dim architecture trait locations. The natural split:

- **Dim 4** trait `Backend<B>` MUST live in ferrum-kernels — it has `type Buffer; type Context;` that need cudarc/metal types.
- **Dim 5** markers (`KvDtypeKind`, `KvFp16` / `KvBf16` / `KvInt8` / `KvFp8`) are pure Rust types with no GPU deps. They belong in the contract crate (ferrum-interfaces), not in the kernel crate.

This PR moves just the markers. The capability trait `BackendKvDtype<K>: BackendPagedKv` stays in ferrum-kernels because its supertrait pulls in Backend.

**Changes:**
- New module `ferrum-interfaces/src/kv_dtype.rs` with `KvDtypeKind` + 4 marker structs.
- Re-exported from `ferrum-interfaces` lib.rs alongside the other trait contracts.
- Original definitions in `ferrum-kernels/src/backend/traits.rs` replaced with `pub use ferrum_interfaces::kv_dtype::{...}` so existing `crate::backend::KvFp16` paths still resolve unchanged.
- ferrum-kernels gains a Cargo.toml dep on ferrum-interfaces.

## Test plan
- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo test --workspace --features metal --lib` clean (118 ferrum-engine)
- [x] `cargo fmt --all -- --check` clean
- [ ] CUDA pod check (running)