### PR TITLE
chore(engine): drop dead backend_name + clarify Phase D/E comments

### DIFF
--- a/crates/ferrum-engine/src/builder.rs
+++ b/crates/ferrum-engine/src/builder.rs
@@ -24,8 +24,6 @@ pub struct EngineBuilder {
     registry: Arc<ComponentRegistry>,
     /// Engine configuration
     config: EngineConfig,
-    /// Override: custom backend name
-    backend_name: Option<String>,
     /// Override: custom tokenizer name
     tokenizer_name: Option<String>,
     /// Override: custom sampler name
@@ -59,7 +57,6 @@ impl EngineBuilder {
         Self {
             registry,
             config,
-            backend_name: None,
             tokenizer_name: None,
             sampler_name: None,
             scheduler_name: None,
@@ -71,12 +68,6 @@ impl EngineBuilder {
             custom_kv_cache: None,
             custom_executor: None,
         }
-    }
-
-    /// Set the backend to use by name
-    pub fn with_backend(mut self, name: impl Into<String>) -> Self {
-        self.backend_name = Some(name.into());
-        self
     }
 
     /// Set the tokenizer to use by name
@@ -418,7 +409,6 @@ mod tests {
         let config = EngineConfig::default();
         let builder = EngineBuilder::new(config);
 
-        assert!(builder.backend_name.is_none());
         assert!(builder.tokenizer_name.is_none());
     }
 
@@ -426,14 +416,12 @@ mod tests {
     fn test_builder_with_overrides() {
         let config = EngineConfig::default();
         let builder = EngineBuilder::new(config)
-            .with_backend("custom_backend")
             .with_tokenizer("custom_tokenizer")
             .with_sampler("greedy")
             .with_scheduler("priority")
             .with_kv_cache("paged")
             .with_executor("custom_executor");
 
-        assert_eq!(builder.backend_name, Some("custom_backend".to_string()));
         assert_eq!(builder.tokenizer_name, Some("custom_tokenizer".to_string()));
         assert_eq!(builder.sampler_name, Some("greedy".to_string()));
         assert_eq!(builder.scheduler_name, Some("priority".to_string()));

--- a/crates/ferrum-engine/src/registry.rs
+++ b/crates/ferrum-engine/src/registry.rs
@@ -947,21 +947,25 @@ impl ComponentFactory<Arc<dyn ModelExecutor + Send + Sync>> for CandleExecutorFa
                 let _loader = ferrum_models::SafeTensorsLoader::new(&model_path);
                 let model_dir_path: std::path::PathBuf = model_path.clone().into();
 
-                // TP and GPTQ still pending on the new path (Phase D/E).
+                // Tensor parallelism (FERRUM_TP>1) was wired against the
+                // pre-Architecture-v2 CandleBackend and hasn't been ported
+                // to the Backend<B> trait stack. Reject explicitly so users
+                // don't get a silent single-GPU fallback.
                 let tp_size: usize = std::env::var("FERRUM_TP")
                     .ok()
                     .and_then(|v| v.parse().ok())
                     .unwrap_or(0);
                 if tp_size > 1 {
                     return Err(FerrumError::unsupported(
-                        "FERRUM_TP>1 temporarily unsupported during \
-                         architecture-v2 migration (Phase D/E).",
+                        "FERRUM_TP>1 not supported on the Backend<B> path. \
+                         Run with FERRUM_TP=1 (default) for single-GPU inference.",
                     ));
                 }
-                // NOTE: GPTQ is now wired through NativeSafetensorsLoader's
-                // load_linear path (Phase E-GPTQ). The loader auto-detects
-                // `<name>.qweight` tensors and constructs GptqLinear via
-                // Backend::load_gptq; no legacy opt-out here.
+                // GPTQ is loaded via NativeSafetensorsLoader's load_linear:
+                // it auto-detects `<name>.qweight` tensors and constructs
+                // a GptqLinear via Backend::load_gptq. The QuantizeConfig
+                // probe is kept for back-compat with old configs that
+                // explicitly listed a quantization method.
                 let _ = ferrum_models::loader::QuantizeConfig::from_model_dir(&model_dir_path);
 
                 // Per-architecture config constructor picks has_qk_norm +


### PR DESCRIPTION
Two small post-audit cleanups:
- Drop `EngineBuilder::backend_name` field + `with_backend()` (zero callers after PR #127's resolve_backend_name delete)
- Reword stale 'Phase D/E' comments in registry.rs to reflect current state (TP>1 is the only remaining gap, framed as a feature port not a 'Phase')

CPU + metal compile pass.