### PR TITLE
feat(cuda): INT8 paged decode + KV append kernels (Dim 5 step 1)

### DIFF
--- a/crates/ferrum-kernels/build.rs
+++ b/crates/ferrum-kernels/build.rs
@@ -56,6 +56,7 @@ fn main() {
     println!("cargo:rerun-if-changed=kernels/moe_combine.cu");
     println!("cargo:rerun-if-changed=kernels/moe_router.cu");
     println!("cargo:rerun-if-changed=kernels/moe_align_block_size.cu");
+    println!("cargo:rerun-if-changed=kernels/int8_paged_decode_attention.cu");
 
     if env::var_os("CARGO_FEATURE_CUDA").is_none() {
         return;
@@ -96,6 +97,7 @@ fn main() {
             "kernels/moe_combine.cu",
             "kernels/moe_router.cu",
             "kernels/moe_align_block_size.cu",
+            "kernels/int8_paged_decode_attention.cu",
         ])
         .out_dir(out_dir)
         .arg("-Ikernels") // for common.cuh

--- a/crates/ferrum-kernels/kernels/int8_paged_decode_attention.cu
+++ b/crates/ferrum-kernels/kernels/int8_paged_decode_attention.cu
@@ -1,0 +1,265 @@
+// INT8 paged decode attention — Dim 5 INT8 KV.
+//
+// Mirrors paged_decode_attention.cu but K/V are stored as int8 + per-token
+// per-kv-head FP16 scales (vLLM-style symmetric quantization).
+//
+// Block pool layouts:
+//   k_block_pool / v_block_pool: int8
+//     [max_blocks * block_size * num_kv_heads * head_dim]
+//   k_scales_pool / v_scales_pool: __half
+//     [max_blocks * block_size * num_kv_heads]
+//
+// Address translation (kv_pos → ptrs):
+//   logical_block = kv_pos / block_size
+//   slot          = kv_pos % block_size
+//   physical      = block_table[logical_block]
+//   data_offset   = physical * block_size * num_kv_heads * head_dim
+//                 + slot * num_kv_heads * head_dim
+//                 + kv_head * head_dim
+//   scale_offset  = physical * block_size * num_kv_heads
+//                 + slot * num_kv_heads
+//                 + kv_head
+//
+// Each int8 element is dequantized as `scale * (float)int8_val`.
+//
+// Grid:  (num_q_heads,)
+// Block: (256,)
+// Shared: valid_kv_len * sizeof(float) for attention scores
+
+#include "common.cuh"
+
+#define WARP_SIZE 32
+
+extern "C" __global__ void paged_decode_attention_int8(
+    const __half* __restrict__ q,                 // [num_q_heads, head_dim] FP16
+    const int8_t* __restrict__ k_block_pool,      // INT8 paged
+    const int8_t* __restrict__ v_block_pool,      // INT8 paged
+    const __half* __restrict__ k_scales_pool,     // FP16 per-token scales
+    const __half* __restrict__ v_scales_pool,     // FP16 per-token scales
+    const int*    __restrict__ block_table,       // [max_logical_blocks]
+    __half* __restrict__ output,                  // [num_q_heads, head_dim]
+    const int num_q_heads,
+    const int num_kv_heads,
+    const int head_dim,
+    const int valid_kv_len,
+    const int block_size,
+    const float scale                             // attention scale = 1/sqrt(hd)
+) {
+    const int q_head = blockIdx.x;
+    const int kv_head = q_head / (num_q_heads / num_kv_heads);
+    const int kv_stride = num_kv_heads * head_dim;
+    const int block_stride = block_size * kv_stride;
+    const int scale_block_stride = block_size * num_kv_heads;
+    const int scale_kv_stride = num_kv_heads;
+
+    const __half* q_ptr = q + q_head * head_dim;
+    __half* out_ptr = output + q_head * head_dim;
+
+    extern __shared__ float s_scores[];
+
+    // Load Q into registers (warp-cooperative).
+    const int elems_per_thread = (head_dim + WARP_SIZE - 1) / WARP_SIZE;
+    float q_reg[8];
+    #pragma unroll
+    for (int i = 0; i < 8; i++) {
+        int d = (threadIdx.x % WARP_SIZE) + i * WARP_SIZE;
+        q_reg[i] = (i < elems_per_thread && d < head_dim)
+            ? __half2float(q_ptr[d]) : 0.0f;
+    }
+
+    int warp_id = threadIdx.x / WARP_SIZE;
+    int lane_id = threadIdx.x % WARP_SIZE;
+    int num_warps = blockDim.x / WARP_SIZE;
+
+    // ====== Step 1: Q·K^T (dequantizing K on the fly) ======
+    for (int kv_pos = warp_id; kv_pos < valid_kv_len; kv_pos += num_warps) {
+        int logical_block = kv_pos / block_size;
+        int slot = kv_pos % block_size;
+        int physical_block = block_table[logical_block];
+
+        const int8_t* k_row = k_block_pool
+            + physical_block * block_stride
+            + slot * kv_stride
+            + kv_head * head_dim;
+        const __half k_scale_h = k_scales_pool[
+            physical_block * scale_block_stride
+            + slot * scale_kv_stride
+            + kv_head];
+        const float k_scale = __half2float(k_scale_h);
+
+        float dot = 0.0f;
+        #pragma unroll
+        for (int i = 0; i < 8; i++) {
+            int d = lane_id + i * WARP_SIZE;
+            if (i < elems_per_thread && d < head_dim) {
+                float k_dq = k_scale * (float)k_row[d];
+                dot += q_reg[i] * k_dq;
+            }
+        }
+        float score = warp_reduce_sum(dot) * scale;
+        if (lane_id == 0)
+            s_scores[kv_pos] = score;
+    }
+    __syncthreads();
+
+    // ====== Step 2: Softmax (identical to FP16) ======
+    float thread_max = -1e20f;
+    for (int i = threadIdx.x; i < valid_kv_len; i += blockDim.x)
+        thread_max = fmaxf(thread_max, s_scores[i]);
+
+    __shared__ float s_global_max;
+    float bmax = block_reduce_max(thread_max);
+    if (threadIdx.x == 0) s_global_max = bmax;
+    __syncthreads();
+    float global_max = s_global_max;
+
+    float thread_sum = 0.0f;
+    for (int i = threadIdx.x; i < valid_kv_len; i += blockDim.x) {
+        float val = expf(s_scores[i] - global_max);
+        s_scores[i] = val;
+        thread_sum += val;
+    }
+    __syncthreads();
+
+    __shared__ float s_global_sum;
+    float bsum = block_reduce_sum(thread_sum);
+    if (threadIdx.x == 0) s_global_sum = bsum;
+    __syncthreads();
+    float inv_sum = 1.0f / s_global_sum;
+
+    for (int i = threadIdx.x; i < valid_kv_len; i += blockDim.x)
+        s_scores[i] *= inv_sum;
+    __syncthreads();
+
+    // ====== Step 3: Weighted V sum (dequantizing V on the fly) ======
+    for (int d = threadIdx.x; d < head_dim; d += blockDim.x) {
+        float acc = 0.0f;
+        for (int kv_pos = 0; kv_pos < valid_kv_len; kv_pos++) {
+            int logical_block = kv_pos / block_size;
+            int slot = kv_pos % block_size;
+            int physical_block = block_table[logical_block];
+
+            const int8_t* v_row = v_block_pool
+                + physical_block * block_stride
+                + slot * kv_stride
+                + kv_head * head_dim;
+            const __half v_scale_h = v_scales_pool[
+                physical_block * scale_block_stride
+                + slot * scale_kv_stride
+                + kv_head];
+            const float v_scale = __half2float(v_scale_h);
+
+            acc += s_scores[kv_pos] * v_scale * (float)v_row[d];
+        }
+        out_ptr[d] = __float2half(acc);
+    }
+}
+
+// ===================== INT8 KV append =====================
+//
+// Take FP16 K/V tokens, compute per-token per-kv-head symmetric scale
+// `s = max(|x|)/127`, write INT8 quantized values to the paged cache.
+//
+// Layouts:
+//   k_in / v_in  : [num_tokens, num_kv_heads, head_dim] FP16
+//   k_out_pool / v_out_pool : same paged INT8 layout as the kernel above
+//   k_scales_pool / v_scales_pool : same FP16 scales
+//   slot_mapping : [num_tokens] i32 — flat KV position for each input token,
+//                  i.e. slot_mapping[t] = (physical_block * block_size + slot).
+//                  Caller fills this from block_table + per-token (block_idx, slot).
+//
+// Grid:  (num_tokens, num_kv_heads)
+// Block: (head_dim,) — one thread per head element. Assumes head_dim ≤ 256.
+//
+// Algorithm per (token, kv_head):
+//   1. Each thread holds one head element of K and V.
+//   2. block-wide reductions to find max(|K|) and max(|V|).
+//   3. Compute scale_k = max_k / 127, scale_v = max_v / 127 (in thread 0).
+//   4. Each thread quantizes its element and writes int8 + the shared scale.
+
+extern "C" __global__ void int8_kv_cache_append(
+    const __half* __restrict__ k_in,             // FP16 [num_tokens, num_kv_heads, head_dim]
+    const __half* __restrict__ v_in,             // FP16 same shape
+    int8_t* __restrict__ k_out_pool,             // INT8 paged
+    int8_t* __restrict__ v_out_pool,             // INT8 paged
+    __half* __restrict__ k_scales_pool,          // FP16 [pool_tokens, num_kv_heads]
+    __half* __restrict__ v_scales_pool,          // FP16 same shape
+    const int*    __restrict__ slot_mapping,     // i32 [num_tokens]
+    const int num_kv_heads,
+    const int head_dim,
+    const int num_tokens
+) {
+    const int token = blockIdx.x;
+    const int kv_head = blockIdx.y;
+    const int tid = threadIdx.x;
+    if (token >= num_tokens || kv_head >= num_kv_heads || tid >= head_dim) return;
+
+    const int slot = slot_mapping[token];
+
+    // Input pointers (token-major, packed by head_dim).
+    const int in_offset = (token * num_kv_heads + kv_head) * head_dim;
+    float kv_k = __half2float(k_in[in_offset + tid]);
+    float kv_v = __half2float(v_in[in_offset + tid]);
+
+    // Block-wide max(|x|) for K and V.
+    __shared__ float s_max_k, s_max_v;
+
+    float my_abs_k = fabsf(kv_k);
+    float my_abs_v = fabsf(kv_v);
+
+    // block_reduce_max from common.cuh works on warp+block scope but here
+    // the block has at most head_dim threads (≤256). Do it manually.
+    __shared__ float s_warp_max_k[8];
+    __shared__ float s_warp_max_v[8];
+
+    int warp_id = tid / WARP_SIZE;
+    int lane_id = tid % WARP_SIZE;
+
+    // Warp-level reduction
+    for (int offset = WARP_SIZE / 2; offset > 0; offset /= 2) {
+        my_abs_k = fmaxf(my_abs_k, __shfl_xor_sync(0xffffffff, my_abs_k, offset));
+        my_abs_v = fmaxf(my_abs_v, __shfl_xor_sync(0xffffffff, my_abs_v, offset));
+    }
+    if (lane_id == 0) {
+        s_warp_max_k[warp_id] = my_abs_k;
+        s_warp_max_v[warp_id] = my_abs_v;
+    }
+    __syncthreads();
+
+    // First warp reduces the per-warp maxes.
+    if (warp_id == 0) {
+        int num_warps = (head_dim + WARP_SIZE - 1) / WARP_SIZE;
+        float wm_k = (lane_id < num_warps) ? s_warp_max_k[lane_id] : 0.0f;
+        float wm_v = (lane_id < num_warps) ? s_warp_max_v[lane_id] : 0.0f;
+        for (int offset = WARP_SIZE / 2; offset > 0; offset /= 2) {
+            wm_k = fmaxf(wm_k, __shfl_xor_sync(0xffffffff, wm_k, offset));
+            wm_v = fmaxf(wm_v, __shfl_xor_sync(0xffffffff, wm_v, offset));
+        }
+        if (lane_id == 0) {
+            // Avoid scale=0 (would make dequant always 0); clamp to 1e-8.
+            s_max_k = fmaxf(wm_k, 1e-8f);
+            s_max_v = fmaxf(wm_v, 1e-8f);
+        }
+    }
+    __syncthreads();
+
+    const float scale_k = s_max_k / 127.0f;
+    const float scale_v = s_max_v / 127.0f;
+    const float inv_scale_k = 1.0f / scale_k;
+    const float inv_scale_v = 1.0f / scale_v;
+
+    // Quantize-and-clamp, write int8.
+    int8_t qk = (int8_t)__float2int_rn(fmaxf(-127.0f, fminf(127.0f, kv_k * inv_scale_k)));
+    int8_t qv = (int8_t)__float2int_rn(fmaxf(-127.0f, fminf(127.0f, kv_v * inv_scale_v)));
+
+    const int out_offset = slot * num_kv_heads * head_dim + kv_head * head_dim + tid;
+    k_out_pool[out_offset] = qk;
+    v_out_pool[out_offset] = qv;
+
+    // Thread 0 writes the per-(token, head) scales.
+    if (tid == 0) {
+        const int scale_offset = slot * num_kv_heads + kv_head;
+        k_scales_pool[scale_offset] = __float2half(scale_k);
+        v_scales_pool[scale_offset] = __float2half(scale_v);
+    }
+}

--- a/crates/ferrum-kernels/src/backend/cuda.rs
+++ b/crates/ferrum-kernels/src/backend/cuda.rs
@@ -4698,3 +4698,12 @@ impl BackendMoeFused for CudaBackend {
 }
 // CUDA: existing KV cache path is FP16.
 impl crate::backend::BackendKvDtype<crate::backend::KvFp16> for CudaBackend {}
+
+// CUDA: INT8 KV cache (vLLM-style scale-per-token symmetric quantization).
+// Kernel-side dispatch is exposed via [`crate::int8_kv::launch_int8_paged_decode_attention`]
+// and [`crate::int8_kv::launch_int8_kv_cache_append`]. The trait itself is
+// currently a marker (no methods); model wire-up that switches a
+// `KvCache<B, KvInt8>` to call those launchers is a follow-up that
+// belongs in `ferrum-models`. See `tests/int8_kv_parity.rs` for a
+// host-reference parity check (cos sim ≈ 0.99999 vs FP32 ref).
+impl crate::backend::BackendKvDtype<crate::backend::KvInt8> for CudaBackend {}

--- a/crates/ferrum-kernels/src/int8_kv.rs
+++ b/crates/ferrum-kernels/src/int8_kv.rs
@@ -1,0 +1,146 @@
+//! INT8 KV cache kernels — Dim 5 (KV cache precision).
+//!
+//! Two launchers:
+//!   - [`launch_int8_paged_decode_attention`]: read INT8 K/V (dequantized
+//!     on the fly via per-token per-kv-head FP16 scales), compute paged
+//!     decode attention. Mirrors [`crate::cuda_decode::launch_paged_decode_attention`]
+//!     for the FP16 path.
+//!   - [`launch_int8_kv_cache_append`]: take FP16 K/V tokens, compute
+//!     per-token symmetric scale `s = max(|x|)/127`, write INT8 + scale
+//!     into the paged pool.
+//!
+//! Storage layout:
+//!   - K/V pool : `int8_t [num_blocks * block_size * num_kv_heads * head_dim]`
+//!   - scales   : `__half  [num_blocks * block_size * num_kv_heads]`
+//!   - block_table : `i32 [max_blocks_per_seq]`
+//!
+//! These launchers operate on plain cudarc primitives (no candle Tensor)
+//! so they can be unit-tested independently of the `Backend` trait. Trait
+//! integration (`BackendKvDtype<KvInt8>` for `CudaBackend`) lands in a
+//! follow-up PR alongside model wire-up.
+
+use cudarc::driver::{CudaContext, CudaSlice, LaunchConfig, PushKernelArg};
+use std::sync::Arc;
+
+use crate::ptx;
+
+/// Launch the INT8 paged decode attention kernel.
+///
+/// All dimensions match the FP16 path; the only difference is that
+/// `k_pool` / `v_pool` are `int8_t` and `k_scales_pool` / `v_scales_pool`
+/// carry per-token (per-kv-head) FP16 scales.
+#[allow(clippy::too_many_arguments)]
+pub fn launch_int8_paged_decode_attention(
+    ctx: &Arc<CudaContext>,
+    q: &CudaSlice<half::f16>,
+    k_pool: &CudaSlice<i8>,
+    v_pool: &CudaSlice<i8>,
+    k_scales_pool: &CudaSlice<half::f16>,
+    v_scales_pool: &CudaSlice<half::f16>,
+    block_table: &CudaSlice<i32>,
+    output: &mut CudaSlice<half::f16>,
+    num_q_heads: usize,
+    num_kv_heads: usize,
+    head_dim: usize,
+    valid_kv_len: usize,
+    block_size: usize,
+    scale: f32,
+) -> std::result::Result<(), String> {
+    let stream = ctx.default_stream();
+    let func = stream
+        .context()
+        .load_module(ptx::INT8_PAGED_DECODE_ATTENTION.into())
+        .map_err(|e| format!("load int8_paged_decode_attention module: {e}"))?
+        .load_function("paged_decode_attention_int8")
+        .map_err(|e| format!("load paged_decode_attention_int8 func: {e}"))?;
+
+    let nq = num_q_heads as i32;
+    let nkv = num_kv_heads as i32;
+    let hd = head_dim as i32;
+    let kvl = valid_kv_len as i32;
+    let bs = block_size as i32;
+
+    let mut b = stream.launch_builder(&func);
+    b.arg(q);
+    b.arg(k_pool);
+    b.arg(v_pool);
+    b.arg(k_scales_pool);
+    b.arg(v_scales_pool);
+    b.arg(block_table);
+    b.arg(output);
+    b.arg(&nq);
+    b.arg(&nkv);
+    b.arg(&hd);
+    b.arg(&kvl);
+    b.arg(&bs);
+    b.arg(&scale);
+
+    let shared_bytes = (valid_kv_len as u32) * 4;
+    let cfg = LaunchConfig {
+        grid_dim: (num_q_heads as u32, 1, 1),
+        block_dim: (256, 1, 1),
+        shared_mem_bytes: shared_bytes,
+    };
+    unsafe { b.launch(cfg) }
+        .map(|_| ())
+        .map_err(|e| format!("int8_paged_decode_attention launch: {e}"))
+}
+
+/// Launch the INT8 KV cache append kernel.
+///
+/// Reads FP16 K/V at `[num_tokens, num_kv_heads, head_dim]` (token-major)
+/// and writes INT8 + per-(token, head) FP16 scale to the paged pool at
+/// the slot indices given by `slot_mapping[t]` (a flat KV position =
+/// physical_block * block_size + slot).
+#[allow(clippy::too_many_arguments)]
+pub fn launch_int8_kv_cache_append(
+    ctx: &Arc<CudaContext>,
+    k_in: &CudaSlice<half::f16>,
+    v_in: &CudaSlice<half::f16>,
+    k_out_pool: &mut CudaSlice<i8>,
+    v_out_pool: &mut CudaSlice<i8>,
+    k_scales_pool: &mut CudaSlice<half::f16>,
+    v_scales_pool: &mut CudaSlice<half::f16>,
+    slot_mapping: &CudaSlice<i32>,
+    num_tokens: usize,
+    num_kv_heads: usize,
+    head_dim: usize,
+) -> std::result::Result<(), String> {
+    if head_dim > 256 {
+        return Err(format!(
+            "int8_kv_cache_append: head_dim {head_dim} > 256 (kernel uses one thread per element)"
+        ));
+    }
+    let stream = ctx.default_stream();
+    let func = stream
+        .context()
+        .load_module(ptx::INT8_PAGED_DECODE_ATTENTION.into())
+        .map_err(|e| format!("load int8_paged_decode_attention module: {e}"))?
+        .load_function("int8_kv_cache_append")
+        .map_err(|e| format!("load int8_kv_cache_append func: {e}"))?;
+
+    let nkv = num_kv_heads as i32;
+    let hd = head_dim as i32;
+    let nt = num_tokens as i32;
+
+    let mut b = stream.launch_builder(&func);
+    b.arg(k_in);
+    b.arg(v_in);
+    b.arg(&mut *k_out_pool);
+    b.arg(&mut *v_out_pool);
+    b.arg(&mut *k_scales_pool);
+    b.arg(&mut *v_scales_pool);
+    b.arg(slot_mapping);
+    b.arg(&nkv);
+    b.arg(&hd);
+    b.arg(&nt);
+
+    let cfg = LaunchConfig {
+        grid_dim: (num_tokens as u32, num_kv_heads as u32, 1),
+        block_dim: (head_dim as u32, 1, 1),
+        shared_mem_bytes: 0,
+    };
+    unsafe { b.launch(cfg) }
+        .map(|_| ())
+        .map_err(|e| format!("int8_kv_cache_append launch: {e}"))
+}

--- a/crates/ferrum-kernels/src/lib.rs
+++ b/crates/ferrum-kernels/src/lib.rs
@@ -61,6 +61,9 @@ pub(crate) mod ptx {
 }
 
 #[cfg(feature = "cuda")]
+pub mod int8_kv;
+
+#[cfg(feature = "cuda")]
 mod fused_add_rms_norm;
 #[cfg(feature = "cuda")]
 pub use fused_add_rms_norm::fused_add_rms_norm;

--- a/crates/ferrum-kernels/tests/int8_kv_parity.rs
+++ b/crates/ferrum-kernels/tests/int8_kv_parity.rs
@@ -285,21 +285,36 @@ fn int8_paged_decode_parity_vs_host_ref() {
 
     let out_int8: Vec<f32> = CudaBackend::to_vec(&out_dev, NUM_HEADS * HEAD_DIM);
 
+    // Compare via cosine similarity + max absolute error against the
+    // full output max — per-element relative error is meaningless when
+    // outputs are near zero (16% rel on a 0.0002 abs diff is fine if
+    // the max output magnitude is 0.06).
     let mut max_abs = 0f32;
-    let mut max_rel = 0f32;
+    let mut sse = 0f64;
+    let mut sum_a = 0f64;
+    let mut sum_b = 0f64;
+    let mut dot = 0f64;
     let mut max_mag = 0f32;
     for i in 0..out_ref.len() {
         let diff = (out_int8[i] - out_ref[i]).abs();
         max_abs = max_abs.max(diff);
-        let mag = out_ref[i].abs().max(1e-3);
-        max_rel = max_rel.max(diff / mag);
+        sse += (diff as f64) * (diff as f64);
         max_mag = max_mag.max(out_ref[i].abs());
+        sum_a += (out_ref[i] as f64) * (out_ref[i] as f64);
+        sum_b += (out_int8[i] as f64) * (out_int8[i] as f64);
+        dot += (out_ref[i] as f64) * (out_int8[i] as f64);
     }
+    let rmse = (sse / out_ref.len() as f64).sqrt() as f32;
+    let cosine = dot / (sum_a.sqrt() * sum_b.sqrt() + 1e-12);
+    let rel_to_mag = max_abs / max_mag.max(1e-6);
     eprintln!(
-        "int8 vs host-ref: max|diff|={max_abs:.5} max rel={max_rel:.4} (max output mag={max_mag:.4})"
+        "int8 vs host-ref: max|diff|={max_abs:.5} rmse={rmse:.5} cos={cosine:.5} \
+         rel-to-max-mag={rel_to_mag:.4} (max output mag={max_mag:.4})"
     );
-    // INT8 sym-quant per token-head + FP16 Q/output induces a few-%
-    // relative error on attention output for benign random inputs.
-    assert!(max_abs < 0.05, "abs diff too high: {max_abs}");
-    assert!(max_rel < 0.10, "rel diff too high: {max_rel}");
+    // Cosine ≈ 1 means INT8 reproduces the FP32 reference vector
+    // direction nearly perfectly. The remaining absolute error is the
+    // INT8 quantization noise floor (~max(|K|)/127 propagated through
+    // attention, ≈ 0.0003 at this shape).
+    assert!(cosine > 0.999, "cosine similarity too low: {cosine}");
+    assert!(rel_to_mag < 0.02, "max abs / max mag too high: {rel_to_mag}");
 }

--- a/crates/ferrum-kernels/tests/int8_kv_parity.rs
+++ b/crates/ferrum-kernels/tests/int8_kv_parity.rs
@@ -5,24 +5,25 @@
 //!   1. **Append round-trip.** Take random FP16 K/V tokens, push them
 //!      through `launch_int8_kv_cache_append`, read back the INT8 buffer
 //!      + per-token FP16 scales, dequantize on the host, and check that
-//!      the round-trip max-relative-error is bounded by `1/127` (the
-//!      INT8 quantization step).
+//!      the round-trip max-relative-error is bounded — INT8 sym-quant is
+//!      lossy by ~1/127 of the per-token max.
 //!
-//!   2. **Decode parity vs FP16.** Build a paged KV pool with random
-//!      FP16 K/V, run the existing `paged_decode_attention_f16` kernel,
-//!      then quantize the SAME K/V to INT8 (using the kernel's scale
-//!      convention), run `paged_decode_attention_int8`, and check that
-//!      the two output tensors agree within a small relative tolerance.
+//!   2. **Decode parity vs host reference.** Build a paged KV pool with
+//!      random FP16 K/V, compute attention output on the host (FP32
+//!      reference), quantize the same K/V to INT8 (using the kernel's
+//!      scale convention), run `paged_decode_attention_int8`, and check
+//!      that the GPU INT8 output agrees with the FP32 reference within
+//!      a small relative tolerance (the only loss is the quant step).
 //!
 //! Run on a CUDA box:
 //!   cargo test -p ferrum-kernels --features cuda --release \
-//!     --test int8_kv_parity -- --nocapture
+//!     --test int8_kv_parity -- --ignored --nocapture
 
 #![cfg(feature = "cuda")]
 
 use cudarc::driver::CudaContext;
 use ferrum_kernels::backend::cuda::CudaBackend;
-use ferrum_kernels::backend::{Backend, BackendPagedKv};
+use ferrum_kernels::backend::Backend;
 use ferrum_kernels::int8_kv::{launch_int8_kv_cache_append, launch_int8_paged_decode_attention};
 use half::f16;
 
@@ -34,15 +35,17 @@ fn rnd(state: &mut u64) -> f32 {
     (u as f32) / 16_777_216.0 * 2.0 - 1.0
 }
 
+/// Per-token per-kv-head symmetric INT8 quantization. Mirrors the
+/// kernel's `s = max(|x|)/127` convention exactly.
 fn quantize_token_per_head(
-    fp16: &[f32],            // [num_tokens, num_kv_heads, head_dim]
-    num_tokens: usize,
+    fp16: &[f32], // [pool_tokens, num_kv_heads, head_dim]
+    pool_tokens: usize,
     num_kv_heads: usize,
     head_dim: usize,
 ) -> (Vec<i8>, Vec<f32>) {
-    let mut q = vec![0i8; num_tokens * num_kv_heads * head_dim];
-    let mut s = vec![0f32; num_tokens * num_kv_heads];
-    for t in 0..num_tokens {
+    let mut q = vec![0i8; pool_tokens * num_kv_heads * head_dim];
+    let mut s = vec![0f32; pool_tokens * num_kv_heads];
+    for t in 0..pool_tokens {
         for h in 0..num_kv_heads {
             let base = (t * num_kv_heads + h) * head_dim;
             let mut max_abs = 0f32;
@@ -68,16 +71,16 @@ fn int8_kv_append_roundtrip() {
     const NUM_TOKENS: usize = 16;
     const NUM_KV_HEADS: usize = 4;
     const HEAD_DIM: usize = 128;
-    const POOL_TOKENS: usize = 32; // sparse: only half the slots filled
+    const POOL_TOKENS: usize = 64; // sparse: half-filled, room for slot up to 60
 
     let total = NUM_TOKENS * NUM_KV_HEADS * HEAD_DIM;
     let mut s = 0xDEADBEEFu64;
     let k_in: Vec<f32> = (0..total).map(|_| rnd(&mut s) * 0.1).collect();
     let v_in: Vec<f32> = (0..total).map(|_| rnd(&mut s) * 0.1).collect();
 
-    // Place tokens in non-contiguous slots (5, 9, 13, ..., 5+4*15) to
-    // exercise slot_mapping.
-    let slot_mapping: Vec<i32> = (0..NUM_TOKENS).map(|i| (5 + i * 4) as i32).collect();
+    // Place tokens in non-contiguous slots within the pool [0..POOL_TOKENS).
+    // 3 + 4*i for i in 0..16 → max = 3 + 60 = 63.
+    let slot_mapping: Vec<i32> = (0..NUM_TOKENS).map(|i| (3 + i * 4) as i32).collect();
 
     let ctx = CudaContext::new(0).expect("CUDA context");
     let stream = ctx.default_stream();
@@ -120,8 +123,9 @@ fn int8_kv_append_roundtrip() {
     let k_scales_h: Vec<f16> = stream.memcpy_dtov(&k_scales).unwrap();
     let v_scales_h: Vec<f16> = stream.memcpy_dtov(&v_scales).unwrap();
 
-    // Dequantize and compare.
-    let mut max_rel = 0f32;
+    // Dequantize and compare. INT8 sym-quant is lossy by ~1/127 of the
+    // per-token-head max — assert a generous bound.
+    let mut max_abs = 0f32;
     for t in 0..NUM_TOKENS {
         let slot = slot_mapping[t] as usize;
         for h in 0..NUM_KV_HEADS {
@@ -133,23 +137,81 @@ fn int8_kv_append_roundtrip() {
                 let pool_off = slot * NUM_KV_HEADS * HEAD_DIM + h * HEAD_DIM + d;
                 let k_dq = ks * k_pool_h[pool_off] as f32;
                 let v_dq = vs * v_pool_h[pool_off] as f32;
-                let mag = k_in[in_off].abs().max(1e-3);
-                let rel_k = (k_dq - k_in[in_off]).abs() / mag;
-                let rel_v = (v_dq - v_in[in_off]).abs() / mag;
-                max_rel = max_rel.max(rel_k).max(rel_v);
+                max_abs = max_abs.max((k_dq - k_in[in_off]).abs());
+                max_abs = max_abs.max((v_dq - v_in[in_off]).abs());
             }
         }
     }
-    eprintln!("int8 append round-trip max relative error: {max_rel:.4}");
-    // INT8 sym-quant per token-head: worst case is ~1/127 relative for
-    // small values, but per-token scale keeps most dims at ≤ 1/64 ≈ 0.016.
-    // Use a generous bound to make the test robust to RNG.
-    assert!(max_rel < 0.05, "round-trip rel err too high: {max_rel}");
+    eprintln!("int8 append round-trip max abs error: {max_abs:.5}");
+    // Inputs are scaled by 0.1 so per-token max ≈ 0.1; quantization
+    // step is max/127 ≈ 0.0008. Allow 2× margin.
+    assert!(max_abs < 0.002, "round-trip abs err too high: {max_abs}");
+}
+
+/// Pure-Rust reference: paged decode attention in FP32, mirroring the
+/// kernel's algorithm. Used to validate the GPU INT8 output.
+#[allow(clippy::too_many_arguments)]
+fn host_ref_paged_decode(
+    q: &[f32],         // [num_q_heads, head_dim]
+    k_pool: &[f32],    // [pool_tokens * num_kv_heads * head_dim]
+    v_pool: &[f32],    // same
+    block_table: &[i32],
+    num_q_heads: usize,
+    num_kv_heads: usize,
+    head_dim: usize,
+    valid_kv_len: usize,
+    block_size: usize,
+    scale: f32,
+) -> Vec<f32> {
+    let mut out = vec![0f32; num_q_heads * head_dim];
+    let q_per_kv = num_q_heads / num_kv_heads;
+    let kv_stride = num_kv_heads * head_dim;
+    let block_stride = block_size * kv_stride;
+    for qh in 0..num_q_heads {
+        let kv_head = qh / q_per_kv;
+        // 1. Q·K^T scores
+        let mut scores = vec![0f32; valid_kv_len];
+        for kv_pos in 0..valid_kv_len {
+            let logical_block = kv_pos / block_size;
+            let slot = kv_pos % block_size;
+            let physical = block_table[logical_block] as usize;
+            let k_base = physical * block_stride + slot * kv_stride + kv_head * head_dim;
+            let mut dot = 0f32;
+            for d in 0..head_dim {
+                dot += q[qh * head_dim + d] * k_pool[k_base + d];
+            }
+            scores[kv_pos] = dot * scale;
+        }
+        // 2. softmax
+        let max = scores.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
+        let mut sum = 0f32;
+        for s in &mut scores {
+            *s = (*s - max).exp();
+            sum += *s;
+        }
+        let inv = 1.0 / sum;
+        for s in &mut scores {
+            *s *= inv;
+        }
+        // 3. weighted V sum
+        for d in 0..head_dim {
+            let mut acc = 0f32;
+            for kv_pos in 0..valid_kv_len {
+                let logical_block = kv_pos / block_size;
+                let slot = kv_pos % block_size;
+                let physical = block_table[logical_block] as usize;
+                let v_base = physical * block_stride + slot * kv_stride + kv_head * head_dim;
+                acc += scores[kv_pos] * v_pool[v_base + d];
+            }
+            out[qh * head_dim + d] = acc;
+        }
+    }
+    out
 }
 
 #[test]
 #[ignore]
-fn int8_paged_decode_parity_vs_fp16() {
+fn int8_paged_decode_parity_vs_host_ref() {
     const NUM_HEADS: usize = 8;
     const NUM_KV_HEADS: usize = 2;
     const HEAD_DIM: usize = 128;
@@ -159,31 +221,40 @@ fn int8_paged_decode_parity_vs_fp16() {
 
     let mut rng = 0xCAFEF00Du64;
 
-    // Q : [num_heads, head_dim] FP16
     let q_n = NUM_HEADS * HEAD_DIM;
     let q_data: Vec<f32> = (0..q_n).map(|_| rnd(&mut rng) * 0.5).collect();
 
-    // K/V pool : [max_blocks, block_size, num_kv_heads, head_dim] FP16/INT8
-    let kv_n = MAX_BLOCKS * BLOCK_SIZE * NUM_KV_HEADS * HEAD_DIM;
+    let pool_tokens = MAX_BLOCKS * BLOCK_SIZE;
+    let kv_n = pool_tokens * NUM_KV_HEADS * HEAD_DIM;
     let k_data: Vec<f32> = (0..kv_n).map(|_| rnd(&mut rng) * 0.3).collect();
     let v_data: Vec<f32> = (0..kv_n).map(|_| rnd(&mut rng) * 0.3).collect();
 
     // Block table: identity mapping (logical i → physical i).
     let block_table: Vec<i32> = (0..MAX_BLOCKS as i32).collect();
 
-    let ctx = CudaContext::new(0).expect("CUDA context");
-    let stream = ctx.default_stream();
+    // Host reference (FP32).
+    let scale = 1.0f32 / (HEAD_DIM as f32).sqrt();
+    let out_ref = host_ref_paged_decode(
+        &q_data,
+        &k_data,
+        &v_data,
+        &block_table,
+        NUM_HEADS,
+        NUM_KV_HEADS,
+        HEAD_DIM,
+        VALID_KV_LEN,
+        BLOCK_SIZE,
+        scale,
+    );
 
     // Quantize K/V on host (using kernel's scale convention).
-    // Layout for quant: [max_blocks * block_size, num_kv_heads, head_dim].
-    let pool_tokens = MAX_BLOCKS * BLOCK_SIZE;
     let (k_q, k_s) = quantize_token_per_head(&k_data, pool_tokens, NUM_KV_HEADS, HEAD_DIM);
     let (v_q, v_s) = quantize_token_per_head(&v_data, pool_tokens, NUM_KV_HEADS, HEAD_DIM);
 
-    // Upload everything.
+    let ctx = CudaContext::new(0).expect("CUDA context");
+    let stream = ctx.default_stream();
+
     let q_dev = CudaBackend::from_slice(&q_data);
-    let k_pool_fp16 = CudaBackend::from_slice(&k_data);
-    let v_pool_fp16 = CudaBackend::from_slice(&v_data);
     let k_pool_i8 = stream.memcpy_stod(&k_q).unwrap();
     let v_pool_i8 = stream.memcpy_stod(&v_q).unwrap();
     let k_scales_h: Vec<f16> = k_s.iter().map(|x| f16::from_f32(*x)).collect();
@@ -192,46 +263,7 @@ fn int8_paged_decode_parity_vs_fp16() {
     let v_scales_dev = stream.memcpy_stod(&v_scales_h).unwrap();
     let bt_dev = stream.memcpy_stod(&block_table).unwrap();
 
-    // Run FP16 reference. Trait API uses `&Buffer` (CudaSlice<f16>) for
-    // block_table and context_lens — we reinterpret the i32 slice via
-    // upgrade_device_ptr (same hack as the existing bench).
-    use cudarc::driver::sys::CUdeviceptr;
-    use cudarc::driver::CudaSlice;
-    use cudarc::driver::DevicePtr;
-    let mut out_fp16 = CudaBackend::alloc(NUM_HEADS * HEAD_DIM);
-    let context_lens_i32: Vec<i32> = vec![VALID_KV_LEN as i32];
-    let context_lens_dev = stream.memcpy_stod(&context_lens_i32).unwrap();
-    let (bt_ptr, _g0) = bt_dev.device_ptr(&stream);
-    let (cl_ptr, _g1) = context_lens_dev.device_ptr(&stream);
-    let bt_f16: CudaSlice<f16> = unsafe { stream.upgrade_device_ptr(bt_ptr as CUdeviceptr, 0) };
-    let cl_f16: CudaSlice<f16> = unsafe { stream.upgrade_device_ptr(cl_ptr as CUdeviceptr, 0) };
-    let mut bctx = <CudaBackend as Backend>::new_context();
-
-    let attn_scale = 1.0f32 / (HEAD_DIM as f32).sqrt();
-
-    <CudaBackend as BackendPagedKv>::paged_decode_attention(
-        &mut bctx,
-        &q_dev,
-        &k_pool_fp16,
-        &v_pool_fp16,
-        &mut out_fp16,
-        &bt_f16,
-        &cl_f16,
-        1, // num_seqs
-        NUM_HEADS,
-        NUM_KV_HEADS,
-        HEAD_DIM,
-        BLOCK_SIZE,
-        MAX_BLOCKS,
-        1, // q_len
-    )
-    .expect("fp16 paged decode");
-    <CudaBackend as Backend>::sync(&mut bctx);
-
-    let out_fp16_h: Vec<f32> = CudaBackend::to_vec(&out_fp16, NUM_HEADS * HEAD_DIM);
-
-    // Run INT8 path.
-    let mut out_int8 = CudaBackend::alloc(NUM_HEADS * HEAD_DIM);
+    let mut out_dev = CudaBackend::alloc(NUM_HEADS * HEAD_DIM);
     launch_int8_paged_decode_attention(
         &ctx,
         &q_dev,
@@ -240,36 +272,34 @@ fn int8_paged_decode_parity_vs_fp16() {
         &k_scales_dev,
         &v_scales_dev,
         &bt_dev,
-        &mut out_int8,
+        &mut out_dev,
         NUM_HEADS,
         NUM_KV_HEADS,
         HEAD_DIM,
         VALID_KV_LEN,
         BLOCK_SIZE,
-        attn_scale,
+        scale,
     )
     .expect("int8 paged decode");
     stream.synchronize().unwrap();
 
-    let out_int8_h: Vec<f32> = CudaBackend::to_vec(&out_int8, NUM_HEADS * HEAD_DIM);
+    let out_int8: Vec<f32> = CudaBackend::to_vec(&out_dev, NUM_HEADS * HEAD_DIM);
 
-    // Compare. INT8 dequantization induces ~1% per-element relative
-    // error in attention output for benign inputs.
     let mut max_abs = 0f32;
     let mut max_rel = 0f32;
-    let mut mag_max = 0f32;
-    for i in 0..out_fp16_h.len() {
-        let diff = (out_fp16_h[i] - out_int8_h[i]).abs();
+    let mut max_mag = 0f32;
+    for i in 0..out_ref.len() {
+        let diff = (out_int8[i] - out_ref[i]).abs();
         max_abs = max_abs.max(diff);
-        let mag = out_fp16_h[i].abs().max(1e-4);
+        let mag = out_ref[i].abs().max(1e-3);
         max_rel = max_rel.max(diff / mag);
-        mag_max = mag_max.max(out_fp16_h[i].abs());
+        max_mag = max_mag.max(out_ref[i].abs());
     }
     eprintln!(
-        "int8 vs fp16: max|diff|={max_abs:.5} max rel={max_rel:.4} (max output mag={mag_max:.4})"
+        "int8 vs host-ref: max|diff|={max_abs:.5} max rel={max_rel:.4} (max output mag={max_mag:.4})"
     );
-    // INT8 paged decode should land within 5% relative of FP16 reference
-    // for benign random inputs at this scale.
+    // INT8 sym-quant per token-head + FP16 Q/output induces a few-%
+    // relative error on attention output for benign random inputs.
     assert!(max_abs < 0.05, "abs diff too high: {max_abs}");
     assert!(max_rel < 0.10, "rel diff too high: {max_rel}");
 }

--- a/crates/ferrum-kernels/tests/int8_kv_parity.rs
+++ b/crates/ferrum-kernels/tests/int8_kv_parity.rs
@@ -1,0 +1,275 @@
+//! INT8 KV parity test (CUDA-only).
+//!
+//! Two checks run end-to-end on a real CUDA device:
+//!
+//!   1. **Append round-trip.** Take random FP16 K/V tokens, push them
+//!      through `launch_int8_kv_cache_append`, read back the INT8 buffer
+//!      + per-token FP16 scales, dequantize on the host, and check that
+//!      the round-trip max-relative-error is bounded by `1/127` (the
+//!      INT8 quantization step).
+//!
+//!   2. **Decode parity vs FP16.** Build a paged KV pool with random
+//!      FP16 K/V, run the existing `paged_decode_attention_f16` kernel,
+//!      then quantize the SAME K/V to INT8 (using the kernel's scale
+//!      convention), run `paged_decode_attention_int8`, and check that
+//!      the two output tensors agree within a small relative tolerance.
+//!
+//! Run on a CUDA box:
+//!   cargo test -p ferrum-kernels --features cuda --release \
+//!     --test int8_kv_parity -- --nocapture
+
+#![cfg(feature = "cuda")]
+
+use cudarc::driver::CudaContext;
+use ferrum_kernels::backend::cuda::CudaBackend;
+use ferrum_kernels::backend::{Backend, BackendPagedKv};
+use ferrum_kernels::int8_kv::{launch_int8_kv_cache_append, launch_int8_paged_decode_attention};
+use half::f16;
+
+fn rnd(state: &mut u64) -> f32 {
+    *state = state
+        .wrapping_mul(6364136223846793005)
+        .wrapping_add(1442695040888963407);
+    let u = (*state >> 33) as u32 & 0x00FF_FFFF;
+    (u as f32) / 16_777_216.0 * 2.0 - 1.0
+}
+
+fn quantize_token_per_head(
+    fp16: &[f32],            // [num_tokens, num_kv_heads, head_dim]
+    num_tokens: usize,
+    num_kv_heads: usize,
+    head_dim: usize,
+) -> (Vec<i8>, Vec<f32>) {
+    let mut q = vec![0i8; num_tokens * num_kv_heads * head_dim];
+    let mut s = vec![0f32; num_tokens * num_kv_heads];
+    for t in 0..num_tokens {
+        for h in 0..num_kv_heads {
+            let base = (t * num_kv_heads + h) * head_dim;
+            let mut max_abs = 0f32;
+            for d in 0..head_dim {
+                max_abs = max_abs.max(fp16[base + d].abs());
+            }
+            let max_abs = max_abs.max(1e-8);
+            let scale = max_abs / 127.0;
+            s[t * num_kv_heads + h] = scale;
+            let inv = 1.0 / scale;
+            for d in 0..head_dim {
+                let v = (fp16[base + d] * inv).round();
+                q[base + d] = v.clamp(-127.0, 127.0) as i8;
+            }
+        }
+    }
+    (q, s)
+}
+
+#[test]
+#[ignore]
+fn int8_kv_append_roundtrip() {
+    const NUM_TOKENS: usize = 16;
+    const NUM_KV_HEADS: usize = 4;
+    const HEAD_DIM: usize = 128;
+    const POOL_TOKENS: usize = 32; // sparse: only half the slots filled
+
+    let total = NUM_TOKENS * NUM_KV_HEADS * HEAD_DIM;
+    let mut s = 0xDEADBEEFu64;
+    let k_in: Vec<f32> = (0..total).map(|_| rnd(&mut s) * 0.1).collect();
+    let v_in: Vec<f32> = (0..total).map(|_| rnd(&mut s) * 0.1).collect();
+
+    // Place tokens in non-contiguous slots (5, 9, 13, ..., 5+4*15) to
+    // exercise slot_mapping.
+    let slot_mapping: Vec<i32> = (0..NUM_TOKENS).map(|i| (5 + i * 4) as i32).collect();
+
+    let ctx = CudaContext::new(0).expect("CUDA context");
+    let stream = ctx.default_stream();
+
+    let k_in_dev = CudaBackend::from_slice(&k_in);
+    let v_in_dev = CudaBackend::from_slice(&v_in);
+    let mut k_pool: cudarc::driver::CudaSlice<i8> = stream
+        .alloc_zeros::<i8>(POOL_TOKENS * NUM_KV_HEADS * HEAD_DIM)
+        .unwrap();
+    let mut v_pool: cudarc::driver::CudaSlice<i8> = stream
+        .alloc_zeros::<i8>(POOL_TOKENS * NUM_KV_HEADS * HEAD_DIM)
+        .unwrap();
+    let mut k_scales: cudarc::driver::CudaSlice<f16> = stream
+        .alloc_zeros::<f16>(POOL_TOKENS * NUM_KV_HEADS)
+        .unwrap();
+    let mut v_scales: cudarc::driver::CudaSlice<f16> = stream
+        .alloc_zeros::<f16>(POOL_TOKENS * NUM_KV_HEADS)
+        .unwrap();
+    let slot_dev = stream.memcpy_stod(&slot_mapping).unwrap();
+
+    launch_int8_kv_cache_append(
+        &ctx,
+        &k_in_dev,
+        &v_in_dev,
+        &mut k_pool,
+        &mut v_pool,
+        &mut k_scales,
+        &mut v_scales,
+        &slot_dev,
+        NUM_TOKENS,
+        NUM_KV_HEADS,
+        HEAD_DIM,
+    )
+    .expect("int8_kv_cache_append");
+
+    stream.synchronize().unwrap();
+
+    let k_pool_h: Vec<i8> = stream.memcpy_dtov(&k_pool).unwrap();
+    let v_pool_h: Vec<i8> = stream.memcpy_dtov(&v_pool).unwrap();
+    let k_scales_h: Vec<f16> = stream.memcpy_dtov(&k_scales).unwrap();
+    let v_scales_h: Vec<f16> = stream.memcpy_dtov(&v_scales).unwrap();
+
+    // Dequantize and compare.
+    let mut max_rel = 0f32;
+    for t in 0..NUM_TOKENS {
+        let slot = slot_mapping[t] as usize;
+        for h in 0..NUM_KV_HEADS {
+            let s_off = slot * NUM_KV_HEADS + h;
+            let ks = k_scales_h[s_off].to_f32();
+            let vs = v_scales_h[s_off].to_f32();
+            for d in 0..HEAD_DIM {
+                let in_off = (t * NUM_KV_HEADS + h) * HEAD_DIM + d;
+                let pool_off = slot * NUM_KV_HEADS * HEAD_DIM + h * HEAD_DIM + d;
+                let k_dq = ks * k_pool_h[pool_off] as f32;
+                let v_dq = vs * v_pool_h[pool_off] as f32;
+                let mag = k_in[in_off].abs().max(1e-3);
+                let rel_k = (k_dq - k_in[in_off]).abs() / mag;
+                let rel_v = (v_dq - v_in[in_off]).abs() / mag;
+                max_rel = max_rel.max(rel_k).max(rel_v);
+            }
+        }
+    }
+    eprintln!("int8 append round-trip max relative error: {max_rel:.4}");
+    // INT8 sym-quant per token-head: worst case is ~1/127 relative for
+    // small values, but per-token scale keeps most dims at ≤ 1/64 ≈ 0.016.
+    // Use a generous bound to make the test robust to RNG.
+    assert!(max_rel < 0.05, "round-trip rel err too high: {max_rel}");
+}
+
+#[test]
+#[ignore]
+fn int8_paged_decode_parity_vs_fp16() {
+    const NUM_HEADS: usize = 8;
+    const NUM_KV_HEADS: usize = 2;
+    const HEAD_DIM: usize = 128;
+    const BLOCK_SIZE: usize = 16;
+    const VALID_KV_LEN: usize = 96; // 6 blocks
+    const MAX_BLOCKS: usize = 8;
+
+    let mut rng = 0xCAFEF00Du64;
+
+    // Q : [num_heads, head_dim] FP16
+    let q_n = NUM_HEADS * HEAD_DIM;
+    let q_data: Vec<f32> = (0..q_n).map(|_| rnd(&mut rng) * 0.5).collect();
+
+    // K/V pool : [max_blocks, block_size, num_kv_heads, head_dim] FP16/INT8
+    let kv_n = MAX_BLOCKS * BLOCK_SIZE * NUM_KV_HEADS * HEAD_DIM;
+    let k_data: Vec<f32> = (0..kv_n).map(|_| rnd(&mut rng) * 0.3).collect();
+    let v_data: Vec<f32> = (0..kv_n).map(|_| rnd(&mut rng) * 0.3).collect();
+
+    // Block table: identity mapping (logical i → physical i).
+    let block_table: Vec<i32> = (0..MAX_BLOCKS as i32).collect();
+
+    let ctx = CudaContext::new(0).expect("CUDA context");
+    let stream = ctx.default_stream();
+
+    // Quantize K/V on host (using kernel's scale convention).
+    // Layout for quant: [max_blocks * block_size, num_kv_heads, head_dim].
+    let pool_tokens = MAX_BLOCKS * BLOCK_SIZE;
+    let (k_q, k_s) = quantize_token_per_head(&k_data, pool_tokens, NUM_KV_HEADS, HEAD_DIM);
+    let (v_q, v_s) = quantize_token_per_head(&v_data, pool_tokens, NUM_KV_HEADS, HEAD_DIM);
+
+    // Upload everything.
+    let q_dev = CudaBackend::from_slice(&q_data);
+    let k_pool_fp16 = CudaBackend::from_slice(&k_data);
+    let v_pool_fp16 = CudaBackend::from_slice(&v_data);
+    let k_pool_i8 = stream.memcpy_stod(&k_q).unwrap();
+    let v_pool_i8 = stream.memcpy_stod(&v_q).unwrap();
+    let k_scales_h: Vec<f16> = k_s.iter().map(|x| f16::from_f32(*x)).collect();
+    let v_scales_h: Vec<f16> = v_s.iter().map(|x| f16::from_f32(*x)).collect();
+    let k_scales_dev = stream.memcpy_stod(&k_scales_h).unwrap();
+    let v_scales_dev = stream.memcpy_stod(&v_scales_h).unwrap();
+    let bt_dev = stream.memcpy_stod(&block_table).unwrap();
+
+    // Run FP16 reference. Trait API uses `&Buffer` (CudaSlice<f16>) for
+    // block_table and context_lens — we reinterpret the i32 slice via
+    // upgrade_device_ptr (same hack as the existing bench).
+    use cudarc::driver::sys::CUdeviceptr;
+    use cudarc::driver::CudaSlice;
+    use cudarc::driver::DevicePtr;
+    let mut out_fp16 = CudaBackend::alloc(NUM_HEADS * HEAD_DIM);
+    let context_lens_i32: Vec<i32> = vec![VALID_KV_LEN as i32];
+    let context_lens_dev = stream.memcpy_stod(&context_lens_i32).unwrap();
+    let (bt_ptr, _g0) = bt_dev.device_ptr(&stream);
+    let (cl_ptr, _g1) = context_lens_dev.device_ptr(&stream);
+    let bt_f16: CudaSlice<f16> = unsafe { stream.upgrade_device_ptr(bt_ptr as CUdeviceptr, 0) };
+    let cl_f16: CudaSlice<f16> = unsafe { stream.upgrade_device_ptr(cl_ptr as CUdeviceptr, 0) };
+    let mut bctx = <CudaBackend as Backend>::new_context();
+
+    let attn_scale = 1.0f32 / (HEAD_DIM as f32).sqrt();
+
+    <CudaBackend as BackendPagedKv>::paged_decode_attention(
+        &mut bctx,
+        &q_dev,
+        &k_pool_fp16,
+        &v_pool_fp16,
+        &mut out_fp16,
+        &bt_f16,
+        &cl_f16,
+        1, // num_seqs
+        NUM_HEADS,
+        NUM_KV_HEADS,
+        HEAD_DIM,
+        BLOCK_SIZE,
+        MAX_BLOCKS,
+        1, // q_len
+    )
+    .expect("fp16 paged decode");
+    <CudaBackend as Backend>::sync(&mut bctx);
+
+    let out_fp16_h: Vec<f32> = CudaBackend::to_vec(&out_fp16, NUM_HEADS * HEAD_DIM);
+
+    // Run INT8 path.
+    let mut out_int8 = CudaBackend::alloc(NUM_HEADS * HEAD_DIM);
+    launch_int8_paged_decode_attention(
+        &ctx,
+        &q_dev,
+        &k_pool_i8,
+        &v_pool_i8,
+        &k_scales_dev,
+        &v_scales_dev,
+        &bt_dev,
+        &mut out_int8,
+        NUM_HEADS,
+        NUM_KV_HEADS,
+        HEAD_DIM,
+        VALID_KV_LEN,
+        BLOCK_SIZE,
+        attn_scale,
+    )
+    .expect("int8 paged decode");
+    stream.synchronize().unwrap();
+
+    let out_int8_h: Vec<f32> = CudaBackend::to_vec(&out_int8, NUM_HEADS * HEAD_DIM);
+
+    // Compare. INT8 dequantization induces ~1% per-element relative
+    // error in attention output for benign inputs.
+    let mut max_abs = 0f32;
+    let mut max_rel = 0f32;
+    let mut mag_max = 0f32;
+    for i in 0..out_fp16_h.len() {
+        let diff = (out_fp16_h[i] - out_int8_h[i]).abs();
+        max_abs = max_abs.max(diff);
+        let mag = out_fp16_h[i].abs().max(1e-4);
+        max_rel = max_rel.max(diff / mag);
+        mag_max = mag_max.max(out_fp16_h[i].abs());
+    }
+    eprintln!(
+        "int8 vs fp16: max|diff|={max_abs:.5} max rel={max_rel:.4} (max output mag={mag_max:.4})"
+    );
+    // INT8 paged decode should land within 5% relative of FP16 reference
+    // for benign random inputs at this scale.
+    assert!(max_abs < 0.05, "abs diff too high: {max_abs}");
+    assert!(max_rel < 0.10, "rel diff too high: {max_rel}");
+}

--- a/docs/architecture-refactor-status.md
+++ b/docs/architecture-refactor-status.md
@@ -48,9 +48,9 @@ Three gates — ALL must pass before the refactor is considered done:
 | 2. Compute precision | ✅ done | Phase 3e cutover complete (#123 Marlin, #124 GGUF). All quant kernel dispatch lives in `Linear<B>` impls in `ferrum-kernels::quant_linear/`. `BackendQuantMarlin::gemm_gptq*` and `BackendQuantGguf::gemm_quant` deleted. |
 | 3. Weight format | ✅ done | `Linear<B>` polymorphism point owns the kernel call; new format = new `Linear<B>` impl in ferrum-kernels (no Backend trait change). |
 | 4. **Inference device** | ✅ done | Backend → 5 supertraits + 3 capability bundles (#107-#110) |
-| 5. KV cache precision | 🟡 partial | `KvDtypeKind` + `BackendKvDtype<K>` traits (#112) + `KvCache<B, K = KvFp16>` type param (#119); INT8/FP8 kernel impls still pending |
+| 5. KV cache precision | 🟡 mostly done | Type system (#112, #119): `KvDtypeKind` + `BackendKvDtype<K>` + `KvCache<B, K = KvFp16>`. CUDA INT8 KV kernels + `BackendKvDtype<KvInt8> for CudaBackend` marker landed (`paged_decode_attention_int8`, `int8_kv_cache_append`, host-ref cosine parity 0.99999). Model-side wire-up that flips a path to `KvCache<B, KvInt8>` + the int8 launchers is the only remaining step. FP8 KV is a separate future PR. |
 
-**4 of 5 dims complete.** The remaining gap is Dim 5 INT8 KV kernel work — the type-system shape is there, just need the actual quant KV kernels.
+**5 of 5 dims structurally complete.** CUDA INT8 KV kernels are validated against an FP32 host reference (cos sim 0.99999, max abs / max output ≈ 0.36%). Closing the last 5% requires only model integration — not kernel work.
 
 ### PRs landed (in order)
 
@@ -77,6 +77,7 @@ Three gates — ALL must pass before the refactor is considered done:
 | [#127](https://github.com/sizzlecar/ferrum-infer-rs/pull/127) | PR B | Delete the legacy `ComputeBackend` / `KernelOps` / `model_builder` / memory modules from ferrum-interfaces (had no implementations after Phase 3e). Drop the dead `MetalKernelOps` shell, the `ferrum-engine::backends::candle` `ComputeBackend` impl, the dead `custom_backend` builder field, and `ferrum-models::{builder,weights}`. |
 | [#128](https://github.com/sizzlecar/ferrum-infer-rs/pull/128) | PR C | Merge `ferrum-attention` into `ferrum-kernels::attention`. The crate's only consumers were `ferrum-kernels::backend::metal` and `ferrum-models` (Qwen3-TTS); merging removes a duplicated metal feature pass-through and the cudarc-0.12 stub. Two-cudarc-version workspace gone. |
 | [#129](https://github.com/sizzlecar/ferrum-infer-rs/pull/129) | cleanup | Drop dead `LinearFactory` trait + `DefaultLinearFactory` (zero callers anywhere). |
+| [#131](https://github.com/sizzlecar/ferrum-infer-rs/pull/131) | Dim 5 INT8 KV step 1 | CUDA INT8 KV kernels: `paged_decode_attention_int8` (read INT8 + per-token FP16 scale, dequantize on the fly) and `int8_kv_cache_append` (FP16 → per-(token, kv_head) symmetric INT8 + scale). Rust launchers in `ferrum-kernels::int8_kv`. `BackendKvDtype<KvInt8>` marker on `CudaBackend`. Host-reference parity test: cosine 0.99999 vs FP32 ref. |
 
 ### Backend trait shrinkage
 
@@ -93,7 +94,8 @@ Three gates — ALL must pass before the refactor is considered done:
 
 | Phase | Scope | Risk | Estimate |
 |---|---|---|---|
-| 4 INT8 KV | Implement `BackendKvDtype<KvInt8>` for CUDA (vLLM-style scale-per-token); add the actual quant KV kernels (rope / kv-append / paged attention read INT8 cache). **Closes Dim 5.** | Medium | 1-2 days. |
+| 4 INT8 KV — model wire-up | Switch a model's `KvCache<B>` to `KvCache<B, KvInt8>` behind an env var (`FERRUM_INT8_KV=1`), call the INT8 launchers from `ferrum-kernels::int8_kv` in the decode/append path, run a parity bench against FP16 (Llama-8B INT4 + INT8 KV vs FP16 KV). | Low (kernels already validated) | 1 day. |
+| FP8 KV | Add `paged_decode_attention_fp8` + `fp8_kv_cache_append` mirroring the INT8 pair (use `__nv_fp8_e4m3` storage and per-token f8 scale). Marker impl `BackendKvDtype<KvFp8>` on CudaBackend. | Medium (FP8 needs SM ≥ 8.9) | 1-2 days. |
 
 ## GPU testing workflow (Vast.ai 4090)
 


### PR DESCRIPTION
## Summary

Closes the kernel side of **Dim 5 (KV cache precision)**. Two new CUDA
kernels in \`kernels/int8_paged_decode_attention.cu\` plus Rust
launchers in \`ferrum-kernels::int8_kv\`:

- **\`paged_decode_attention_int8\`** — paged attention read with
  on-the-fly INT8→FP32 dequantization via per-token per-kv-head FP16
  scales. Mirrors \`paged_decode_attention_f16\` algorithmically
  (warp-cooperative Q·K + softmax + scores·V) but reads \`int8_t\`
  pools instead of \`__half\`.
- **\`int8_kv_cache_append\`** — take FP16 K/V, compute per-token
  per-kv-head symmetric scale \`s = max(|x|)/127\`, write INT8 + FP16
  scale to the paged pool at \`slot_mapping[t]\`.

Storage layout (vLLM-compatible):
- K/V pool: \`int8_t [num_blocks * block_size * num_kv_heads * head_dim]\`
- scales:   \`__half  [num_blocks * block_size * num_kv_heads]\`

Marker impl \`BackendKvDtype<KvInt8> for CudaBackend\` lands; full model
wire-up (switching a \`KvCache<B>\` to \`KvCache<B, KvInt8>\` and calling
the launchers) is intentionally a follow-up.

## Test plan
- [x] \`cargo check --workspace --all-targets\` passes (CPU)
- [x] \`cargo check --workspace --all-targets --features cuda\` passes (Vast 4090)
- [x] \`int8_kv_append_roundtrip\`: max abs round-trip error 0.00043 vs the 0.002 threshold (well within INT8 noise floor)
- [x] \`int8_paged_decode_parity_vs_host_ref\`: cosine similarity **0.99999** vs FP32 host reference (max abs diff 0.00023, max output magnitude 0.0634, rel-to-max-mag = 0.36%)

Run on a CUDA box:
\`\`\`
cargo test -p ferrum-kernels --features cuda --release \\
    --test int8_kv_parity -- --ignored --nocapture
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)