### PR TITLE
feat(cli): wire Dim 5 KvCacheDtype through CLI/serve/bench

### DIFF
--- a/crates/ferrum-cli/src/commands/bench.rs
+++ b/crates/ferrum-cli/src/commands/bench.rs
@@ -48,6 +48,11 @@ pub struct BenchCommand {
     /// Long-context mode: use a ~2k token prompt (tests flash decode / paged KV)
     #[arg(long)]
     pub long_context: bool,
+
+    /// KV cache element dtype (Dim 5). Accepts `fp16`, `bf16`, `int8`, `fp8`.
+    /// Default `fp16`. Override via `FERRUM_KV_DTYPE` env var.
+    #[arg(long, value_name = "DTYPE")]
+    pub kv_dtype: Option<String>,
 }
 
 pub async fn execute(cmd: BenchCommand, config: CliConfig) -> Result<()> {
@@ -165,6 +170,7 @@ pub async fn execute(cmd: BenchCommand, config: CliConfig) -> Result<()> {
     // DefaultInferenceEngine (Priority) has stream lifecycle issues with bench.
     let mut engine_config = ferrum_engine::simple_engine_config(model_id.clone(), device);
     engine_config.scheduler.policy = ferrum_types::SchedulingPolicy::ContinuousBatch;
+    super::run::apply_kv_dtype_override(&mut engine_config, cmd.kv_dtype.as_deref())?;
     let engine = ferrum_engine::create_default_engine(engine_config).await?;
 
     let prompt = if cmd.long_context {

--- a/crates/ferrum-cli/src/commands/run.rs
+++ b/crates/ferrum-cli/src/commands/run.rs
@@ -92,6 +92,13 @@ pub struct RunCommand {
     /// exclusive GPU; leave at 0.9 if other processes share the card.
     #[arg(long, default_value = "0.9")]
     pub gpu_memory_utilization: f32,
+
+    /// KV cache element dtype (Dim 5 polymorphism point). Accepts
+    /// `fp16`, `bf16`, `int8`, `fp8`. Default `fp16`. INT8 / FP8
+    /// require model wire-up; today only the kernel + type layer ships.
+    /// Override via `FERRUM_KV_DTYPE` env var.
+    #[arg(long, value_name = "DTYPE")]
+    pub kv_dtype: Option<String>,
 }
 
 pub async fn execute(cmd: RunCommand, config: CliConfig) -> Result<()> {
@@ -211,7 +218,8 @@ pub async fn execute(cmd: RunCommand, config: CliConfig) -> Result<()> {
         "Loading weights to GPU... (30s+ for >10 GB models)".dimmed()
     );
     let load_start = std::time::Instant::now();
-    let engine_config = ferrum_engine::simple_engine_config(model_id.clone(), device);
+    let mut engine_config = ferrum_engine::simple_engine_config(model_id.clone(), device);
+    apply_kv_dtype_override(&mut engine_config, cmd.kv_dtype.as_deref())?;
     let engine = ferrum_engine::create_default_engine(engine_config).await?;
     eprintln!(
         "{}",
@@ -746,5 +754,47 @@ fn build_chat_prompt(
         }
         prompt.push_str(&format!("<|user|>\n{}</s>\n<|assistant|>\n", user_input));
         prompt
+    }
+}
+
+/// Apply the `--kv-dtype` CLI flag (or `FERRUM_KV_DTYPE` env override)
+/// to an engine config, validating early. Default is FP16 (the
+/// production-validated path on every backend); selecting INT8 / FP8
+/// is rejected with a helpful message until model integration ships.
+pub fn apply_kv_dtype_override(
+    engine_config: &mut ferrum_types::EngineConfig,
+    cli_arg: Option<&str>,
+) -> ferrum_types::Result<()> {
+    use ferrum_types::KvCacheDtype;
+    let raw = cli_arg
+        .map(|s| s.to_string())
+        .or_else(|| std::env::var("FERRUM_KV_DTYPE").ok());
+    let Some(raw) = raw else {
+        // No override → keep config default (FP16).
+        return Ok(());
+    };
+    let parsed = KvCacheDtype::parse(&raw).ok_or_else(|| {
+        ferrum_types::FerrumError::config(format!(
+            "Unknown --kv-dtype value '{}'. Accepts: fp16, bf16, int8, fp8.",
+            raw
+        ))
+    })?;
+    match parsed {
+        KvCacheDtype::Fp16 => {
+            engine_config.kv_cache.dtype = KvCacheDtype::Fp16;
+            Ok(())
+        }
+        KvCacheDtype::Int8 => Err(ferrum_types::FerrumError::unsupported(
+            "INT8 KV cache: kernels and KvCacheQuant<B, KvInt8> have landed \
+             (PR #131 / #134 / #135), but the model decode loop hasn't been \
+             generic'd over K: KvDtypeKind yet. Re-run with --kv-dtype=fp16 \
+             (or omit the flag) until the model wire-up ships.",
+        )),
+        KvCacheDtype::Fp8 => Err(ferrum_types::FerrumError::unsupported(
+            "FP8 KV cache: kernels not yet implemented. Tracked as a future PR.",
+        )),
+        KvCacheDtype::Bf16 => Err(ferrum_types::FerrumError::unsupported(
+            "BF16 KV cache: marker only, no backend impl ships yet.",
+        )),
     }
 }

--- a/crates/ferrum-cli/src/commands/serve.rs
+++ b/crates/ferrum-cli/src/commands/serve.rs
@@ -54,6 +54,13 @@ pub struct ServeCommand {
     /// Set 1.0 for an exclusive GPU; lower if you share the card.
     #[arg(long, default_value = "0.9")]
     pub gpu_memory_utilization: f32,
+
+    /// KV cache element dtype (Dim 5 polymorphism point). Accepts
+    /// `fp16`, `bf16`, `int8`, `fp8`. Default `fp16`. INT8 / FP8
+    /// require model wire-up; today only the kernel + type layer ships.
+    /// Override via `FERRUM_KV_DTYPE` env var.
+    #[arg(long, value_name = "DTYPE")]
+    pub kv_dtype: Option<String>,
 }
 
 pub async fn execute(cmd: ServeCommand, config: CliConfig) -> Result<()> {
@@ -66,6 +73,7 @@ pub async fn execute(cmd: ServeCommand, config: CliConfig) -> Result<()> {
         spec_draft,
         spec_tokens,
         gpu_memory_utilization,
+        kv_dtype,
     } = cmd;
 
     // Print banner
@@ -314,6 +322,7 @@ pub async fn execute(cmd: ServeCommand, config: CliConfig) -> Result<()> {
             let mut engine_config = ferrum_engine::simple_engine_config(model_id.clone(), device);
             engine_config.scheduler.policy = ferrum_types::SchedulingPolicy::ContinuousBatch;
             engine_config.kv_cache.cache_type = ferrum_types::KvCacheType::Paged;
+            super::run::apply_kv_dtype_override(&mut engine_config, kv_dtype.as_deref())?;
             let engine: Arc<dyn ferrum_engine::LlmInferenceEngine + Send + Sync> =
                 Arc::from(ferrum_engine::create_default_engine(engine_config).await?);
             AxumServer::from_llm(engine)

--- a/crates/ferrum-types/src/config.rs
+++ b/crates/ferrum-types/src/config.rs
@@ -89,6 +89,12 @@ pub enum SchedulingPolicy {
 pub struct KvCacheConfig {
     /// Cache implementation type
     pub cache_type: KvCacheType,
+    /// Element dtype (Dim 5 polymorphism point). FP16 is the
+    /// validated production path; INT8 / FP8 require a backend impl
+    /// of `BackendKvDtype<KvInt8>` / `BackendKvDtype<KvFp8>` and a
+    /// model wired through `KvCacheQuant<B, K>`.
+    #[serde(default)]
+    pub dtype: KvCacheDtype,
     /// Block size for paged attention
     pub block_size: usize,
     /// Maximum number of blocks
@@ -111,6 +117,7 @@ impl Default for KvCacheConfig {
     fn default() -> Self {
         Self {
             cache_type: KvCacheType::Contiguous,
+            dtype: KvCacheDtype::default(),
             block_size: 16,
             max_blocks: 1024,
             enable_compression: false,
@@ -132,6 +139,53 @@ pub enum KvCacheType {
     Paged,
     /// Tree-based cache for prefix sharing
     Tree,
+}
+
+/// KV Cache element dtype (Dim 5 polymorphism point).
+///
+/// Mirrors `ferrum_interfaces::kv_dtype::KvDtypeKind` markers but
+/// lives here because `KvCacheConfig` is part of the user-facing
+/// `EngineConfig` and needs `Serialize` / `Deserialize`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum KvCacheDtype {
+    /// FP16 K/V — the validated production path on every backend.
+    #[default]
+    Fp16,
+    /// BF16 K/V — same memory cost as FP16, slightly different precision.
+    /// Marker only; no backend impl ships yet.
+    Bf16,
+    /// INT8 K/V with per-token per-kv-head FP16 scale (vLLM-style).
+    /// Halves KV memory at small (<1%) accuracy hit. CUDA kernels
+    /// land via `BackendKvDtype<KvInt8>` (PR #131); model wire-up
+    /// (`KvCacheQuant<B, KvInt8>` through the model decode loop) is
+    /// the only remaining step.
+    Int8,
+    /// FP8 (E4M3) K/V. Marker only; CUDA kernels pending.
+    Fp8,
+}
+
+impl KvCacheDtype {
+    /// Parse from a CLI / env-var string. Accepts fp16/f16/bf16/int8/fp8/f8e4m3.
+    pub fn parse(s: &str) -> Option<Self> {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "fp16" | "f16" | "float16" => Some(Self::Fp16),
+            "bf16" | "bfloat16" => Some(Self::Bf16),
+            "int8" | "i8" => Some(Self::Int8),
+            "fp8" | "f8" | "f8e4m3" | "e4m3" => Some(Self::Fp8),
+            _ => None,
+        }
+    }
+
+    /// Short label for display + telemetry.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Fp16 => "fp16",
+            Self::Bf16 => "bf16",
+            Self::Int8 => "int8",
+            Self::Fp8 => "fp8",
+        }
+    }
 }
 
 /// Memory management configuration


### PR DESCRIPTION
## Summary

Closes the config gap from the post-Dim-5 audit. Kernels + types shipped (#131 / #134 / #135) but no CLI knob existed.

- New \`ferrum_types::config::KvCacheDtype\` enum (Fp16/Bf16/Int8/Fp8) + \`parse()\` helper
- \`KvCacheConfig.dtype\` field (default Fp16, \`#[serde(default)]\` for back-compat)
- \`--kv-dtype DTYPE\` flag on \`run\` / \`serve\` / \`bench\`
- \`FERRUM_KV_DTYPE\` env-var override
- \`apply_kv_dtype_override\` helper: no-ops on default, sets fp16 on explicit fp16, errors helpfully on int8/fp8 (model wire-up pending)

## Test plan
- [x] CPU + Metal compile, 332 metal lib tests pass
- [x] Hand-tested locally on Metal:
  - \`ferrum bench qwen3:0.6b --kv-dtype fp16\` → runs (TPOT 15.95 ms)
  - \`ferrum bench qwen3:0.6b --kv-dtype int8\` → clean error explaining wire-up gap
  - \`ferrum bench qwen3:0.6b --kv-dtype foo\` → "Accepts: fp16, bf16, int8, fp8"

🤖 Generated with [Claude Code](https://claude.com/claude-code)