### PR TITLE
refactor(config): drop simple_engine_config — fold defaults into EngineConfig::default()

### DIFF
--- a/crates/ferrum-cli/src/commands/bench.rs
+++ b/crates/ferrum-cli/src/commands/bench.rs
@@ -151,7 +151,9 @@ pub async fn execute(cmd: BenchCommand, config: CliConfig) -> Result<()> {
 
     // Create engine with ContinuousBatch scheduler (not Priority).
     // DefaultInferenceEngine (Priority) has stream lifecycle issues with bench.
-    let mut engine_config = ferrum_engine::simple_engine_config(model_id.clone(), device);
+    let mut engine_config = ferrum_types::EngineConfig::default();
+    engine_config.model.model_id = ferrum_types::ModelId::new(model_id.clone());
+    engine_config.backend.device = device;
     engine_config.scheduler.policy = ferrum_types::SchedulingPolicy::ContinuousBatch;
     super::run::apply_kv_dtype_override(&mut engine_config, cmd.kv_dtype.as_deref())?;
     let engine = ferrum_engine::create_default_engine(engine_config).await?;

--- a/crates/ferrum-cli/src/commands/run.rs
+++ b/crates/ferrum-cli/src/commands/run.rs
@@ -146,7 +146,9 @@ pub async fn execute(cmd: RunCommand, config: CliConfig) -> Result<()> {
         "Loading weights to GPU... (30s+ for >10 GB models)".dimmed()
     );
     let load_start = std::time::Instant::now();
-    let mut engine_config = ferrum_engine::simple_engine_config(model_id.clone(), device);
+    let mut engine_config = ferrum_types::EngineConfig::default();
+    engine_config.model.model_id = ferrum_types::ModelId::new(model_id.clone());
+    engine_config.backend.device = device;
     apply_kv_dtype_override(&mut engine_config, cmd.kv_dtype.as_deref())?;
     let engine = ferrum_engine::create_default_engine(engine_config).await?;
     eprintln!(

--- a/crates/ferrum-cli/src/commands/serve.rs
+++ b/crates/ferrum-cli/src/commands/serve.rs
@@ -259,7 +259,9 @@ pub async fn execute(cmd: ServeCommand, config: CliConfig) -> Result<()> {
                 candle_core::DType::F32,
             )?;
             let tokenizer = crate::commands::embed::load_tokenizer(&source.local_path)?;
-            let engine_config = ferrum_engine::simple_engine_config(model_id.clone(), device);
+            let mut engine_config = ferrum_types::EngineConfig::default();
+            engine_config.model.model_id = ferrum_types::ModelId::new(model_id.clone());
+            engine_config.backend.device = device;
             let engine: Arc<dyn ferrum_engine::EmbedEngine + Send + Sync> = Arc::new(
                 ferrum_engine::embedding_engine::EmbeddingEngine::new(executor, engine_config)
                     .with_tokenizer(tokenizer),
@@ -274,7 +276,9 @@ pub async fn execute(cmd: ServeCommand, config: CliConfig) -> Result<()> {
                 candle_device,
                 candle_core::DType::F32,
             )?;
-            let engine_config = ferrum_engine::simple_engine_config(model_id.clone(), device);
+            let mut engine_config = ferrum_types::EngineConfig::default();
+            engine_config.model.model_id = ferrum_types::ModelId::new(model_id.clone());
+            engine_config.backend.device = device;
             let engine: Arc<dyn ferrum_engine::TranscribeEngine + Send + Sync> = Arc::new(
                 ferrum_engine::transcription_engine::TranscriptionEngine::new(
                     executor,
@@ -319,7 +323,9 @@ pub async fn execute(cmd: ServeCommand, config: CliConfig) -> Result<()> {
                 "{}",
                 "Initializing engine (continuous batching)...".dimmed()
             );
-            let mut engine_config = ferrum_engine::simple_engine_config(model_id.clone(), device);
+            let mut engine_config = ferrum_types::EngineConfig::default();
+            engine_config.model.model_id = ferrum_types::ModelId::new(model_id.clone());
+            engine_config.backend.device = device;
             engine_config.scheduler.policy = ferrum_types::SchedulingPolicy::ContinuousBatch;
             engine_config.kv_cache.cache_type = ferrum_types::KvCacheType::Paged;
             super::run::apply_kv_dtype_override(&mut engine_config, kv_dtype.as_deref())?;

--- a/crates/ferrum-engine/src/lib.rs
+++ b/crates/ferrum-engine/src/lib.rs
@@ -117,33 +117,6 @@ pub async fn create_default_engine(
     create_engine(config).await
 }
 
-/// Create a simple engine config from minimal parameters
-pub fn simple_engine_config(
-    model_id: impl Into<ferrum_types::ModelId>,
-    device: ferrum_types::Device,
-) -> EngineConfig {
-    use ferrum_types::*;
-
-    let mut config = EngineConfig::default();
-    config.model.model_id = model_id.into();
-    config.backend.device = device;
-
-    // Set reasonable defaults for MVP
-    config.batching.max_batch_size = 32;
-    config.kv_cache.block_size = 16;
-    // Default 2048 blocks: covers c=32 ShareGPT prompts (~32×500/16
-    // = 1000 blocks). The previous 512 floor crashed at c≥16 on real
-    // workloads with "Block pool exhausted". Override via
-    // FERRUM_KV_MAX_BLOCKS for tighter memory budgets.
-    config.kv_cache.max_blocks = std::env::var("FERRUM_KV_MAX_BLOCKS")
-        .ok()
-        .and_then(|v| v.parse::<usize>().ok())
-        .unwrap_or(2048);
-    config.scheduler.max_running_requests = 32;
-
-    config
-}
-
 // ============================================================================
 // Integration Tests
 // ============================================================================
@@ -152,11 +125,16 @@ pub fn simple_engine_config(
 mod integration_tests {
     use super::*;
 
+    fn test_config() -> EngineConfig {
+        let mut config = EngineConfig::default();
+        config.model.model_id = ferrum_types::ModelId::new("test-model");
+        config.backend.device = ferrum_types::Device::CPU;
+        config
+    }
+
     #[tokio::test]
     async fn test_create_engine_via_builder() {
-        let config = simple_engine_config("test-model", ferrum_types::Device::CPU);
-
-        let engine = EngineBuilder::new(config)
+        let engine = EngineBuilder::new(test_config())
             .with_tokenizer("stub")
             .with_executor("stub")
             .build()
@@ -167,8 +145,7 @@ mod integration_tests {
 
     #[tokio::test]
     async fn test_create_engine_convenience() {
-        let config = simple_engine_config("test-model", ferrum_types::Device::CPU);
-        let engine = create_default_engine(config).await;
+        let engine = create_default_engine(test_config()).await;
 
         assert!(engine.is_ok());
     }

--- a/crates/ferrum-engine/src/tts_engine.rs
+++ b/crates/ferrum-engine/src/tts_engine.rs
@@ -31,7 +31,9 @@ impl TtsService {
     /// Create with a single executor (backward compatible).
     pub fn new(executor: TtsModelExecutor, model_id: ModelId) -> Self {
         let sr = executor.sample_rate() as u32;
-        let config = crate::simple_engine_config(model_id, ferrum_types::Device::CPU);
+        let mut config = ferrum_types::EngineConfig::default();
+        config.model.model_id = model_id;
+        config.backend.device = ferrum_types::Device::CPU;
         Self {
             slots: vec![Arc::new(Mutex::new(executor))],
             semaphore: tokio::sync::Semaphore::new(1),
@@ -48,7 +50,9 @@ impl TtsService {
             .first()
             .map(|e| e.sample_rate() as u32)
             .unwrap_or(24000);
-        let config = crate::simple_engine_config(model_id, ferrum_types::Device::CPU);
+        let mut config = ferrum_types::EngineConfig::default();
+        config.model.model_id = model_id;
+        config.backend.device = ferrum_types::Device::CPU;
         let slots: Vec<_> = executors
             .into_iter()
             .map(|e| Arc::new(Mutex::new(e)))

--- a/crates/ferrum-engine/tests/qwen_concurrency.rs
+++ b/crates/ferrum-engine/tests/qwen_concurrency.rs
@@ -1,6 +1,6 @@
-use ferrum_engine::{create_default_engine, simple_engine_config};
+use ferrum_engine::create_default_engine;
 use ferrum_interfaces::engine::LlmInferenceEngine;
-use ferrum_types::{Device, InferenceRequest, SamplingParams};
+use ferrum_types::{Device, EngineConfig, InferenceRequest, ModelId, SamplingParams};
 use std::{path::Path, sync::Arc, time::Duration};
 
 const DEFAULT_QWEN_05B_PATH: &str = "/Users/chejinxuan/.cache/huggingface/hub/models--Qwen--Qwen2.5-0.5B-Instruct/snapshots/7ae557604adf67be50417f59c2c2f167def9a775";
@@ -25,7 +25,9 @@ async fn qwen_25_05b_requests_are_serialized_for_correctness() {
         std::env::set_var("FERRUM_MODEL_PATH", &model_path);
     }
 
-    let mut config = simple_engine_config(QWEN_MODEL_ID, Device::CPU);
+    let mut config = EngineConfig::default();
+    config.model.model_id = ModelId::new(QWEN_MODEL_ID);
+    config.backend.device = Device::CPU;
     config.scheduler.max_running_requests = 4;
 
     let engine: Arc<dyn LlmInferenceEngine + Send + Sync> =

--- a/crates/ferrum-types/src/config.rs
+++ b/crates/ferrum-types/src/config.rs
@@ -58,7 +58,7 @@ impl Default for SchedulerConfig {
         Self {
             policy: SchedulingPolicy::Priority,
             max_waiting_requests: 1000,
-            max_running_requests: 256,
+            max_running_requests: 32,
             enable_preemption: true,
             enable_load_balancing: false,
             fair_share_weights: HashMap::new(),
@@ -115,11 +115,21 @@ pub struct KvCacheConfig {
 
 impl Default for KvCacheConfig {
     fn default() -> Self {
+        // 2048 blocks covers c=32 ShareGPT prompts (~32×500/16 = 1000
+        // blocks). The previous 1024 floor crashed at c≥16 on real
+        // workloads with "Block pool exhausted". `FERRUM_KV_MAX_BLOCKS`
+        // is set by the GPU autosizer (`ferrum-cli::gpu_mem_autosize`)
+        // before engine construction; honour it here so the autosizer
+        // is the single source of truth for memory-budgeted runs.
+        let max_blocks = std::env::var("FERRUM_KV_MAX_BLOCKS")
+            .ok()
+            .and_then(|v| v.parse::<usize>().ok())
+            .unwrap_or(2048);
         Self {
             cache_type: KvCacheType::Contiguous,
             dtype: KvCacheDtype::default(),
             block_size: 16,
-            max_blocks: 1024,
+            max_blocks,
             enable_compression: false,
             compression_ratio: 0.5,
             enable_multi_level: true,
@@ -433,7 +443,7 @@ pub struct BatchConfig {
 impl Default for BatchConfig {
     fn default() -> Self {
         Self {
-            max_batch_size: 16,
+            max_batch_size: 32,
             max_wait_ms: 8,
             enable_dynamic: true,
             enable_continuous: false,


### PR DESCRIPTION
## Summary

`simple_engine_config` was the SOLE config builder for `bench`/`run`/`serve`/`tts_engine`/concurrency-test, but its name suggested a stripped-down variant alongside an imaginary "production_engine_config" that never existed. The four hardcoded "MVP defaults" it layered on top of `EngineConfig::default()` were actually the production values, leaving `EngineConfig::default()` itself producing a different (smaller) config that nobody used end-to-end.

Fold the MVP defaults into the per-section `Default` impls so there's one entry point and `Default` matches what production runs:

  - `BatchConfig::default().max_batch_size`: 16 → 32
  - `KvCacheConfig::default().max_blocks`: 1024 → 2048 (or `FERRUM_KV_MAX_BLOCKS`, set by the GPU autosizer)
  - `SchedulerConfig::default().max_running_requests`: 256 → 32

Delete `simple_engine_config`. All 7 callers (3 CLI commands, 2 TtsService constructors, qwen concurrency test, lib unit tests) now construct via `EngineConfig::default()` + 2 field assignments. Same behaviour, no second entry point, and `Default` is now the truth.

`FERRUM_KV_MAX_BLOCKS` env-var read moved into `KvCacheConfig::default()` itself — the autosizer (`gpu_mem_autosize`) populates it before engine build, so `Default` becoming env-aware preserves the existing producer/consumer pair without a separate `apply_overrides` step.

Same code-smell category as `run_gguf_one_shot` (PR #145): a misleading-name single entry point with magic constants in the body.

## Test plan
- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo test --workspace --no-default-features` — all suites pass on Mac (config_tests, models_tests, builder defaults, engine integration)
- [x] `cargo build --features cuda --release -p ferrum-cli --bin ferrum` clean (4m 39s on RTX 4090)
- [x] Smoke bench Qwen3-0.6B FP16 on RTX 4090: **81.9 tok/s avg / TPOT 12.12ms** — identical to Phase 4 (#151) baseline; defaults change is behaviour-neutral

🤖 Generated with [Claude Code](https://claude.com/claude-code)