### PR TITLE
fix(models): re-init paged_batch_* scratch after ensure_scratch realloc

### DIFF
--- a/bench/v0.2-cuda/m3_phase_a.sh
+++ b/bench/v0.2-cuda/m3_phase_a.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# Phase A baseline — Qwen3-30B-A3B-GPTQ-Int4 on current main (post #148-#153
+# cuda/mod.rs split + simple_engine_config drop). Uses ferrum bench (not
+# vllm bench serve) to avoid requiring vllm install on the pod; numbers
+# are self-comparable to future Phase B/C/D runs but not directly to
+# PR #102's `vllm bench serve` numbers (different harness).
+#
+# Goal: confirm we haven't regressed at c=1/4/16/32 and lock in a starting
+# line for the "close-vLLM-gap-to-80%" perf push.
+
+set -uo pipefail
+
+WORKSPACE="${WORKSPACE:-/workspace}"
+HF_HOME="${HF_HOME:-$WORKSPACE/.hf_home}"
+MODEL_SNAP_DIR="$HF_HOME/hub/models--Qwen--Qwen3-30B-A3B-GPTQ-Int4/snapshots"
+MODEL_DIR="$MODEL_SNAP_DIR/$(ls "$MODEL_SNAP_DIR" 2>/dev/null | head -1)"
+RESULTS_DIR="$WORKSPACE/ferrum-infer-rs/bench/v0.2-cuda/results_phase_a_$(date +%Y%m%d_%H%M%S)"
+mkdir -p "$RESULTS_DIR"
+
+if [[ ! -f "$MODEL_DIR/config.json" ]]; then
+  echo "ERROR: Qwen3-30B-A3B-GPTQ-Int4 not found at $MODEL_DIR" >&2
+  exit 1
+fi
+
+GIT_HEAD=$(git -C "$WORKSPACE/ferrum-infer-rs" rev-parse --short HEAD)
+echo "=== Phase A baseline @ $GIT_HEAD ===" | tee "$RESULTS_DIR/summary.txt"
+nvidia-smi --query-gpu=name,memory.free --format=csv,noheader | tee -a "$RESULTS_DIR/summary.txt"
+echo "Model: $MODEL_DIR" | tee -a "$RESULTS_DIR/summary.txt"
+echo "" | tee -a "$RESULTS_DIR/summary.txt"
+
+# Same env as m3_clean.sh PR #102 baseline.
+COMMON_ENV=(
+  CUDA_VISIBLE_DEVICES=0
+  FERRUM_VLLM_MOE=1
+  FERRUM_KV_CAPACITY=2048
+  FERRUM_KV_MAX_BLOCKS=4096
+  FERRUM_PAGED_MAX_SEQS=32
+  FERRUM_METAL_PAGED_KV=1
+  FERRUM_MIXED_BATCH=0
+  FERRUM_GREEDY_ARGMAX=1
+  FERRUM_MOE_BUCKETED=1
+  FERRUM_MARLIN_SKIP_WS_ZERO=1
+  FERRUM_MOE_STREAMS=4
+)
+
+for c in 1 4 16 32; do
+  echo "--- c=$c ---" | tee -a "$RESULTS_DIR/summary.txt"
+  env "${COMMON_ENV[@]}" \
+    timeout 600 "$WORKSPACE/ferrum-infer-rs/target/release/ferrum" bench \
+      "$MODEL_DIR" --concurrency "$c" --max-tokens 128 --rounds 3 \
+      2>&1 | tee "$RESULTS_DIR/c${c}.log"
+  echo "" | tee -a "$RESULTS_DIR/summary.txt"
+done
+
+echo "" | tee -a "$RESULTS_DIR/summary.txt"
+echo "=== Phase A summary ===" | tee -a "$RESULTS_DIR/summary.txt"
+for c in 1 4 16 32; do
+  line=$(grep -E "Throughput \(e2e\):" "$RESULTS_DIR/c${c}.log" | head -1)
+  tpot=$(grep -E "TPOT:" "$RESULTS_DIR/c${c}.log" | head -1)
+  ttft=$(grep -E "TTFT:" "$RESULTS_DIR/c${c}.log" | head -1)
+  echo "c=$c  $line  $tpot  $ttft" | tee -a "$RESULTS_DIR/summary.txt"
+done

--- a/crates/ferrum-models/src/models/llama_family.rs
+++ b/crates/ferrum-models/src/models/llama_family.rs
@@ -533,6 +533,12 @@ pub struct LlamaFamilyModel<B: MoeLlmBackend, K: KvLayer<B> = KvFp16> {
     /// `Mutex` because the engine can call `ensure_kv` / `release_kv`
     /// from multiple threads in concurrent serving.
     pub paged_block_alloc: Option<std::sync::Mutex<crate::common::paged_pool::BlockAllocator>>,
+    /// Paged-batch dispatch dimensions `(max_seqs, max_blocks_per_seq)`,
+    /// pinned at the first `ensure_kv` when paged-KV is on. Stored on
+    /// the model (not on scratch) so `ensure_scratch`'s realloc can
+    /// re-call `enable_paged_batch` after wiping scratch's
+    /// `paged_batch_block_tables` / `paged_batch_q` etc.
+    pub paged_dims: Option<(usize, usize)>,
 
     // ── Graph capture state (CUDA only; harmless no-op on other backends) ──
     /// Count of eager decode steps run so far. After `GRAPH_WARMUP`, the
@@ -664,6 +670,7 @@ impl<B: MoeLlmBackend, K: KvLayer<B>> LlamaFamilyModel<B, K> {
             kv_free_pool: Vec::new(),
             paged_pools: None,
             paged_block_alloc: None,
+            paged_dims: None,
             graph_warmup: 0,
             graph_capture_failed: false,
             batched_graph_warmup: 0,
@@ -747,6 +754,7 @@ impl<B: MoeLlmBackend, K: KvLayer<B>> LlamaFamilyModel<B, K> {
             kv_free_pool: Vec::new(),
             paged_pools: None,
             paged_block_alloc: None,
+            paged_dims: None,
             graph_warmup: 0,
             graph_capture_failed: false,
             batched_graph_warmup: 0,
@@ -779,6 +787,14 @@ impl<B: MoeLlmBackend, K: KvLayer<B>> LlamaFamilyModel<B, K> {
             self.unified_graph_keys_seen.clear();
             self.unified_graph_warmup = 0;
             self.unified_graph_failed = false;
+            // Realloc wiped paged_batch_*. Re-enable using the dims
+            // pinned at first ensure_kv. Without this, the next
+            // `forward_layer_batched_decode` panics on
+            // `paged_batch_block_tables missing`.
+            if let Some((max_seqs, max_blocks_per_seq)) = self.paged_dims {
+                self.scratch
+                    .enable_paged_batch(&self.cfg, max_seqs, max_blocks_per_seq);
+            }
         }
     }
 
@@ -872,6 +888,9 @@ impl<B: MoeLlmBackend, K: KvLayer<B>> LlamaFamilyModel<B, K> {
         if paged {
             self.scratch
                 .enable_paged_batch(&self.cfg, max_seqs, max_blocks_per_seq);
+            // Pin dims on the model so `ensure_scratch`'s realloc can
+            // re-init paged_batch_* after wiping scratch.
+            self.paged_dims = Some((max_seqs, max_blocks_per_seq));
         }
 
         // Try pool first — reused buffers have stable device pointers,

--- a/crates/ferrum-models/src/models/qwen3_moe.rs
+++ b/crates/ferrum-models/src/models/qwen3_moe.rs
@@ -412,6 +412,14 @@ pub struct Qwen3MoeModel<B: MoeLlmBackend, K: KvDtypeKind = KvFp16> {
     // views (block_table + context_lens) into the shared `paged_pools`.
     pub paged_pools: Option<Vec<(B::Buffer, B::Buffer)>>,
     pub paged_block_alloc: Option<std::sync::Mutex<crate::common::paged_pool::BlockAllocator>>,
+    // Paged-batch dispatch dimensions. Pinned at the first `ensure_kv`
+    // when paged-KV is on. Stored on the model (not on scratch) so
+    // `ensure_scratch`'s realloc — which wipes scratch's
+    // `paged_batch_block_tables`/`paged_batch_q`/etc. — can re-call
+    // `enable_paged_batch` with the same dims afterwards. Without this
+    // re-init the next forward enters `forward_layer_batched_decode`
+    // and panics on `paged_batch_block_tables missing`.
+    pub paged_dims: Option<(usize, usize)>, // (max_seqs, max_blocks_per_seq)
 }
 
 impl<B: MoeLlmBackend, K: KvDtypeKind> Qwen3MoeModel<B, K> {
@@ -536,6 +544,7 @@ impl<B: MoeLlmBackend, K: KvDtypeKind> Qwen3MoeModel<B, K> {
             kv_free_pool: Vec::new(),
             paged_pools: None,
             paged_block_alloc: None,
+            paged_dims: None,
         })
     }
 
@@ -709,6 +718,7 @@ impl<B: MoeLlmBackend, K: KvDtypeKind> Qwen3MoeModel<B, K> {
             kv_free_pool: Vec::new(),
             paged_pools: None,
             paged_block_alloc: None,
+            paged_dims: None,
         })
     }
 
@@ -719,6 +729,16 @@ impl<B: MoeLlmBackend, K: KvDtypeKind> Qwen3MoeModel<B, K> {
                 B::reset_all_graphs(&mut ctx);
             }
             self.scratch = Qwen3MoeScratch::alloc(&self.cfg, tokens);
+            // Realloc wiped paged_batch_*. Re-enable using the dims
+            // pinned at first ensure_kv. Without this, the next
+            // `forward_layer_batched_decode` panics on
+            // `paged_batch_block_tables missing` (regression manifests
+            // at c≥16 when batch growth triggers scratch realloc
+            // between `ensure_kv` and the batched-decode entry point).
+            if let Some((max_seqs, max_blocks_per_seq)) = self.paged_dims {
+                self.scratch
+                    .enable_paged_batch(&self.cfg, max_seqs, max_blocks_per_seq);
+            }
         }
     }
 
@@ -782,6 +802,9 @@ impl<B: MoeLlmBackend, K: KvDtypeKind> Qwen3MoeModel<B, K> {
         if paged {
             self.scratch
                 .enable_paged_batch(&self.cfg, max_seqs, max_blocks_per_seq);
+            // Pin dims on the model so `ensure_scratch`'s realloc can
+            // re-call `enable_paged_batch` after wiping scratch.
+            self.paged_dims = Some((max_seqs, max_blocks_per_seq));
         }
 
         let mut caches = self.kv_free_pool.pop().unwrap_or_else(|| {


### PR DESCRIPTION
## Summary

Pre-existing bug in `Qwen3MoeModel` and `LlamaFamilyModel`: `ensure_scratch(m)` reallocates `self.scratch` when batch size grows beyond the current `max_tokens`, wiping the `paged_batch_block_tables` / `paged_batch_q` / `paged_batch_context_lens` / `paged_batch_pos_offsets` / `paged_batch_cu_seqlens_q` fields that `enable_paged_batch` (called from `ensure_kv`) populated. The next forward enters `forward_layer_batched_decode`, sees `is_paged=true` (paged_pools is still Some), but `paged_batch_block_tables=None`, and panics with `"paged_batch_block_tables missing"`.

**Repro** (manifested while running Phase A baseline for the 30B-A3B perf push):
```
FERRUM_METAL_PAGED_KV=1 ferrum bench Qwen3-30B-A3B-GPTQ-Int4 --concurrency 16 --max-tokens 128
```
Crashes mid-iteration. c=4 happens to work because the scratch sized for c=4 doesn't grow on later iterations.

**Fix**: pin `(max_seqs, max_blocks_per_seq)` in a new `paged_dims: Option<(usize, usize)>` field on the model itself (not on scratch — scratch is what gets wiped), and re-call `enable_paged_batch` from inside `ensure_scratch` whenever the realloc fires. `enable_paged_batch` is already idempotent. Same fix in both `Qwen3MoeModel` and `LlamaFamilyModel`.

## Test plan
- [x] `cargo check --workspace --all-targets` clean on Mac
- [x] `cargo build --features cuda,vllm-moe-marlin --release -p ferrum-cli --bin ferrum` clean
- [x] Pre-fix repro: `ferrum bench Qwen3-30B-A3B-GPTQ-Int4 --concurrency 16` → panic at `qwen3_moe.rs:2097: paged_batch_block_tables missing`
- [x] Post-fix: same command runs to completion. **Phase A baseline locked**: c=1 58.2 tok/s, c=16 94.0 tok/s, c=32 92.4 tok/s on RTX 4090.

🤖 Generated with [Claude Code](https://claude.com/claude-code)