### PR TITLE
refactor(engine): WeightFormat enum + rename CandleExecutorFactory → LlmExecutorFactory

### DIFF
--- a/crates/ferrum-cli/src/commands/serve.rs
+++ b/crates/ferrum-cli/src/commands/serve.rs
@@ -89,7 +89,7 @@ pub async fn execute(cmd: ServeCommand, config: CliConfig) -> Result<()> {
     // an alias resolving to a GGUF (e.g. `qwen3:8b-q4_k_m`), look up the
     // file in the HF cache (or accept the path) and skip
     // `ConfigManager::load_from_path` (which expects an HF safetensors
-    // directory). The engine's CandleExecutorFactory +
+    // directory). The engine's LlmExecutorFactory +
     // HuggingFaceTokenizerFactory both detect `.gguf` and route to
     // GgufLoader + sibling-tokenizer auto-discovery.
     let cache_dir_for_gguf = get_hf_cache_dir(&config);
@@ -239,7 +239,7 @@ pub async fn execute(cmd: ServeCommand, config: CliConfig) -> Result<()> {
     // Detect architecture to choose engine type. For GGUF we skip
     // ConfigManager::load_from_path (which expects HF safetensors layout)
     // and route directly to the continuous-batching LLM engine — the
-    // engine's CandleExecutorFactory branches to GgufLoader internally.
+    // engine's LlmExecutorFactory uses WeightFormat::detect() to route GGUF.
     println!();
     let arch_for_dispatch: Option<ferrum_models::Architecture> = if gguf_path.is_some() {
         None

--- a/crates/ferrum-engine/src/builder.rs
+++ b/crates/ferrum-engine/src/builder.rs
@@ -191,7 +191,7 @@ impl EngineBuilder {
 
         // If model path is set, try candle executor
         if std::env::var("FERRUM_MODEL_PATH").is_ok() {
-            return "candle".to_string();
+            return "llm".to_string();
         }
 
         "stub".to_string()

--- a/crates/ferrum-engine/src/lib.rs
+++ b/crates/ferrum-engine/src/lib.rs
@@ -90,13 +90,16 @@ pub use builder::{create_engine, EngineBuilder};
 
 // Re-exports of registry
 pub use registry::{
-    global_registry, set_global_registry, CandleExecutorFactory,
-    ComponentConfig, ComponentFactory, ComponentMetadata, ComponentRegistry,
-    ContinuousBatchSchedulerFactory, DefaultKvCacheFactory, FifoSchedulerFactory, GreedySampler,
-    GreedySamplerFactory, HuggingFaceTokenizerFactory, MultinomialSamplerFactory,
-    PagedKvCacheFactory, PrioritySchedulerFactory, StubExecutorFactory, StubTokenizer,
-    StubTokenizerFactory,
+    global_registry, set_global_registry, ComponentConfig, ComponentFactory, ComponentMetadata,
+    ComponentRegistry, ContinuousBatchSchedulerFactory, DefaultKvCacheFactory,
+    FifoSchedulerFactory, GreedySampler, GreedySamplerFactory, HuggingFaceTokenizerFactory,
+    LlmExecutorFactory, MultinomialSamplerFactory, PagedKvCacheFactory, PrioritySchedulerFactory,
+    StubExecutorFactory, StubTokenizer, StubTokenizerFactory,
 };
+
+// Back-compat alias for the renamed factory (PR A).
+#[allow(deprecated)]
+pub use registry::CandleExecutorFactory;
 
 // Re-exports of parallel module
 pub use parallel::{

--- a/crates/ferrum-engine/src/registry.rs
+++ b/crates/ferrum-engine/src/registry.rs
@@ -169,7 +169,7 @@ impl ComponentRegistry {
 
         // Executor factories
         self.register_executor_factory("stub", Arc::new(StubExecutorFactory));
-        self.register_executor_factory("candle", Arc::new(CandleExecutorFactory));
+        self.register_executor_factory("llm", Arc::new(LlmExecutorFactory));
 
         debug!(
             "Registered factories - tokenizers: {:?}, samplers: {:?}, schedulers: {:?}, kv_caches: {:?}, executors: {:?}",
@@ -834,15 +834,33 @@ impl ComponentFactory<Arc<dyn ModelExecutor + Send + Sync>> for StubExecutorFact
 }
 
 /// Candle executor factory
-pub struct CandleExecutorFactory;
+/// Builds a [`ModelExecutor`] from a resolved model path. Despite the
+/// historical "candle" name (PR #127 deleted the legacy `CandleBackend`
+/// trait), this factory now produces real `Backend<B>`-based executors
+/// for LLMs (LlamaFamilyModel / Qwen3MoeModel) and candle-based
+/// executors for embedding / multimodal / ASR (Bert, CLIP, Whisper).
+///
+/// The factory dispatches over Dim 1 (architecture) and Dim 3
+/// (weight format = safetensors vs gguf). Dim 4 (device) and Dim 5 (kv
+/// dtype) currently match by `match config.device { ... }` arms inside
+/// the per-architecture branches; flattening those into a single
+/// `(device, kv_dtype) → build_llm::<B, K>` cascade lands in PR B
+/// alongside the model-side `K: KvDtypeKind` parameter.
+pub struct LlmExecutorFactory;
+
+/// Back-compat alias; retained so external test fixtures referencing
+/// the old name continue to compile while we sweep call sites.
+#[deprecated(note = "use `LlmExecutorFactory` (renamed PR A — Dim 1/3 cleanup)")]
+pub type CandleExecutorFactory = LlmExecutorFactory;
 
 #[async_trait]
-impl ComponentFactory<Arc<dyn ModelExecutor + Send + Sync>> for CandleExecutorFactory {
+impl ComponentFactory<Arc<dyn ModelExecutor + Send + Sync>> for LlmExecutorFactory {
     async fn create(
         &self,
         config: &ComponentConfig,
     ) -> Result<Arc<dyn ModelExecutor + Send + Sync>> {
         use candle_core::{DType, Device as CandleDevice};
+        use ferrum_models::weight_format::WeightFormat;
 
         // Try to load model from path
         let model_path = config
@@ -857,25 +875,34 @@ impl ComponentFactory<Arc<dyn ModelExecutor + Send + Sync>> for CandleExecutorFa
             }
         };
 
-        info!("Loading Candle model from: {}", model_path);
+        // Dim 3 dispatch — peer-level enum (no GGUF special-case at the
+        // top of an architecture cascade). Adding a new format (AWQ /
+        // EXL2 / HQQ) means a new `WeightFormat` variant + a matching
+        // `WeightLoader<B>` impl in `ferrum-quantization`.
+        let weight_fmt = WeightFormat::detect(std::path::Path::new(&model_path))?;
+        info!(
+            "Loading model from {} (format: {})",
+            model_path,
+            weight_fmt.label()
+        );
 
-        // GGUF fast path — `model_path` points directly at a `.gguf` file.
-        // Bypass the safetensors `ConfigManager::load_from_path` (which
-        // expects an HF directory layout) and route through ferrum's own
-        // GgufLoader to build a `LlamaFamilyModel` / `Qwen3MoeModel`. The
-        // resulting `DecoderOnlyLLM` plugs into `LlmExecutor` exactly like
-        // the safetensors path, so the rest of the engine is unchanged.
-        if ferrum_models::gguf_engine_loader::is_gguf_path(&model_path) {
-            info!("  Detected GGUF file — using GgufLoader path");
+        if let WeightFormat::Gguf { ref path } = weight_fmt {
+            // GGUF goes through its own loader — single-file format with
+            // architecture + tokenizer baked in, no separate config.json
+            // step. Output is a `Box<dyn DecoderOnlyLLM>` that plugs into
+            // the same LlmExecutor as the safetensors path, so the rest of
+            // the engine is unchanged.
             let (llm, model_info) = ferrum_models::gguf_engine_loader::load_gguf_decoder_with_info(
-                std::path::Path::new(&model_path),
+                path,
                 &config.device,
                 config.engine_config.model.model_id.clone(),
             )?;
             return Ok(Arc::new(ferrum_models::LlmExecutor::new(llm, model_info)));
         }
 
-        // Load model definition
+        // Safetensors path — re-use ConfigManager to extract Architecture
+        // + dims from `config.json`, then dispatch over Dim 1 (arch) +
+        // Dim 4 (device) below.
         let mut config_manager = ferrum_models::ConfigManager::new();
         let model_def = config_manager
             .load_from_path(std::path::Path::new(&model_path))
@@ -1144,15 +1171,24 @@ impl ComponentFactory<Arc<dyn ModelExecutor + Send + Sync>> for CandleExecutorFa
 
     fn metadata(&self) -> ComponentMetadata {
         ComponentMetadata {
-            name: "candle".to_string(),
-            version: "0.1.0".to_string(),
-            description: "Candle-based model executor".to_string(),
+            name: "llm".to_string(),
+            version: "0.2.0".to_string(),
+            description:
+                "LLM executor (LlamaFamily / Qwen3MoE via Backend<B>; \
+                 BERT / CLIP / Whisper via candle)"
+                    .to_string(),
             supported_devices: cpu_cuda_and_optional_metal_devices(),
             capabilities: vec![
                 "llama".to_string(),
                 "qwen2".to_string(),
                 "qwen3".to_string(),
+                "qwen3_moe".to_string(),
+                "mistral".to_string(),
+                "bert".to_string(),
                 "clip".to_string(),
+                "whisper".to_string(),
+                "safetensors".to_string(),
+                "gguf".to_string(),
                 "fp16".to_string(),
                 "fp32".to_string(),
             ],

--- a/crates/ferrum-models/src/lib.rs
+++ b/crates/ferrum-models/src/lib.rs
@@ -35,6 +35,7 @@ pub mod registry;
 pub mod source;
 pub mod tensor_wrapper;
 pub mod tokenizer;
+pub mod weight_format;
 
 pub use architectures::{BertModelWrapper, ClipModelWrapper, WhisperModelWrapper};
 pub use common::{DecoderOnlyLLM, LlmRuntimeConfig};

--- a/crates/ferrum-models/src/weight_format.rs
+++ b/crates/ferrum-models/src/weight_format.rs
@@ -1,0 +1,120 @@
+//! Dim 3 polymorphism point — weight-format detection for the executor
+//! factory.
+//!
+//! Sibling of `source::ModelFormat`. The difference:
+//!
+//! - [`source::ModelFormat`](crate::source::ModelFormat) is a "what kind
+//!   of files did we just download" hint used for cache classification
+//!   and progress bars. It carries no path.
+//! - [`WeightFormat`] is a "loader recipe" — it carries the resolved
+//!   path AND tells the executor factory which `WeightLoader<B>` to
+//!   instantiate. New formats (AWQ, EXL2, HQQ, ...) plug in by adding a
+//!   variant + a `WeightLoader<B>` impl in `ferrum-quantization`, with
+//!   no special-casing in `LlmExecutorFactory`.
+//!
+//! Replaces the `is_gguf_path` short-circuit in
+//! `ferrum-engine::registry::CandleExecutorFactory` with a real
+//! polymorphism point matching the 5-dim architecture (see
+//! `docs/architecture-refactor-status.md`).
+
+use ferrum_types::{FerrumError, Result};
+use std::path::{Path, PathBuf};
+
+/// Resolved weight format + path. Produced by [`WeightFormat::detect`]
+/// from a user-supplied path (HF cache snapshot, local dir, or a
+/// `.gguf` file).
+#[derive(Debug, Clone)]
+pub enum WeightFormat {
+    /// HuggingFace safetensors directory: `config.json` + one or more
+    /// `.safetensors` shards. The on-disk weights may be plain FP16/BF16
+    /// **or** GPTQ-Int4 (`<name>.qweight` tensors); this is decided
+    /// per-tensor by `NativeSafetensorsLoader::load_linear`.
+    Safetensors { dir: PathBuf },
+
+    /// GGUF single-file format (Llama-family / Qwen3-MoE quantized).
+    /// Loaded by `ferrum_quantization::gguf::GgufLoader`.
+    Gguf { path: PathBuf },
+    // Future: Awq { dir }, Exl2 { dir }, Hqq { dir } …
+}
+
+impl WeightFormat {
+    /// Detect the weight format from a user-supplied path.
+    ///
+    /// - If `path` is a file ending in `.gguf` (case-insensitive)
+    ///   → [`WeightFormat::Gguf`].
+    /// - If `path` is a directory containing `config.json`
+    ///   → [`WeightFormat::Safetensors`].
+    /// - Anything else returns a model error.
+    pub fn detect(path: &Path) -> Result<Self> {
+        if path.is_file()
+            && path
+                .extension()
+                .map(|e| e.eq_ignore_ascii_case("gguf"))
+                .unwrap_or(false)
+        {
+            return Ok(Self::Gguf {
+                path: path.to_owned(),
+            });
+        }
+        if path.is_dir() && path.join("config.json").is_file() {
+            return Ok(Self::Safetensors {
+                dir: path.to_owned(),
+            });
+        }
+        Err(FerrumError::model(format!(
+            "Unrecognized weight format at {}: expected a `.gguf` file or \
+             a HuggingFace safetensors directory containing `config.json`.",
+            path.display()
+        )))
+    }
+
+    /// The on-disk path this format resolved to.
+    pub fn path(&self) -> &Path {
+        match self {
+            Self::Safetensors { dir } => dir,
+            Self::Gguf { path } => path,
+        }
+    }
+
+    /// Short label for logs / telemetry.
+    pub fn label(&self) -> &'static str {
+        match self {
+            Self::Safetensors { .. } => "safetensors",
+            Self::Gguf { .. } => "gguf",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn detect_gguf_by_extension() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("Qwen3-0.6B-Q4_K_M.gguf");
+        fs::write(&path, b"GGUF\0\0\0\0").unwrap();
+        let fmt = WeightFormat::detect(&path).unwrap();
+        assert!(matches!(fmt, WeightFormat::Gguf { .. }));
+        assert_eq!(fmt.label(), "gguf");
+    }
+
+    #[test]
+    fn detect_safetensors_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("config.json"), b"{}").unwrap();
+        let fmt = WeightFormat::detect(dir.path()).unwrap();
+        assert!(matches!(fmt, WeightFormat::Safetensors { .. }));
+        assert_eq!(fmt.label(), "safetensors");
+    }
+
+    #[test]
+    fn detect_unknown_returns_error() {
+        let dir = tempfile::tempdir().unwrap();
+        // Empty dir, no config.json, not a .gguf file.
+        let err = WeightFormat::detect(dir.path()).unwrap_err();
+        let msg = format!("{}", err);
+        assert!(msg.contains("Unrecognized weight format"), "{msg}");
+    }
+}


### PR DESCRIPTION
## Summary

Closes the post-audit issue where Dim 3 (weight format) was a hardcoded \`is_gguf_path()\` short-circuit at the top of the architecture cascade, mis-leveling it relative to the other 4 dims. Also fixes the stale \`Candle\` name on the executor factory (after PR #127 deleted the \`CandleBackend\` trait, the LLM hot path no longer uses candle).

### Changes

**New:**
- \`ferrum_models::weight_format::WeightFormat\` enum with \`detect()\`:
  - \`Safetensors { dir }\` — HF directory with \`config.json\`
  - \`Gguf { path }\` — single \`.gguf\` file
  - Future formats (AWQ / EXL2 / HQQ) plug in by adding a variant + a \`WeightLoader<B>\` impl in \`ferrum-quantization\` — no special-case in the executor factory.
- 3 unit tests covering gguf / safetensors / unknown detection paths.

**Renames:**
- \`CandleExecutorFactory\` → \`LlmExecutorFactory\` (old name = stale)
- Registry key \`"candle"\` → \`"llm"\` (\`EngineBuilder::resolve_executor_name\` updated)
- \`pub type CandleExecutorFactory = LlmExecutorFactory\` alias kept as \`#[deprecated]\` back-compat

**Refactor:**
- \`is_gguf_path\` short-circuit replaced by \`WeightFormat::detect()\` → \`if let Gguf {..}\` arm
- Log line now reads \`Loading model from <path> (format: safetensors|gguf)\`

### NOT in this PR (deferred to PR B)

The flat \`(device, kv_dtype) → build_llm::<B, K>(...)\` cascade. That requires generic-ing models on \`K: KvDtypeKind\` and lands alongside the Dim 5 model wire-up.

## Test plan

- [x] \`cargo check --workspace --all-targets\` passes (CPU + metal)
- [x] \`cargo test --workspace --features metal --lib\`: **335** passed / 0 failed (3 new weight_format tests added; previous 332 unchanged)
- [x] Metal smoke bench Qwen3-0.6B: **59.8 tok/s** (vs 60.3 baseline = -0.8%, within noise floor)
- [x] Log output verified: \`Loading model from <path> (format: safetensors)\` → \`Architecture: Qwen3, Layers: 28, Vocab: 151936\` — Dim 3 then Dim 1, in order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)