### PR TITLE
docs: Dim 5 structural done — log PRs #134, #135

### DIFF
--- a/docs/architecture-refactor-status.md
+++ b/docs/architecture-refactor-status.md
@@ -48,9 +48,9 @@ Three gates — ALL must pass before the refactor is considered done:
 | 2. Compute precision | ✅ done | Phase 3e cutover complete (#123 Marlin, #124 GGUF). All quant kernel dispatch lives in `Linear<B>` impls in `ferrum-kernels::quant_linear/`. `BackendQuantMarlin::gemm_gptq*` and `BackendQuantGguf::gemm_quant` deleted. |
 | 3. Weight format | ✅ done | `Linear<B>` polymorphism point owns the kernel call; new format = new `Linear<B>` impl in ferrum-kernels (no Backend trait change). |
 | 4. **Inference device** | ✅ done | Backend → 5 supertraits + 3 capability bundles (#107-#110) |
-| 5. KV cache precision | 🟡 mostly done | Type system (#112, #119): `KvDtypeKind` + `BackendKvDtype<K>` + `KvCache<B, K = KvFp16>`. CUDA INT8 KV kernels + `BackendKvDtype<KvInt8> for CudaBackend` marker landed (`paged_decode_attention_int8`, `int8_kv_cache_append`, host-ref cosine parity 0.99999). Model-side wire-up that flips a path to `KvCache<B, KvInt8>` + the int8 launchers is the only remaining step. FP8 KV is a separate future PR. |
+| 5. KV cache precision | ✅ structural done | Type system (#112, #119, #134): `KvDtypeKind` + `BackendKvDtype<K>` with `KvBuffer` + `KvScales` associated types + parallel `KvCacheQuant<B, K>` struct. CUDA INT8 KV kernels (#131): `paged_decode_attention_int8`, `int8_kv_cache_append`, host-ref cosine 0.99999. CudaBackend constructor `KvCacheQuant<CudaBackend, KvInt8>::new_paged_cuda(...)` (#135) with full append→decode parity test. Model-side wire-up (generic the model on `K`, branch call sites) is a feature task, not architecture work. FP8 KV is a separate future PR. |
 
-**5 of 5 dims structurally complete.** CUDA INT8 KV kernels are validated against an FP32 host reference (cos sim 0.99999, max abs / max output ≈ 0.36%). Closing the last 5% requires only model integration — not kernel work.
+**5 of 5 dims structurally complete.** Dim 5 architecture: kernels + types + cache abstraction + tests. INT8 path validated cos 0.99999 vs FP32 host ref through three different test entry points (standalone decode, append→decode raw cudarc, append→decode through `KvCacheQuant`). Switching a specific model to INT8 KV is now mechanical: K-generic the model, branch the kv-append + decode call sites on K.
 
 ### PRs landed (in order)
 
@@ -79,6 +79,8 @@ Three gates — ALL must pass before the refactor is considered done:
 | [#129](https://github.com/sizzlecar/ferrum-infer-rs/pull/129) | cleanup | Drop dead `LinearFactory` trait + `DefaultLinearFactory` (zero callers anywhere). |
 | [#131](https://github.com/sizzlecar/ferrum-infer-rs/pull/131) | Dim 5 INT8 KV step 1 | CUDA INT8 KV kernels: `paged_decode_attention_int8` (read INT8 + per-token FP16 scale, dequantize on the fly) and `int8_kv_cache_append` (FP16 → per-(token, kv_head) symmetric INT8 + scale). Rust launchers in `ferrum-kernels::int8_kv`. `BackendKvDtype<KvInt8>` marker on `CudaBackend`. Host-reference parity test: cosine 0.99999 vs FP32 ref. |
 | [#132](https://github.com/sizzlecar/ferrum-infer-rs/pull/132) | Dim 5 INT8 KV test | End-to-end append→decode composition test. FP16 K/V → `int8_kv_cache_append` → `paged_decode_attention_int8` → compare against FP32 host reference. Cosine 0.99999, validates the kernel pair composes cleanly with no storage / scale convention drift. |
+| [#134](https://github.com/sizzlecar/ferrum-infer-rs/pull/134) | Dim 5 type system | `BackendKvDtype<K>` gains `type KvBuffer` + `type KvScales` associated types; for K=KvFp16 they resolve to `Self::Buffer` / `()` (zero-cost), for K=KvInt8 on CudaBackend they resolve to `OptionalCudaInt8` / `OptionalCudaScalesF16`. New parallel `KvCacheQuant<B, K>` struct uses the associated types — leaves the FP16 `KvCache<B, K>` field shape unchanged (no callsite churn). |
+| [#135](https://github.com/sizzlecar/ferrum-infer-rs/pull/135) | Dim 5 INT8 cache abstraction | `KvCacheQuant<CudaBackend, KvInt8>::new_paged_cuda(...)` one-call constructor: K/V int8 pool + FP16 scales + block_table + context_lens. New e2e parity test `kv_cache_quant_int8_e2e` drives append→decode through the cache abstraction (no direct cudarc allocs) — cos 0.99999. |
 
 ### Backend trait shrinkage
 
@@ -91,11 +93,11 @@ Three gates — ALL must pass before the refactor is considered done:
 | 3e/2 (#123) | ~30 | -2 (gemm_gptq + gemm_gptq_with_offset; +make_stacked_expert_linear) |
 | 3e/3 (#124) | ~29 | -1 (gemm_quant; load_quant return type changed) |
 
-### Remaining work
+### Remaining work (feature, not architecture)
 
 | Phase | Scope | Risk | Estimate |
 |---|---|---|---|
-| 4 INT8 KV — model wire-up | Switch a model's `KvCache<B>` to `KvCache<B, KvInt8>` behind an env var (`FERRUM_INT8_KV=1`), call the INT8 launchers from `ferrum-kernels::int8_kv` in the decode/append path, run a parity bench against FP16 (Llama-8B INT4 + INT8 KV vs FP16 KV). | Low (kernels already validated) | 1 day. |
+| INT8 KV — model integration | Generic `LlamaFamilyModel<B, K>` over `K: KvDtypeKind`, hold `KvCacheQuant<B, KvInt8>` when K=KvInt8, branch the append + paged-decode call sites in the per-layer forward on K. Behind `FERRUM_INT8_KV=1` env var. Parity bench against FP16 baseline. | Low (kernels + cache + tests all validated) | 1 day. |
 | FP8 KV | Add `paged_decode_attention_fp8` + `fp8_kv_cache_append` mirroring the INT8 pair (use `__nv_fp8_e4m3` storage and per-token f8 scale). Marker impl `BackendKvDtype<KvFp8>` on CudaBackend. | Medium (FP8 needs SM ≥ 8.9) | 1-2 days. |
 
 ## GPU testing workflow (Vast.ai 4090)


### PR DESCRIPTION
Dim 5 status: 🟡 mostly done → ✅ structural done. Adds entries for #134 (associated types) and #135 (cache constructor + e2e test). Re-categorizes remaining model integration as feature work, not architecture.