### PR TITLE
perf(int8-attn): preload k/v scales to shmem (modest INT8 decode speedup)

### DIFF
--- a/crates/ferrum-kernels/kernels/int8_paged_decode_attention.cu
+++ b/crates/ferrum-kernels/kernels/int8_paged_decode_attention.cu
@@ -55,7 +55,35 @@ extern "C" __global__ void paged_decode_attention_int8(
     const __half* q_ptr = q + q_head * head_dim;
     __half* out_ptr = output + q_head * head_dim;
 
-    extern __shared__ float s_scores[];
+    // Dynamic shmem layout (caller allocates 3 × valid_kv_len floats):
+    //   [0 .. valid_kv_len)             — s_scores  (Q·K^T → softmax → weights)
+    //   [valid_kv_len .. 2*valid_kv_len) — s_k_scales (per-(token, kv_head) FP16 scale, broadcast across head_dim threads in Step 1)
+    //   [2*valid_kv_len .. 3*valid_kv_len) — s_v_scales (same broadcast pattern in Step 3)
+    //
+    // Why preload scales: Step 3 has 256 threads × valid_kv_len global
+    // loads of `v_scales_pool[scale_offset]` — same value across the
+    // 256 threads of a (q_head, kv_head) block. With shmem cache the
+    // 256-way broadcast collapses into 1 shmem read per kv_pos. Step 1
+    // sees a similar (smaller) win.
+    extern __shared__ float s_dyn[];
+    float* s_scores   = s_dyn;
+    float* s_k_scales = s_dyn + valid_kv_len;
+    float* s_v_scales = s_dyn + 2 * valid_kv_len;
+
+    // Block-cooperative prologue: one-shot load of all per-(token, kv_head)
+    // K/V scales into shmem. The (kv_head) component is the same for the
+    // whole block — only the (token) varies — so we need one load per
+    // kv_pos. Coalesces well: consecutive threads load consecutive kv_pos.
+    for (int kv_pos = threadIdx.x; kv_pos < valid_kv_len; kv_pos += blockDim.x) {
+        int logical_block  = kv_pos / block_size;
+        int slot           = kv_pos % block_size;
+        int physical_block = block_table[logical_block];
+        int scale_offset   = physical_block * scale_block_stride
+                           + slot * scale_kv_stride
+                           + kv_head;
+        s_k_scales[kv_pos] = __half2float(k_scales_pool[scale_offset]);
+        s_v_scales[kv_pos] = __half2float(v_scales_pool[scale_offset]);
+    }
 
     // Load Q into registers (warp-cooperative).
     const int elems_per_thread = (head_dim + WARP_SIZE - 1) / WARP_SIZE;
@@ -70,6 +98,7 @@ extern "C" __global__ void paged_decode_attention_int8(
     int warp_id = threadIdx.x / WARP_SIZE;
     int lane_id = threadIdx.x % WARP_SIZE;
     int num_warps = blockDim.x / WARP_SIZE;
+    __syncthreads();  // wait for s_k_scales / s_v_scales to be visible
 
     // ====== Step 1: Q·K^T (dequantizing K on the fly) ======
     for (int kv_pos = warp_id; kv_pos < valid_kv_len; kv_pos += num_warps) {
@@ -81,11 +110,7 @@ extern "C" __global__ void paged_decode_attention_int8(
             + physical_block * block_stride
             + slot * kv_stride
             + kv_head * head_dim;
-        const __half k_scale_h = k_scales_pool[
-            physical_block * scale_block_stride
-            + slot * scale_kv_stride
-            + kv_head];
-        const float k_scale = __half2float(k_scale_h);
+        const float k_scale = s_k_scales[kv_pos];  // shmem read (was per-warp global)
 
         float dot = 0.0f;
         #pragma unroll
@@ -132,6 +157,16 @@ extern "C" __global__ void paged_decode_attention_int8(
     __syncthreads();
 
     // ====== Step 3: Weighted V sum (dequantizing V on the fly) ======
+    // Pre-fold v_scale into the score: weight[kv_pos] = s_scores[kv_pos] * s_v_scales[kv_pos].
+    // This collapses Step 3's inner-loop ops to (1 shmem + 1 INT8 load + 1 cast + 1 fma)
+    // vs the original (1 shmem + 1 global v_scale + 1 cast + 2 fma + scalar mul).
+    // The fold uses s_scores in-place — safe because no thread re-reads
+    // the un-folded values after Step 2's softmax.
+    for (int kv_pos = threadIdx.x; kv_pos < valid_kv_len; kv_pos += blockDim.x) {
+        s_scores[kv_pos] *= s_v_scales[kv_pos];
+    }
+    __syncthreads();
+
     for (int d = threadIdx.x; d < head_dim; d += blockDim.x) {
         float acc = 0.0f;
         for (int kv_pos = 0; kv_pos < valid_kv_len; kv_pos++) {
@@ -143,13 +178,8 @@ extern "C" __global__ void paged_decode_attention_int8(
                 + physical_block * block_stride
                 + slot * kv_stride
                 + kv_head * head_dim;
-            const __half v_scale_h = v_scales_pool[
-                physical_block * scale_block_stride
-                + slot * scale_kv_stride
-                + kv_head];
-            const float v_scale = __half2float(v_scale_h);
 
-            acc += s_scores[kv_pos] * v_scale * (float)v_row[d];
+            acc += s_scores[kv_pos] * (float)v_row[d];
         }
         out_ptr[d] = __float2half(acc);
     }

--- a/crates/ferrum-kernels/src/int8_kv.rs
+++ b/crates/ferrum-kernels/src/int8_kv.rs
@@ -75,7 +75,11 @@ pub fn launch_int8_paged_decode_attention(
     b.arg(&bs);
     b.arg(&scale);
 
-    let shared_bytes = (valid_kv_len as u32) * 4;
+    // Dynamic shmem: 3 × valid_kv_len × sizeof(float)
+    //   s_scores   (Q·K^T → softmax → folded weight)
+    //   s_k_scales (preloaded for Step 1)
+    //   s_v_scales (preloaded for Step 3, folded into s_scores)
+    let shared_bytes = (valid_kv_len as u32) * 12;
     let cfg = LaunchConfig {
         grid_dim: (num_q_heads as u32, 1, 1),
         block_dim: (256, 1, 1),


### PR DESCRIPTION
## Summary

INT8 `paged_decode_attention.cu` had two redundant global-memory broadcast loads per kv_pos (`k_scale_pool[scale_offset]` per warp in Step 1; `v_scale_pool[scale_offset]` per thread per kv_pos in Step 3 — 256-way broadcast). This PR preloads both into shared memory in a one-shot block-cooperative prologue, and folds `v_scale` into the softmax weight in-place after Step 2 so Step 3's inner loop drops to one shmem read per (d, kv_pos) plus the INT8 load.

Caller (`launch_int8_paged_decode_attention`) now allocates `3 × valid_kv_len × sizeof(float)` shmem (was 1×). Fits comfortably in the 100KB-per-block budget on RTX 4090 for `valid_kv_len ≤ 8192`.

## Validation

- Numerical parity preserved: 4/4 ignored tests pass (`int8_paged_decode_parity_vs_host_ref`, `int8_kv_append_roundtrip`, `int8_kv_append_then_decode_e2e`, `kv_cache_quant_int8_e2e`) — cosine 0.99999 vs FP32 host ref unchanged.
- `cargo check --workspace --all-targets --features metal` ✅

CUDA bench RTX 4090, 256-token decode (kv_len long enough to expose the broadcast load):

| Model | KV | main TPOT | branch TPOT | Δ |
|---|---|---|---|---|
| Qwen3-0.6B | INT8 | 24.72ms (n=2 avg) | **22.82ms (n=2 avg)** | **-7.7%** ✅ |
| Llama-3.1-8B | INT8 | 25.84ms (n=4, σ=1.21) | 24.30ms (n=1) | -6.0% (single-sample, within noise band) |

## Plan acceptance #3 — INT8 TPOT within 5% of FP16: still open

This PR closes some of the gap but doesn't reach the target:

| Model | FP16 TPOT (256 tok) | INT8 (after this PR) | gap |
|---|---|---|---|
| Qwen3-0.6B | 12.30ms | 22.82ms | 86% slower |
| Llama-3.1-8B | 16.31ms | ~24-26ms | ~50% slower |

The 2x INT8/FP16 gap on single-token decode is **architectural**: every element on the read path needs dequant (INT8 → float, multiply by per-token scale), which adds compute the FP16 path doesn't pay. Closing the gap to 5% needs a flash-attention-style rewrite (tile-fused QK^T + softmax + V to keep dequant inside register tiles, drop the shmem `s_scores` round-trip, etc.) — that's a 2-3 week kernel project, out of scope here.

INT8 KV's real value proposition stays the **memory** axis: 50% smaller KV cache → fits longer context / more concurrent seqs in the same VRAM. The TPOT math improves at long context where memory bandwidth dominates compute (decode kv_len > ~2048).

🤖 Generated with [Claude Code](https://claude.com/claude-code)