### PR TITLE
refactor(dim3): introduce StackedExpertGgufLinear<B> — drop QuantStore from Backend (Metal phase)

### DIFF
--- a/crates/ferrum-kernels/src/backend/cpu.rs
+++ b/crates/ferrum-kernels/src/backend/cpu.rs
@@ -117,7 +117,6 @@ impl Backend for CpuBackend {
     type Buffer = Vec<f32>;
     type Context = ();
     type GptqStore = CpuGptqStore;
-    type QuantStore = CpuQuantStore;
 
     fn new_context() -> Self::Context {}
     fn sync(_ctx: &mut Self::Context) {}

--- a/crates/ferrum-kernels/src/backend/metal.rs
+++ b/crates/ferrum-kernels/src/backend/metal.rs
@@ -54,8 +54,8 @@ struct MetalMmapEntry {
     _keeper: Arc<dyn std::any::Any + Send + Sync>,
 }
 
-struct MetalState {
-    pipes: MetalPipelines,
+pub(crate) struct MetalState {
+    pub(crate) pipes: MetalPipelines,
     /// Registered mmap regions wrapped as zero-copy Metal buffers. Looked
     /// up at `load_quant*` time so weight tensors that already live in a
     /// registered mmap can reuse the big buffer with an offset instead of
@@ -63,7 +63,7 @@ struct MetalState {
     mmaps: Mutex<Vec<MetalMmapEntry>>,
 }
 static METAL_STATE: OnceLock<MetalState> = OnceLock::new();
-fn st() -> &'static MetalState {
+pub(crate) fn st() -> &'static MetalState {
     METAL_STATE.get_or_init(|| MetalState {
         pipes: MetalPipelines::new(&Device::system_default().unwrap()),
         mmaps: Mutex::new(Vec::new()),
@@ -233,9 +233,9 @@ impl Dtype {
 /// different types for shader selection. `n` is the number of logical
 /// elements; `raw.length()` is `n * dtype.bytes_per_elem()`.
 pub struct MetalBuf {
-    raw: metal::Buffer,
-    dtype: Dtype,
-    n: usize,
+    pub(crate) raw: metal::Buffer,
+    pub(crate) dtype: Dtype,
+    pub(crate) n: usize,
 }
 
 impl MetalBuf {
@@ -259,7 +259,7 @@ impl MetalBuf {
     }
 
     #[inline]
-    fn expect_f32<'a>(&'a self, what: &str) -> &'a metal::Buffer {
+    pub(crate) fn expect_f32<'a>(&'a self, what: &str) -> &'a metal::Buffer {
         debug_assert!(
             matches!(self.dtype, Dtype::F32),
             "{what}: expected F32 buffer, got {:?}",
@@ -268,7 +268,7 @@ impl MetalBuf {
         &self.raw
     }
     #[inline]
-    fn expect_f32_mut<'a>(&'a mut self, what: &str) -> &'a mut metal::Buffer {
+    pub(crate) fn expect_f32_mut<'a>(&'a mut self, what: &str) -> &'a mut metal::Buffer {
         debug_assert!(
             matches!(self.dtype, Dtype::F32),
             "{what}: expected F32 buffer, got {:?}",
@@ -329,7 +329,7 @@ impl MetalContext {
     /// buffer if there isn't already one. Subsequent calls during the
     /// same window return the same encoder — set the pipeline state
     /// before each dispatch.
-    fn compute_encoder(&mut self) -> &'static metal::ComputeCommandEncoderRef {
+    pub(crate) fn compute_encoder(&mut self) -> &'static metal::ComputeCommandEncoderRef {
         if let Some(enc) = self.encoder {
             return enc;
         }
@@ -943,7 +943,6 @@ impl Backend for MetalBackend {
     type Buffer = MetalBuf;
     type Context = MetalContext;
     type GptqStore = (); // Metal GPTQ not yet wired; load_gptq/gemm_gptq return unsupported.
-    type QuantStore = MetalQuantStore;
 
     fn new_context() -> Self::Context {
         MetalContext {
@@ -1641,426 +1640,20 @@ impl crate::backend::BackendQuantGguf for MetalBackend {
         num_experts: usize,
         n_rows: usize,
         n_cols: usize,
-    ) -> Result<Self::QuantStore> {
+    ) -> Result<Box<dyn crate::StackedExpertGgufLinear<Self>>> {
         use super::GgufQuantType;
-        match kind {
-            GgufQuantType::Q4K => load_q4k_experts(bytes, num_experts, n_rows, n_cols),
-            GgufQuantType::Q6K => load_q6k_experts(bytes, num_experts, n_rows, n_cols),
-            other => Err(FerrumError::unsupported(format!(
-                "Metal load_quant_experts: {other:?} not implemented (only Q4K / Q6K)"
-            ))),
-        }
-    }
-    fn gemv_quant_moe_id(
-        ctx: &mut Self::Context,
-        a: &Self::Buffer,
-        weight: &Self::QuantStore,
-        ids: &Self::Buffer,
-        out: &mut Self::Buffer,
-        n_selected: usize,
-        src1_stride: usize,
-    ) -> Result<()> {
-        let a_buf = a.expect_f32("gemv_quant_moe_id a");
-        let ids_buf = &ids.raw;
-        let out_buf = out.expect_f32_mut("gemv_quant_moe_id out");
-        let enc = ctx.compute_encoder();
-        dispatch_gemv_moe_id(
-            enc,
-            a_buf,
-            weight,
-            ids_buf,
-            out_buf,
-            n_selected,
-            src1_stride,
-        )
-    }
-    fn gemv_quant_moe_id_gate_up_silu_batched(
-        ctx: &mut Self::Context,
-        a: &Self::Buffer,
-        gate_w: &Self::QuantStore,
-        up_w: &Self::QuantStore,
-        ids: &Self::Buffer,
-        silu_out: &mut Self::Buffer,
-        m: usize,
-        top_k: usize,
-        src1_outer_stride: usize,
-        src1_inner_stride: usize,
-    ) -> Result<()> {
-        let (gate_blocks, gate_byte_offset, gate_n_rows, gate_n_cols) = match gate_w {
-            MetalQuantStore::Q4KExperts {
-                blocks,
-                byte_offset,
-                n_rows,
-                n_cols,
-                ..
-            } => (blocks, *byte_offset, *n_rows, *n_cols),
-            _ => {
-                return Err(FerrumError::model(
-                    "gemv_quant_moe_id_gate_up_silu_batched: gate_w must be Q4KExperts".to_string(),
-                ));
+        let store = match kind {
+            GgufQuantType::Q4K => load_q4k_experts(bytes, num_experts, n_rows, n_cols)?,
+            GgufQuantType::Q6K => load_q6k_experts(bytes, num_experts, n_rows, n_cols)?,
+            other => {
+                return Err(FerrumError::unsupported(format!(
+                    "Metal load_quant_experts: {other:?} not implemented (only Q4K / Q6K)"
+                )));
             }
         };
-        let (up_blocks, up_byte_offset, up_n_rows, up_n_cols) = match up_w {
-            MetalQuantStore::Q4KExperts {
-                blocks,
-                byte_offset,
-                n_rows,
-                n_cols,
-                ..
-            } => (blocks, *byte_offset, *n_rows, *n_cols),
-            _ => {
-                return Err(FerrumError::model(
-                    "gemv_quant_moe_id_gate_up_silu_batched: up_w must be Q4KExperts".to_string(),
-                ));
-            }
-        };
-        if gate_n_rows != up_n_rows || gate_n_cols != up_n_cols {
-            return Err(FerrumError::model(format!(
-                "gemv_quant_moe_id_gate_up_silu_batched: gate/up shape mismatch — \
-                 gate=({gate_n_rows}, {gate_n_cols}) up=({up_n_rows}, {up_n_cols})"
-            )));
-        }
-
-        let a_buf = a.expect_f32("gemv_quant_moe_id_gate_up_silu_batched a");
-        let ids_buf = &ids.raw;
-        let out_buf = silu_out.expect_f32_mut("gemv_quant_moe_id_gate_up_silu_batched silu_out");
-        let enc = ctx.compute_encoder();
-        crate::q4_k_moe_id_gate_up_silu_batched::dispatch_gemv_q4k_moe_id_gate_up_silu_batched_on_encoder(
-            &st().pipes.device,
-            enc,
-            a_buf,
-            gate_blocks,
-            gate_byte_offset,
-            up_blocks,
-            up_byte_offset,
-            ids_buf,
-            out_buf,
-            gate_n_rows,
-            gate_n_cols,
-            m,
-            top_k,
-            src1_outer_stride,
-            src1_inner_stride,
-        );
-        Ok(())
-    }
-    fn gemv_quant_moe_id_batched(
-        ctx: &mut Self::Context,
-        a: &Self::Buffer,
-        weight: &Self::QuantStore,
-        ids: &Self::Buffer,
-        out: &mut Self::Buffer,
-        m: usize,
-        top_k: usize,
-        src1_outer_stride: usize,
-        src1_inner_stride: usize,
-    ) -> Result<()> {
-        let a_buf = a.expect_f32("gemv_quant_moe_id_batched a");
-        let ids_buf = &ids.raw;
-        let out_buf = out.expect_f32_mut("gemv_quant_moe_id_batched out");
-        let enc = ctx.compute_encoder();
-        match weight {
-            MetalQuantStore::Q4KExperts {
-                blocks,
-                byte_offset,
-                n_rows,
-                n_cols,
-                ..
-            } => {
-                crate::q4_k_moe_id_gemv_batched::dispatch_gemv_q4k_moe_id_batched_on_encoder(
-                    &st().pipes.device,
-                    enc,
-                    a_buf,
-                    blocks,
-                    *byte_offset,
-                    ids_buf,
-                    out_buf,
-                    *n_rows,
-                    *n_cols,
-                    m,
-                    top_k,
-                    src1_outer_stride,
-                    src1_inner_stride,
-                );
-                Ok(())
-            }
-            MetalQuantStore::Q6KExperts {
-                blocks,
-                byte_offset,
-                n_rows,
-                n_cols,
-                ..
-            } => {
-                crate::q6_k_moe_id_gemv_batched::dispatch_gemv_q6k_moe_id_batched_on_encoder(
-                    &st().pipes.device,
-                    enc,
-                    a_buf,
-                    blocks,
-                    *byte_offset,
-                    ids_buf,
-                    out_buf,
-                    *n_rows,
-                    *n_cols,
-                    m,
-                    top_k,
-                    src1_outer_stride,
-                    src1_inner_stride,
-                );
-                Ok(())
-            }
-            _ => Err(FerrumError::model(
-                "gemv_quant_moe_id_batched: weight must be Q4KExperts or Q6KExperts".to_string(),
-            )),
-        }
-    }
-    fn gemv_quant_moe_id_offset(
-        ctx: &mut Self::Context,
-        a: &Self::Buffer,
-        a_offset: usize,
-        weight: &Self::QuantStore,
-        ids: &Self::Buffer,
-        ids_offset: usize,
-        out: &mut Self::Buffer,
-        n_selected: usize,
-        src1_stride: usize,
-    ) -> Result<()> {
-        let a_buf = a.expect_f32("gemv_quant_moe_id_offset a");
-        let ids_buf = &ids.raw;
-        let out_buf = out.expect_f32_mut("gemv_quant_moe_id_offset out");
-        let enc = ctx.compute_encoder();
-        // a_offset is in floats (a is f32), ids_offset in i32s (ids is i32).
-        // Both kernels read with 4-byte stride, so byte offset = elem * 4.
-        let a_byte_offset = (a_offset * std::mem::size_of::<f32>()) as u64;
-        let ids_byte_offset = (ids_offset * std::mem::size_of::<i32>()) as u64;
-        dispatch_gemv_moe_id_offset(
-            enc,
-            a_buf,
-            a_byte_offset,
-            weight,
-            ids_buf,
-            ids_byte_offset,
-            out_buf,
-            n_selected,
-            src1_stride,
-        )
-    }
-    fn gemm_quant_moe_id(
-        ctx: &mut Self::Context,
-        a: &Self::Buffer,
-        weight: &Self::QuantStore,
-        ids: &Self::Buffer,
-        tpe: &Self::Buffer,
-        out: &mut Self::Buffer,
-        ne11: usize,
-        top_k: usize,
-        max_per_expert: usize,
-        batch: usize,
-    ) -> Result<()> {
-        let a_buf = a.expect_f32("gemm_quant_moe_id a");
-        let ids_buf = &ids.raw;
-        let tpe_buf = &tpe.raw;
-        let out_buf = out.expect_f32_mut("gemm_quant_moe_id out");
-        let enc = ctx.compute_encoder();
-        match weight {
-            MetalQuantStore::Q4KExperts {
-                blocks,
-                byte_offset,
-                num_experts,
-                n_rows,
-                n_cols,
-            } => {
-                crate::q4_k_moe_id_gemm::dispatch_gemm_q4k_moe_id_on_encoder(
-                    &st().pipes.device,
-                    enc,
-                    blocks,
-                    *byte_offset,
-                    a_buf,
-                    ids_buf,
-                    tpe_buf,
-                    out_buf,
-                    *num_experts,
-                    *n_rows,
-                    *n_cols,
-                    ne11,
-                    top_k,
-                    max_per_expert,
-                    batch,
-                );
-                Ok(())
-            }
-            MetalQuantStore::Q6KExperts {
-                blocks,
-                byte_offset,
-                num_experts,
-                n_rows,
-                n_cols,
-            } => {
-                crate::q6_k_moe_id_gemm::dispatch_gemm_q6k_moe_id_on_encoder(
-                    &st().pipes.device,
-                    enc,
-                    blocks,
-                    *byte_offset,
-                    a_buf,
-                    ids_buf,
-                    tpe_buf,
-                    out_buf,
-                    *num_experts,
-                    *n_rows,
-                    *n_cols,
-                    ne11,
-                    top_k,
-                    max_per_expert,
-                    batch,
-                );
-                Ok(())
-            }
-            _ => Err(FerrumError::model(
-                "gemm_quant_moe_id: weight must be Q4KExperts or Q6KExperts".to_string(),
-            )),
-        }
-    }
-    fn gemm_quant_moe_id_indirect(
-        ctx: &mut Self::Context,
-        a: &Self::Buffer,
-        weight: &Self::QuantStore,
-        ids: &Self::Buffer,
-        tpe: &Self::Buffer,
-        out: &mut Self::Buffer,
-        args_buf: &Self::Buffer,
-        ne11: usize,
-        top_k: usize,
-        max_per_expert: usize,
-        batch: usize,
-    ) -> Result<()> {
-        let a_buf = a.expect_f32("gemm_quant_moe_id_indirect a");
-        let ids_buf = &ids.raw;
-        let tpe_buf = &tpe.raw;
-        let out_buf = out.expect_f32_mut("gemm_quant_moe_id_indirect out");
-        let args = &args_buf.raw;
-        let enc = ctx.compute_encoder();
-        match weight {
-            MetalQuantStore::Q4KExperts {
-                blocks,
-                byte_offset,
-                num_experts,
-                n_rows,
-                n_cols,
-            } => {
-                crate::q4_k_moe_id_gemm::dispatch_gemm_q4k_moe_id_indirect_on_encoder(
-                    &st().pipes.device,
-                    enc,
-                    blocks,
-                    *byte_offset,
-                    a_buf,
-                    ids_buf,
-                    tpe_buf,
-                    out_buf,
-                    args,
-                    *num_experts,
-                    *n_rows,
-                    *n_cols,
-                    ne11,
-                    top_k,
-                    max_per_expert,
-                    batch,
-                );
-                Ok(())
-            }
-            MetalQuantStore::Q6KExperts {
-                blocks,
-                byte_offset,
-                num_experts,
-                n_rows,
-                n_cols,
-            } => {
-                crate::q6_k_moe_id_gemm::dispatch_gemm_q6k_moe_id_indirect_on_encoder(
-                    &st().pipes.device,
-                    enc,
-                    blocks,
-                    *byte_offset,
-                    a_buf,
-                    ids_buf,
-                    tpe_buf,
-                    out_buf,
-                    args,
-                    *num_experts,
-                    *n_rows,
-                    *n_cols,
-                    ne11,
-                    top_k,
-                    max_per_expert,
-                    batch,
-                );
-                Ok(())
-            }
-            _ => Err(FerrumError::model(
-                "gemm_quant_moe_id_indirect: weight must be Q4KExperts or Q6KExperts".to_string(),
-            )),
-        }
-    }
-    fn gemv_quant_moe_id_gate_up_silu(
-        ctx: &mut Self::Context,
-        a: &Self::Buffer,
-        gate_w: &Self::QuantStore,
-        up_w: &Self::QuantStore,
-        ids: &Self::Buffer,
-        silu_out: &mut Self::Buffer,
-        n_selected: usize,
-    ) -> Result<()> {
-        let (gate_blocks, gate_byte_offset, gate_n_rows, gate_n_cols) = match gate_w {
-            MetalQuantStore::Q4KExperts {
-                blocks,
-                byte_offset,
-                n_rows,
-                n_cols,
-                ..
-            } => (blocks, *byte_offset, *n_rows, *n_cols),
-            _ => {
-                return Err(FerrumError::model(
-                    "gemv_quant_moe_id_gate_up_silu: gate_w must be Q4KExperts".to_string(),
-                ));
-            }
-        };
-        let (up_blocks, up_byte_offset, up_n_rows, up_n_cols) = match up_w {
-            MetalQuantStore::Q4KExperts {
-                blocks,
-                byte_offset,
-                n_rows,
-                n_cols,
-                ..
-            } => (blocks, *byte_offset, *n_rows, *n_cols),
-            _ => {
-                return Err(FerrumError::model(
-                    "gemv_quant_moe_id_gate_up_silu: up_w must be Q4KExperts".to_string(),
-                ));
-            }
-        };
-        if gate_n_rows != up_n_rows || gate_n_cols != up_n_cols {
-            return Err(FerrumError::model(format!(
-                "gemv_quant_moe_id_gate_up_silu: gate/up shape mismatch — \
-                 gate=({gate_n_rows}, {gate_n_cols}) up=({up_n_rows}, {up_n_cols})"
-            )));
-        }
-
-        let a_buf = a.expect_f32("gemv_quant_moe_id_gate_up_silu a");
-        let ids_buf = &ids.raw;
-        let out_buf = silu_out.expect_f32_mut("gemv_quant_moe_id_gate_up_silu silu_out");
-        let enc = ctx.compute_encoder();
-        crate::q4_k_moe_id_gate_up_silu::dispatch_gemv_q4k_moe_id_gate_up_silu_on_encoder(
-            &st().pipes.device,
-            enc,
-            a_buf,
-            gate_blocks,
-            gate_byte_offset,
-            up_blocks,
-            up_byte_offset,
-            ids_buf,
-            out_buf,
-            gate_n_rows,
-            gate_n_cols,
-            n_selected,
-        );
-        Ok(())
+        Ok(Box::new(
+            crate::quant_linear::metal_gguf_moe::MetalStackedExpertGgufLinear::new(store)?,
+        ))
     }
     fn load_quant_fused(
         parts: &[(super::GgufQuantType, &[u8], usize)],
@@ -2103,7 +1696,7 @@ impl crate::backend::BackendQuantGguf for MetalBackend {
 pub fn metal_gemm_quant_dispatch(
     ctx: &mut <MetalBackend as crate::backend::Backend>::Context,
     a: &<MetalBackend as crate::backend::Backend>::Buffer,
-    weight: &<MetalBackend as crate::backend::Backend>::QuantStore,
+    weight: &MetalQuantStore,
     out: &mut <MetalBackend as crate::backend::Backend>::Buffer,
     m: usize,
 ) -> Result<()> {

--- a/crates/ferrum-kernels/src/backend/traits.rs
+++ b/crates/ferrum-kernels/src/backend/traits.rs
@@ -269,21 +269,16 @@ pub trait Backend: Send + Sync + Sized + 'static {
     /// doesn't pay the repack cost per forward pass.
     type GptqStore: Send + Sync;
 
-    /// Single backend-specific store for **all GGUF k-quant flavours**
-    /// (Q4_K_M today; Q5_K_M / Q6_K / Q8_0 etc. become enum variants
-    /// without changing the trait shape).
-    ///
-    /// Each backend's `QuantStore` is typically an enum dispatching on
-    /// the on-disk quant type — the public API (`load_quant`,
-    /// `gemm_quant`) takes a [`QuantKind`] discriminator so callers
-    /// don't see the variant boilerplate.
-    ///
-    /// **GPTQ stays on the older [`Self::GptqStore`] path** because its
-    /// load inputs are split arrays (qweight / scales / qzeros), not
-    /// the contiguous byte payload GGUF quants ship as. A future PR can
-    /// fold GPTQ into `QuantStore` once an input-shape unification is
-    /// agreed.
-    type QuantStore: Send + Sync;
+    // Note (Phase 3e/4): `type QuantStore` (GGUF k-quant storage) was removed
+    // — single-linear GGUF goes through `Box<dyn Linear<Self>>` (returned by
+    // `load_quant` / `load_quant_fused`), and stacked-expert MoE GGUF goes
+    // through `Box<dyn StackedExpertGgufLinear<Self>>` (returned by
+    // `load_quant_experts`). Backend trait no longer needs a backend-
+    // specific GGUF type, so adding a new k-quant flavour is purely a
+    // new enum variant inside the backend's concrete Linear impl.
+    // `type GptqStore` is still here because GPTQ load inputs are split
+    // arrays (qweight / scales / qzeros) — see PR D for the matching
+    // GPTQ cutover.
 
     /// Create a new execution context (begin accumulating work).
     fn new_context() -> Self::Context;
@@ -1274,257 +1269,25 @@ pub trait BackendQuantGguf: Backend {
             "load_quant_fused not implemented for this backend",
         ))
     }
-    /// Build a stacked-experts `QuantStore` from a contiguous 3-D weight
-    /// payload `[num_experts, n_rows, n_cols/256]` super-blocks.
-    /// Used for the MoE indirect-dispatch fast path; backends without
-    /// such a kernel return `Err(unsupported)` and the model code falls
-    /// back to the per-expert loop.
+    /// Build a stacked-experts MoE linear from a contiguous 3-D weight
+    /// payload `[num_experts, n_rows, n_cols/256]` super-blocks. Used for
+    /// the MoE indirect-dispatch fast path; backends without such a kernel
+    /// return `Err(unsupported)` and the model code falls back to the
+    /// per-expert `Box<dyn Linear<Self>>` loop.
     ///
-    /// Default: not supported. Override on backends with batched MoE
-    /// kernels (e.g. Metal `gemv_q*kw_moe_id_f32`).
+    /// Phase 3e/4: returns `Box<dyn StackedExpertGgufLinear<Self>>` directly
+    /// (Metal: `MetalStackedExpertGgufLinear` over Q4KExperts / Q6KExperts).
+    /// Replaces the old `Result<Self::QuantStore>` API + the 7 sibling
+    /// `*_moe_id*` Backend methods that consumed it.
     fn load_quant_experts(
         _kind: GgufQuantType,
         _bytes: &[u8],
         _num_experts: usize,
         _n_rows: usize,
         _n_cols: usize,
-    ) -> Result<Self::QuantStore> {
+    ) -> Result<Box<dyn crate::StackedExpertGgufLinear<Self>>> {
         Err(FerrumError::unsupported(
             "load_quant_experts not implemented for this backend",
-        ))
-    }
-    /// MoE 2-D indirect-dispatch GEMM (prefill m > 1).
-    ///
-    /// Computes per (token, expert_slot) pair, batched across all
-    /// experts in one launch:
-    ///
-    ///   `out[token, slot, :] = a[token, slot_or_0, :] @ dequant(weight[expert(token, slot), :])^T`
-    ///
-    /// `ids[expert][slot] = pair_id` encodes `(token_idx, slot_within_token)`
-    /// so the kernel reads activations indirectly (src1 row for the
-    /// pair) and writes outputs directly to the natural
-    /// `[batch, top_k, M]` layout. `tpe[expert]` gives the count of
-    /// pairs assigned to each expert — threadgroups past `tpe[e]`
-    /// early-exit.
-    ///
-    /// `ne11` selects the src1 inner-batch shape:
-    /// - `1` for `gate` / `up` (broadcast — all slots read the same
-    ///   activation row per token).
-    /// - `top_k` for `down` (per-slot — each pair reads its own row in
-    ///   the upstream silu·gate output).
-    ///
-    /// Closes the prefill MoE gap: the per-token gemv loop becomes one
-    /// batched gemm where each expert's slab handles m ≈ batch·top_k /
-    /// num_experts pairs in parallel via simdgroup_half8x8 matmul.
-    #[allow(clippy::too_many_arguments)]
-    fn gemm_quant_moe_id(
-        _ctx: &mut Self::Context,
-        _a: &Self::Buffer,
-        _weight: &Self::QuantStore,
-        _ids: &Self::Buffer,
-        _tpe: &Self::Buffer,
-        _out: &mut Self::Buffer,
-        _ne11: usize,
-        _top_k: usize,
-        _max_per_expert: usize,
-        _batch: usize,
-    ) -> Result<()> {
-        Err(FerrumError::unsupported(
-            "gemm_quant_moe_id not implemented for this backend",
-        ))
-    }
-    /// Indirect-dispatch variant of `gemm_quant_moe_id`.
-    ///
-    /// Identical inputs except the grid is read from `args_buf` (a 12-
-    /// byte u32 triple written by `compute_ids_tpe_gpu`) instead of
-    /// being computed from `max_per_expert`. `max_per_expert` is still
-    /// the kernel parameter used as the row stride for `ids` indexing
-    /// (= `batch * top_k`, worst case); only the dispatched grid
-    /// shrinks to cover `max(tpe[e])` columns.
-    #[allow(clippy::too_many_arguments)]
-    fn gemm_quant_moe_id_indirect(
-        _ctx: &mut Self::Context,
-        _src1: &Self::Buffer,
-        _weights: &Self::QuantStore,
-        _ids: &Self::Buffer,
-        _tpe: &Self::Buffer,
-        _out: &mut Self::Buffer,
-        _args_buf: &Self::Buffer,
-        _ne11: usize,
-        _top_k: usize,
-        _max_per_expert: usize,
-        _batch: usize,
-    ) -> Result<()> {
-        Err(FerrumError::unsupported(
-            "gemm_quant_moe_id_indirect not implemented for this backend",
-        ))
-    }
-    /// MoE indirect-dispatch GEMV: `out[i, :] = a[i, :] @ dequant(weight[ids[i], :])^T`
-    /// for each `i ∈ [0, n_selected)`. Single backend dispatch covers
-    /// all selected (token, expert) pairs.
-    ///
-    /// `weight` must be a stacked-experts variant produced by
-    /// [`Self::load_quant_experts`]. `ids` is a backend-side buffer of
-    /// `n_selected` i32 expert IDs. `out` is sized `[n_selected, n_rows]`.
-    /// `src1_stride` is the per-slot activation stride in **elements**:
-    /// `0` ⇒ every slot reads the same activation row (broadcast — for
-    /// `gate` / `up` projections); `n_cols` ⇒ each slot reads its own
-    /// activation row (for `down` projections, where each expert
-    /// consumes its own silu(gate)·up output).
-    fn gemv_quant_moe_id(
-        _ctx: &mut Self::Context,
-        _a: &Self::Buffer,
-        _weight: &Self::QuantStore,
-        _ids: &Self::Buffer,
-        _out: &mut Self::Buffer,
-        _n_selected: usize,
-        _src1_stride: usize,
-    ) -> Result<()> {
-        Err(FerrumError::unsupported(
-            "gemv_quant_moe_id not implemented for this backend",
-        ))
-    }
-    /// Offset-aware variant of [`Self::gemv_quant_moe_id`] — reads `a`
-    /// from `a_offset` (in elements; meaningful only when src1_stride=0
-    /// for the broadcast case, or as the start of an `n_selected × K`
-    /// strided read when src1_stride≥K), reads `ids` from `ids_offset`
-    /// (the i-th `top_k` block in a stacked-batch `[M, top_k]` ids
-    /// buffer), and writes `out` from offset 0 (output stays per-iter
-    /// scratch). Used by the per-item batched-decode path so the M=N
-    /// concurrent decodes can read directly from the M-batch
-    /// `selected_ids_buf` / `norm_out` without materialising
-    /// per-iteration copies.
-    #[allow(clippy::too_many_arguments)]
-    fn gemv_quant_moe_id_offset(
-        ctx: &mut Self::Context,
-        a: &Self::Buffer,
-        a_offset: usize,
-        weight: &Self::QuantStore,
-        ids: &Self::Buffer,
-        ids_offset: usize,
-        out: &mut Self::Buffer,
-        n_selected: usize,
-        src1_stride: usize,
-    ) -> Result<()> {
-        let _ = (
-            ctx,
-            a,
-            a_offset,
-            weight,
-            ids,
-            ids_offset,
-            out,
-            n_selected,
-            src1_stride,
-        );
-        Err(FerrumError::unsupported(
-            "gemv_quant_moe_id_offset not implemented for this backend",
-        ))
-    }
-    /// Fused gate+up MoE GEMV with in-register `SiLU(gate) * up`.
-    ///
-    /// Folds the three back-to-back dispatches that the stacked MoE
-    /// FFN decode path emitted per layer:
-    ///   1. `gemv_quant_moe_id` (gate) → gate_out_stacked
-    ///   2. `gemv_quant_moe_id` (up)   → up_out_stacked
-    ///   3. `silu_mul_stacked`         → silu_stacked
-    /// into a single dispatch that writes `silu_stacked` directly.
-    /// Saves 2 dispatches per layer plus the entire round-trip through
-    /// the gate_out / up_out scratch buffers (≈4× `[top_k, ffn]` of
-    /// intermediate traffic). The activation read is also halved
-    /// because the inner Q4_K reduction reuses one register-file load
-    /// across both weight matrices.
-    ///
-    /// Both `gate_w` and `up_w` must be `Q4KExperts` stacks with
-    /// matching `(num_experts, n_rows, n_cols)` (true for Qwen3-MoE
-    /// GGUFs). Backends without the fused kernel can fall back to the
-    /// 3-dispatch path; callers should gate via
-    /// [`Self::supports_fused_moe_gate_up_silu`] to avoid the
-    /// `Unsupported` String-allocating error round trip on the decode
-    /// hot path.
-    #[allow(clippy::too_many_arguments)]
-    fn gemv_quant_moe_id_gate_up_silu(
-        _ctx: &mut Self::Context,
-        _a: &Self::Buffer,
-        _gate_w: &Self::QuantStore,
-        _up_w: &Self::QuantStore,
-        _ids: &Self::Buffer,
-        _silu_out: &mut Self::Buffer,
-        _n_selected: usize,
-    ) -> Result<()> {
-        Err(FerrumError::unsupported(
-            "gemv_quant_moe_id_gate_up_silu not implemented for this backend",
-        ))
-    }
-    /// Batched MoE indirect-dispatch GEMV — one Metal launch covers
-    /// **all** `m * top_k` (token, expert) pairs at once.
-    ///
-    /// This is the symmetric counterpart of
-    /// [`Self::gemv_quant_moe_id`]: same Q4_K decode loop, same
-    /// per-pair output, but the grid Z-axis spans `m * top_k` instead
-    /// of just `top_k`. Eliminates the engine-level per-token outer
-    /// loop that emits ~16× the dispatches llama.cpp emits at c=16
-    /// (their `kernel_mul_mv_id` already handles the M batch in one
-    /// dispatch).
-    ///
-    /// `a`           : activation buffer; pair `p` reads
-    ///                 `(p / top_k) * src1_outer_stride
-    ///                  + (p % top_k) * src1_inner_stride` floats.
-    ///                 gate / up:  src1 = `norm_out [m, K]`,
-    ///                              outer = K, inner = 0
-    ///                              (slots within a token broadcast).
-    ///                 down:       src1 = `silu_stacked [m, top_k, K]`,
-    ///                              outer = top_k * K, inner = K.
-    /// `weight`      : Q4KExperts stacked weights, common across
-    ///                 selected experts.
-    /// `ids`         : flat `[m * top_k]` selected-expert IDs (i32).
-    /// `out`         : `[m * top_k, n_rows]` outputs.
-    /// `m`           : token batch size.
-    /// `top_k`       : selected experts per token.
-    /// `src1_outer_stride`, `src1_inner_stride`: in **floats**.
-    #[allow(clippy::too_many_arguments)]
-    fn gemv_quant_moe_id_batched(
-        _ctx: &mut Self::Context,
-        _a: &Self::Buffer,
-        _weight: &Self::QuantStore,
-        _ids: &Self::Buffer,
-        _out: &mut Self::Buffer,
-        _m: usize,
-        _top_k: usize,
-        _src1_outer_stride: usize,
-        _src1_inner_stride: usize,
-    ) -> Result<()> {
-        Err(FerrumError::unsupported(
-            "gemv_quant_moe_id_batched not implemented for this backend",
-        ))
-    }
-    /// Batched fused gate+up MoE GEMV with in-register `SiLU(gate) * up`.
-    ///
-    /// Counterpart of [`Self::gemv_quant_moe_id_gate_up_silu`] for the
-    /// batched-decode path: same in-register fusion, but the grid Z
-    /// dimension covers all `m * top_k` (token, expert) pairs in one
-    /// dispatch. Folds the three batched MoE FFN dispatches per layer
-    /// (gate gemv + up gemv + silu_mul_batched) into one — the missing
-    /// fusion that left the m≥2 batched-decode path slower than the
-    /// per-token loop (which already had this fusion at m=1).
-    ///
-    /// Both `gate_w` and `up_w` must be `Q4KExperts` stacks with
-    /// matching `(num_experts, n_rows, n_cols)`.
-    #[allow(clippy::too_many_arguments)]
-    fn gemv_quant_moe_id_gate_up_silu_batched(
-        _ctx: &mut Self::Context,
-        _a: &Self::Buffer,
-        _gate_w: &Self::QuantStore,
-        _up_w: &Self::QuantStore,
-        _ids: &Self::Buffer,
-        _silu_out: &mut Self::Buffer,
-        _m: usize,
-        _top_k: usize,
-        _src1_outer_stride: usize,
-        _src1_inner_stride: usize,
-    ) -> Result<()> {
-        Err(FerrumError::unsupported(
-            "gemv_quant_moe_id_gate_up_silu_batched not implemented for this backend",
         ))
     }
 }

--- a/crates/ferrum-kernels/src/lib.rs
+++ b/crates/ferrum-kernels/src/lib.rs
@@ -9,6 +9,9 @@ pub mod backend;
 pub mod linear;
 pub use linear::Linear;
 
+pub mod stacked_expert;
+pub use stacked_expert::StackedExpertGgufLinear;
+
 pub mod quant_linear;
 
 pub mod attention;

--- a/crates/ferrum-kernels/src/quant_linear.rs
+++ b/crates/ferrum-kernels/src/quant_linear.rs
@@ -20,3 +20,6 @@ pub mod cuda_marlin;
 
 #[cfg(all(target_os = "macos", feature = "metal"))]
 pub mod metal_gguf;
+
+#[cfg(all(target_os = "macos", feature = "metal"))]
+pub mod metal_gguf_moe;

--- a/crates/ferrum-kernels/src/quant_linear/metal_gguf_moe.rs
+++ b/crates/ferrum-kernels/src/quant_linear/metal_gguf_moe.rs
@@ -1,0 +1,504 @@
+//! `StackedExpertGgufLinear<MetalBackend>` impl — wraps a Metal
+//! `Q4KExperts` / `Q6KExperts` `MetalQuantStore` and dispatches via the
+//! existing `dispatch_gemv_moe_id*` / `dispatch_gemm_moe_id*` /
+//! `dispatch_gemv_moe_id_gate_up_silu*` free functions in
+//! `crate::backend::metal`.
+//!
+//! Phase 3e/4: replaces the `BackendQuantGguf::gemv_quant_moe_id*` /
+//! `gemm_quant_moe_id*` trait methods + the `Backend::QuantStore`
+//! associated type. Model code (ExpertStack<B>) now holds
+//! `Box<dyn StackedExpertGgufLinear<B>>` instead of `B::QuantStore`,
+//! so adding a new k-quant flavour doesn't touch the Backend trait.
+
+use std::any::Any;
+
+use crate::backend::metal::{
+    dispatch_gemv_moe_id, dispatch_gemv_moe_id_offset, st, MetalBackend, MetalQuantStore,
+};
+use crate::stacked_expert::StackedExpertGgufLinear;
+use ferrum_types::{FerrumError, Result};
+
+/// Metal MoE-stacked GGUF Linear. Internally holds a `MetalQuantStore`
+/// that MUST be `Q4KExperts` or `Q6KExperts` (constructor enforces).
+/// Plain enum wrapper keeps the existing dispatcher signatures usable.
+pub struct MetalStackedExpertGgufLinear {
+    pub store: MetalQuantStore,
+}
+
+impl MetalStackedExpertGgufLinear {
+    /// Wrap a `MetalQuantStore` that's been built by `load_q4k_experts`
+    /// or `load_q6k_experts`. Returns Err if any other variant is passed.
+    pub fn new(store: MetalQuantStore) -> Result<Self> {
+        match &store {
+            MetalQuantStore::Q4KExperts { .. } | MetalQuantStore::Q6KExperts { .. } => {
+                Ok(Self { store })
+            }
+            _ => Err(FerrumError::model(
+                "MetalStackedExpertGgufLinear requires Q4KExperts or Q6KExperts variant"
+                    .to_string(),
+            )),
+        }
+    }
+
+    /// Borrow the inner `MetalQuantStore` — exposed for fused methods that
+    /// need to dispatch on both gate and up stores together.
+    pub fn store(&self) -> &MetalQuantStore {
+        &self.store
+    }
+
+    fn dims(&self) -> (usize, usize, usize) {
+        match &self.store {
+            MetalQuantStore::Q4KExperts {
+                num_experts,
+                n_rows,
+                n_cols,
+                ..
+            }
+            | MetalQuantStore::Q6KExperts {
+                num_experts,
+                n_rows,
+                n_cols,
+                ..
+            } => (*num_experts, *n_rows, *n_cols),
+            _ => unreachable!("constructor guarantees experts variant"),
+        }
+    }
+
+    /// Downcast helper for cross-impl fused methods.
+    fn from_dyn<'a>(
+        other: &'a dyn StackedExpertGgufLinear<MetalBackend>,
+        ctx: &'static str,
+    ) -> Result<&'a Self> {
+        other.as_any().downcast_ref::<Self>().ok_or_else(|| {
+            FerrumError::model(format!(
+                "{ctx}: expected MetalStackedExpertGgufLinear (got a different StackedExpertGgufLinear<MetalBackend> impl)"
+            ))
+        })
+    }
+}
+
+impl StackedExpertGgufLinear<MetalBackend> for MetalStackedExpertGgufLinear {
+    fn num_experts(&self) -> usize {
+        self.dims().0
+    }
+    fn n_rows(&self) -> usize {
+        self.dims().1
+    }
+    fn n_cols(&self) -> usize {
+        self.dims().2
+    }
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn gemv_moe_id(
+        &self,
+        ctx: &mut <MetalBackend as crate::backend::Backend>::Context,
+        a: &<MetalBackend as crate::backend::Backend>::Buffer,
+        ids: &<MetalBackend as crate::backend::Backend>::Buffer,
+        out: &mut <MetalBackend as crate::backend::Backend>::Buffer,
+        n_selected: usize,
+        src1_stride: usize,
+    ) -> Result<()> {
+        let a_buf = a.expect_f32("gemv_moe_id a");
+        let ids_buf = &ids.raw;
+        let out_buf = out.expect_f32_mut("gemv_moe_id out");
+        let enc = ctx.compute_encoder();
+        dispatch_gemv_moe_id(
+            enc,
+            a_buf,
+            &self.store,
+            ids_buf,
+            out_buf,
+            n_selected,
+            src1_stride,
+        )
+    }
+
+    fn gemv_moe_id_offset(
+        &self,
+        ctx: &mut <MetalBackend as crate::backend::Backend>::Context,
+        a: &<MetalBackend as crate::backend::Backend>::Buffer,
+        a_offset: usize,
+        ids: &<MetalBackend as crate::backend::Backend>::Buffer,
+        ids_offset: usize,
+        out: &mut <MetalBackend as crate::backend::Backend>::Buffer,
+        n_selected: usize,
+        src1_stride: usize,
+    ) -> Result<()> {
+        let a_buf = a.expect_f32("gemv_moe_id_offset a");
+        let ids_buf = &ids.raw;
+        let out_buf = out.expect_f32_mut("gemv_moe_id_offset out");
+        let enc = ctx.compute_encoder();
+        let a_byte_offset = (a_offset * std::mem::size_of::<f32>()) as u64;
+        let ids_byte_offset = (ids_offset * std::mem::size_of::<i32>()) as u64;
+        dispatch_gemv_moe_id_offset(
+            enc,
+            a_buf,
+            a_byte_offset,
+            &self.store,
+            ids_buf,
+            ids_byte_offset,
+            out_buf,
+            n_selected,
+            src1_stride,
+        )
+    }
+
+    fn gemv_moe_id_gate_up_silu(
+        &self,
+        ctx: &mut <MetalBackend as crate::backend::Backend>::Context,
+        a: &<MetalBackend as crate::backend::Backend>::Buffer,
+        other_up: &dyn StackedExpertGgufLinear<MetalBackend>,
+        ids: &<MetalBackend as crate::backend::Backend>::Buffer,
+        silu_out: &mut <MetalBackend as crate::backend::Backend>::Buffer,
+        n_selected: usize,
+    ) -> Result<()> {
+        let up = Self::from_dyn(other_up, "gemv_moe_id_gate_up_silu")?;
+        let (gate_blocks, gate_byte_offset, gate_n_rows, gate_n_cols) = match &self.store {
+            MetalQuantStore::Q4KExperts {
+                blocks,
+                byte_offset,
+                n_rows,
+                n_cols,
+                ..
+            } => (blocks, *byte_offset, *n_rows, *n_cols),
+            _ => {
+                return Err(FerrumError::model(
+                    "gemv_moe_id_gate_up_silu: gate weight must be Q4KExperts".to_string(),
+                ));
+            }
+        };
+        let (up_blocks, up_byte_offset, up_n_rows, up_n_cols) = match &up.store {
+            MetalQuantStore::Q4KExperts {
+                blocks,
+                byte_offset,
+                n_rows,
+                n_cols,
+                ..
+            } => (blocks, *byte_offset, *n_rows, *n_cols),
+            _ => {
+                return Err(FerrumError::model(
+                    "gemv_moe_id_gate_up_silu: up weight must be Q4KExperts".to_string(),
+                ));
+            }
+        };
+        if gate_n_rows != up_n_rows || gate_n_cols != up_n_cols {
+            return Err(FerrumError::model(format!(
+                "gemv_moe_id_gate_up_silu: gate/up shape mismatch — \
+                 gate=({gate_n_rows}, {gate_n_cols}) up=({up_n_rows}, {up_n_cols})"
+            )));
+        }
+
+        let a_buf = a.expect_f32("gemv_moe_id_gate_up_silu a");
+        let ids_buf = &ids.raw;
+        let out_buf = silu_out.expect_f32_mut("gemv_moe_id_gate_up_silu silu_out");
+        let enc = ctx.compute_encoder();
+        crate::q4_k_moe_id_gate_up_silu::dispatch_gemv_q4k_moe_id_gate_up_silu_on_encoder(
+            &st().pipes.device,
+            enc,
+            a_buf,
+            gate_blocks,
+            gate_byte_offset,
+            up_blocks,
+            up_byte_offset,
+            ids_buf,
+            out_buf,
+            gate_n_rows,
+            gate_n_cols,
+            n_selected,
+        );
+        Ok(())
+    }
+
+    fn gemv_moe_id_batched(
+        &self,
+        ctx: &mut <MetalBackend as crate::backend::Backend>::Context,
+        a: &<MetalBackend as crate::backend::Backend>::Buffer,
+        ids: &<MetalBackend as crate::backend::Backend>::Buffer,
+        out: &mut <MetalBackend as crate::backend::Backend>::Buffer,
+        m: usize,
+        top_k: usize,
+        src1_outer_stride: usize,
+        src1_inner_stride: usize,
+    ) -> Result<()> {
+        let a_buf = a.expect_f32("gemv_moe_id_batched a");
+        let ids_buf = &ids.raw;
+        let out_buf = out.expect_f32_mut("gemv_moe_id_batched out");
+        let enc = ctx.compute_encoder();
+        match &self.store {
+            MetalQuantStore::Q4KExperts {
+                blocks,
+                byte_offset,
+                n_rows,
+                n_cols,
+                ..
+            } => {
+                crate::q4_k_moe_id_gemv_batched::dispatch_gemv_q4k_moe_id_batched_on_encoder(
+                    &st().pipes.device,
+                    enc,
+                    a_buf,
+                    blocks,
+                    *byte_offset,
+                    ids_buf,
+                    out_buf,
+                    *n_rows,
+                    *n_cols,
+                    m,
+                    top_k,
+                    src1_outer_stride,
+                    src1_inner_stride,
+                );
+                Ok(())
+            }
+            MetalQuantStore::Q6KExperts {
+                blocks,
+                byte_offset,
+                n_rows,
+                n_cols,
+                ..
+            } => {
+                crate::q6_k_moe_id_gemv_batched::dispatch_gemv_q6k_moe_id_batched_on_encoder(
+                    &st().pipes.device,
+                    enc,
+                    a_buf,
+                    blocks,
+                    *byte_offset,
+                    ids_buf,
+                    out_buf,
+                    *n_rows,
+                    *n_cols,
+                    m,
+                    top_k,
+                    src1_outer_stride,
+                    src1_inner_stride,
+                );
+                Ok(())
+            }
+            _ => unreachable!("constructor guarantees experts variant"),
+        }
+    }
+
+    fn gemv_moe_id_gate_up_silu_batched(
+        &self,
+        ctx: &mut <MetalBackend as crate::backend::Backend>::Context,
+        a: &<MetalBackend as crate::backend::Backend>::Buffer,
+        other_up: &dyn StackedExpertGgufLinear<MetalBackend>,
+        ids: &<MetalBackend as crate::backend::Backend>::Buffer,
+        silu_out: &mut <MetalBackend as crate::backend::Backend>::Buffer,
+        m: usize,
+        top_k: usize,
+        src1_outer_stride: usize,
+        src1_inner_stride: usize,
+    ) -> Result<()> {
+        let up = Self::from_dyn(other_up, "gemv_moe_id_gate_up_silu_batched")?;
+        let (gate_blocks, gate_byte_offset, gate_n_rows, gate_n_cols) = match &self.store {
+            MetalQuantStore::Q4KExperts {
+                blocks,
+                byte_offset,
+                n_rows,
+                n_cols,
+                ..
+            } => (blocks, *byte_offset, *n_rows, *n_cols),
+            _ => {
+                return Err(FerrumError::model(
+                    "gemv_moe_id_gate_up_silu_batched: gate must be Q4KExperts".to_string(),
+                ));
+            }
+        };
+        let (up_blocks, up_byte_offset, up_n_rows, up_n_cols) = match &up.store {
+            MetalQuantStore::Q4KExperts {
+                blocks,
+                byte_offset,
+                n_rows,
+                n_cols,
+                ..
+            } => (blocks, *byte_offset, *n_rows, *n_cols),
+            _ => {
+                return Err(FerrumError::model(
+                    "gemv_moe_id_gate_up_silu_batched: up must be Q4KExperts".to_string(),
+                ));
+            }
+        };
+        if gate_n_rows != up_n_rows || gate_n_cols != up_n_cols {
+            return Err(FerrumError::model(format!(
+                "gemv_moe_id_gate_up_silu_batched: gate/up shape mismatch — \
+                 gate=({gate_n_rows}, {gate_n_cols}) up=({up_n_rows}, {up_n_cols})"
+            )));
+        }
+        let a_buf = a.expect_f32("gemv_moe_id_gate_up_silu_batched a");
+        let ids_buf = &ids.raw;
+        let out_buf = silu_out.expect_f32_mut("gemv_moe_id_gate_up_silu_batched silu_out");
+        let enc = ctx.compute_encoder();
+        crate::q4_k_moe_id_gate_up_silu_batched::dispatch_gemv_q4k_moe_id_gate_up_silu_batched_on_encoder(
+            &st().pipes.device,
+            enc,
+            a_buf,
+            gate_blocks,
+            gate_byte_offset,
+            up_blocks,
+            up_byte_offset,
+            ids_buf,
+            out_buf,
+            gate_n_rows,
+            gate_n_cols,
+            m,
+            top_k,
+            src1_outer_stride,
+            src1_inner_stride,
+        );
+        Ok(())
+    }
+
+    fn gemm_moe_id(
+        &self,
+        ctx: &mut <MetalBackend as crate::backend::Backend>::Context,
+        a: &<MetalBackend as crate::backend::Backend>::Buffer,
+        ids: &<MetalBackend as crate::backend::Backend>::Buffer,
+        tpe: &<MetalBackend as crate::backend::Backend>::Buffer,
+        out: &mut <MetalBackend as crate::backend::Backend>::Buffer,
+        ne11: usize,
+        top_k: usize,
+        max_per_expert: usize,
+        batch: usize,
+    ) -> Result<()> {
+        let a_buf = a.expect_f32("gemm_moe_id a");
+        let ids_buf = &ids.raw;
+        let tpe_buf = &tpe.raw;
+        let out_buf = out.expect_f32_mut("gemm_moe_id out");
+        let enc = ctx.compute_encoder();
+        match &self.store {
+            MetalQuantStore::Q4KExperts {
+                blocks,
+                byte_offset,
+                num_experts,
+                n_rows,
+                n_cols,
+            } => {
+                crate::q4_k_moe_id_gemm::dispatch_gemm_q4k_moe_id_on_encoder(
+                    &st().pipes.device,
+                    enc,
+                    blocks,
+                    *byte_offset,
+                    a_buf,
+                    ids_buf,
+                    tpe_buf,
+                    out_buf,
+                    *num_experts,
+                    *n_rows,
+                    *n_cols,
+                    ne11,
+                    top_k,
+                    max_per_expert,
+                    batch,
+                );
+                Ok(())
+            }
+            MetalQuantStore::Q6KExperts {
+                blocks,
+                byte_offset,
+                num_experts,
+                n_rows,
+                n_cols,
+            } => {
+                crate::q6_k_moe_id_gemm::dispatch_gemm_q6k_moe_id_on_encoder(
+                    &st().pipes.device,
+                    enc,
+                    blocks,
+                    *byte_offset,
+                    a_buf,
+                    ids_buf,
+                    tpe_buf,
+                    out_buf,
+                    *num_experts,
+                    *n_rows,
+                    *n_cols,
+                    ne11,
+                    top_k,
+                    max_per_expert,
+                    batch,
+                );
+                Ok(())
+            }
+            _ => unreachable!("constructor guarantees experts variant"),
+        }
+    }
+
+    fn gemm_moe_id_indirect(
+        &self,
+        ctx: &mut <MetalBackend as crate::backend::Backend>::Context,
+        src1: &<MetalBackend as crate::backend::Backend>::Buffer,
+        ids: &<MetalBackend as crate::backend::Backend>::Buffer,
+        tpe: &<MetalBackend as crate::backend::Backend>::Buffer,
+        out: &mut <MetalBackend as crate::backend::Backend>::Buffer,
+        args_buf: &<MetalBackend as crate::backend::Backend>::Buffer,
+        ne11: usize,
+        top_k: usize,
+        max_per_expert: usize,
+        batch: usize,
+    ) -> Result<()> {
+        let a_buf = src1.expect_f32("gemm_moe_id_indirect a");
+        let ids_buf = &ids.raw;
+        let tpe_buf = &tpe.raw;
+        let out_buf = out.expect_f32_mut("gemm_moe_id_indirect out");
+        let args = &args_buf.raw;
+        let enc = ctx.compute_encoder();
+        match &self.store {
+            MetalQuantStore::Q4KExperts {
+                blocks,
+                byte_offset,
+                num_experts,
+                n_rows,
+                n_cols,
+            } => {
+                crate::q4_k_moe_id_gemm::dispatch_gemm_q4k_moe_id_indirect_on_encoder(
+                    &st().pipes.device,
+                    enc,
+                    blocks,
+                    *byte_offset,
+                    a_buf,
+                    ids_buf,
+                    tpe_buf,
+                    out_buf,
+                    args,
+                    *num_experts,
+                    *n_rows,
+                    *n_cols,
+                    ne11,
+                    top_k,
+                    max_per_expert,
+                    batch,
+                );
+                Ok(())
+            }
+            MetalQuantStore::Q6KExperts {
+                blocks,
+                byte_offset,
+                num_experts,
+                n_rows,
+                n_cols,
+            } => {
+                crate::q6_k_moe_id_gemm::dispatch_gemm_q6k_moe_id_indirect_on_encoder(
+                    &st().pipes.device,
+                    enc,
+                    blocks,
+                    *byte_offset,
+                    a_buf,
+                    ids_buf,
+                    tpe_buf,
+                    out_buf,
+                    args,
+                    *num_experts,
+                    *n_rows,
+                    *n_cols,
+                    ne11,
+                    top_k,
+                    max_per_expert,
+                    batch,
+                );
+                Ok(())
+            }
+            _ => unreachable!("constructor guarantees experts variant"),
+        }
+    }
+}

--- a/crates/ferrum-kernels/src/stacked_expert.rs
+++ b/crates/ferrum-kernels/src/stacked_expert.rs
@@ -1,0 +1,154 @@
+//! `StackedExpertGgufLinear<B>` — abstraction for "N MoE experts' GGUF
+//! quantized weights stored contiguously, dispatched as one batched
+//! MoE GEMV/GEMM kernel".
+//!
+//! Phase 3e/4 (sibling to `Linear<B>`): replaces the `*_moe_id*`
+//! trait methods on `BackendQuantGguf` and the `type QuantStore`
+//! associated type on `Backend`. Same goal as PR #123 (Marlin Linear
+//! cutover): make weight-format a polymorphism point that doesn't
+//! leak into the `Backend` trait.
+//!
+//! Concrete impls live in `quant_linear/`:
+//!   - `quant_linear::metal_gguf_moe::MetalStackedExpertGgufLinear`
+//!     (wraps Metal `Q4KExperts` / `Q6KExperts` `MetalQuantStore`
+//!     variants, dispatches via `dispatch_gemv_moe_id*` /
+//!     `dispatch_gemm_moe_id*`).
+//!   - CPU has no MoE batched kernel today — the trait default
+//!     `Unsupported` is fine; ExpertStack falls back to per-expert
+//!     `Linear<B>` calls.
+//!   - CUDA's stacked-expert path goes through `make_stacked_expert_linear`
+//!     (returns `Box<dyn Linear<Self>>`) since it's Marlin tiles, not
+//!     GGUF k-quant. That path stays unchanged.
+//!
+//! The trait surface is **7 methods**: one GEMV per dispatch shape
+//! (single / offset / batched / fused-gate-up-silu / batched-fused) +
+//! two GEMM variants (direct / indirect-args). Each is a one-line
+//! wrapper over a backend-specific dispatcher in practice.
+
+use crate::backend::Backend;
+use ferrum_types::Result;
+
+/// MoE-stacked GGUF-quantized linear: holds N experts' weights for one
+/// matmul role (gate / up / down) in one contiguous buffer, dispatches
+/// `out[pair] = a[pair] @ dequant(W[ids[pair]])^T` over all `(token,
+/// slot)` pairs in a single backend launch.
+pub trait StackedExpertGgufLinear<B: Backend>: Send + Sync {
+    fn num_experts(&self) -> usize;
+    /// Per-expert output features (n_rows).
+    fn n_rows(&self) -> usize;
+    /// Input features (n_cols). Common across experts.
+    fn n_cols(&self) -> usize;
+
+    /// Downcast hook for fused multi-store methods (`gemv_moe_id_gate_up_silu*`)
+    /// — the impl needs to reach into the *up* projection's concrete store
+    /// to access raw GPU resources. Standard `dyn Any` pattern; only used at
+    /// FFN dispatch boundaries (low frequency vs the per-pair kernel work).
+    fn as_any(&self) -> &dyn std::any::Any;
+
+    /// MoE indirect-dispatch GEMV (single-token decode path):
+    /// `out[i, :] = a[off(i, src1_stride), :] @ dequant(W[ids[i], :])^T` for `i ∈ [0, n_selected)`.
+    fn gemv_moe_id(
+        &self,
+        ctx: &mut B::Context,
+        a: &B::Buffer,
+        ids: &B::Buffer,
+        out: &mut B::Buffer,
+        n_selected: usize,
+        src1_stride: usize,
+    ) -> Result<()>;
+
+    /// Offset-aware variant — `a` starts at `a_offset` (elements), `ids` at
+    /// `ids_offset`. Used by the per-item batched decode loop to read
+    /// directly from the M-batch buffer without per-iter copies.
+    #[allow(clippy::too_many_arguments)]
+    fn gemv_moe_id_offset(
+        &self,
+        ctx: &mut B::Context,
+        a: &B::Buffer,
+        a_offset: usize,
+        ids: &B::Buffer,
+        ids_offset: usize,
+        out: &mut B::Buffer,
+        n_selected: usize,
+        src1_stride: usize,
+    ) -> Result<()>;
+
+    /// Fused gate+up MoE GEMV with in-register `SiLU(gate) * up`.
+    /// Folds 3 dispatches (gate gemv, up gemv, silu_mul) into one.
+    /// `other` is the up-projection weight stack (must match shape).
+    fn gemv_moe_id_gate_up_silu(
+        &self,
+        ctx: &mut B::Context,
+        a: &B::Buffer,
+        other_up: &dyn StackedExpertGgufLinear<B>,
+        ids: &B::Buffer,
+        silu_out: &mut B::Buffer,
+        n_selected: usize,
+    ) -> Result<()>;
+
+    /// Batched MoE GEMV — one launch covers all `m * top_k` pairs.
+    /// `pair p` reads `a[(p/top_k) * src1_outer_stride + (p%top_k) * src1_inner_stride]`.
+    #[allow(clippy::too_many_arguments)]
+    fn gemv_moe_id_batched(
+        &self,
+        ctx: &mut B::Context,
+        a: &B::Buffer,
+        ids: &B::Buffer,
+        out: &mut B::Buffer,
+        m: usize,
+        top_k: usize,
+        src1_outer_stride: usize,
+        src1_inner_stride: usize,
+    ) -> Result<()>;
+
+    /// Batched fused gate+up GEMV — counterpart of
+    /// `gemv_moe_id_gate_up_silu` for the m≥2 batched-decode path.
+    #[allow(clippy::too_many_arguments)]
+    fn gemv_moe_id_gate_up_silu_batched(
+        &self,
+        ctx: &mut B::Context,
+        a: &B::Buffer,
+        other_up: &dyn StackedExpertGgufLinear<B>,
+        ids: &B::Buffer,
+        silu_out: &mut B::Buffer,
+        m: usize,
+        top_k: usize,
+        src1_outer_stride: usize,
+        src1_inner_stride: usize,
+    ) -> Result<()>;
+
+    /// MoE 2-D indirect-dispatch GEMM (prefill, m > 1).
+    /// `out[token, slot, :] = a[token, slot_or_0, :] @ dequant(W[expert(token, slot)])^T`.
+    #[allow(clippy::too_many_arguments)]
+    fn gemm_moe_id(
+        &self,
+        ctx: &mut B::Context,
+        a: &B::Buffer,
+        ids: &B::Buffer,
+        tpe: &B::Buffer,
+        out: &mut B::Buffer,
+        ne11: usize,
+        top_k: usize,
+        max_per_expert: usize,
+        batch: usize,
+    ) -> Result<()>;
+
+    /// Indirect-dispatch GEMM — grid read from `args_buf` (12-byte u32
+    /// triple written by `compute_ids_tpe_gpu`) instead of computed from
+    /// `max_per_expert`. Eliminates the host-side D2H of `tpe` that the
+    /// direct variant needs.
+    #[allow(clippy::too_many_arguments)]
+    fn gemm_moe_id_indirect(
+        &self,
+        ctx: &mut B::Context,
+        src1: &B::Buffer,
+        ids: &B::Buffer,
+        tpe: &B::Buffer,
+        out: &mut B::Buffer,
+        args_buf: &B::Buffer,
+        ne11: usize,
+        top_k: usize,
+        max_per_expert: usize,
+        batch: usize,
+    ) -> Result<()>;
+}

--- a/crates/ferrum-models/src/moe/dispatch.rs
+++ b/crates/ferrum-models/src/moe/dispatch.rs
@@ -29,7 +29,7 @@ use ferrum_kernels::backend::{
     Backend, BackendMoeFused, BackendPagedKv, BackendQuantGguf, BackendQuantMarlin, GgufQuantType,
     LlmBackend, QuantLlmBackend,
 };
-use ferrum_kernels::Linear;
+use ferrum_kernels::{Linear, StackedExpertGgufLinear};
 use ferrum_quantization::gguf::GgufFile;
 use ferrum_quantization::{DenseLinear, QuantLinear};
 use ferrum_types::{FerrumError, Result};
@@ -89,17 +89,18 @@ pub struct ExpertStack<B: QuantLlmBackend + BackendMoeFused> {
     /// Stacked-experts representation for backends that have a batched
     /// MoE indirect-dispatch kernel (Metal `gemv_q4kw_moe_id_f32` /
     /// `gemv_q6kw_moe_id_f32`). Holds **all experts** for one matmul
-    /// role in a single `B::QuantStore` with byte stride between expert
-    /// slabs, so a single dispatch can cover all selected (token, expert)
-    /// pairs at decode m=1.
+    /// role behind a `StackedExpertGgufLinear<B>` (typically backed by a
+    /// single GPU buffer with byte stride between expert slabs), so a
+    /// single dispatch can cover all selected (token, expert) pairs at
+    /// decode m=1.
     ///
     /// `None` on backends without the kernel (CPU, CUDA-without-MoE-kernel)
     /// and on quant flavours that don't have a stacked path yet — callers
     /// fall back to the per-expert `gate_up` / `down` Linears in those
     /// cases.
-    pub gate_stacked: Option<B::QuantStore>,
-    pub up_stacked: Option<B::QuantStore>,
-    pub down_stacked: Option<B::QuantStore>,
+    pub gate_stacked: Option<Box<dyn StackedExpertGgufLinear<B>>>,
+    pub up_stacked: Option<Box<dyn StackedExpertGgufLinear<B>>>,
+    pub down_stacked: Option<Box<dyn StackedExpertGgufLinear<B>>>,
 
     /// Stacked GPTQ Marlin stores for the bucketed CUDA path. When both
     /// are Some, [`moe_forward_bucketed`] dispatches expert GEMMs as
@@ -139,10 +140,10 @@ impl<B: QuantLlmBackend + BackendMoeFused> ExpertStack<B> {
         out: &mut B::Buffer,
         top_k: usize,
     ) -> Result<()> {
-        let weight = self.gate_stacked.as_ref().ok_or_else(|| {
+        let weight = self.gate_stacked.as_deref().ok_or_else(|| {
             FerrumError::unsupported("ExpertStack::gemv_gate: gate_stacked not loaded")
         })?;
-        B::gemv_quant_moe_id(ctx, input, weight, ids, out, top_k, 0)
+        weight.gemv_moe_id(ctx, input, ids, out, top_k, 0)
     }
 
     /// Up projection: same shape as gate, broadcast input.
@@ -154,10 +155,10 @@ impl<B: QuantLlmBackend + BackendMoeFused> ExpertStack<B> {
         out: &mut B::Buffer,
         top_k: usize,
     ) -> Result<()> {
-        let weight = self.up_stacked.as_ref().ok_or_else(|| {
+        let weight = self.up_stacked.as_deref().ok_or_else(|| {
             FerrumError::unsupported("ExpertStack::gemv_up: up_stacked not loaded")
         })?;
-        B::gemv_quant_moe_id(ctx, input, weight, ids, out, top_k, 0)
+        weight.gemv_moe_id(ctx, input, ids, out, top_k, 0)
     }
 
     /// Down projection: per-slot input via `in_stride = expert_intermediate`.
@@ -171,10 +172,10 @@ impl<B: QuantLlmBackend + BackendMoeFused> ExpertStack<B> {
         top_k: usize,
         expert_intermediate: usize,
     ) -> Result<()> {
-        let weight = self.down_stacked.as_ref().ok_or_else(|| {
+        let weight = self.down_stacked.as_deref().ok_or_else(|| {
             FerrumError::unsupported("ExpertStack::gemv_down: down_stacked not loaded")
         })?;
-        B::gemv_quant_moe_id(ctx, input, weight, ids, out, top_k, expert_intermediate)
+        weight.gemv_moe_id(ctx, input, ids, out, top_k, expert_intermediate)
     }
 
     /// Fused gate + up + SiLU·gate: replaces 3 separate dispatches with 1.
@@ -188,15 +189,15 @@ impl<B: QuantLlmBackend + BackendMoeFused> ExpertStack<B> {
         out_silu_stacked: &mut B::Buffer,
         top_k: usize,
     ) -> Result<()> {
-        let gate = self.gate_stacked.as_ref().ok_or_else(|| {
+        let gate = self.gate_stacked.as_deref().ok_or_else(|| {
             FerrumError::unsupported(
                 "ExpertStack::gemv_gate_up_silu_fused: gate_stacked not loaded",
             )
         })?;
-        let up = self.up_stacked.as_ref().ok_or_else(|| {
+        let up = self.up_stacked.as_deref().ok_or_else(|| {
             FerrumError::unsupported("ExpertStack::gemv_gate_up_silu_fused: up_stacked not loaded")
         })?;
-        B::gemv_quant_moe_id_gate_up_silu(ctx, input, gate, up, ids, out_silu_stacked, top_k)
+        gate.gemv_moe_id_gate_up_silu(ctx, input, up, ids, out_silu_stacked, top_k)
     }
 
     // ── Prefill GEMM dispatch (Phase 3d) ──
@@ -225,14 +226,13 @@ impl<B: QuantLlmBackend + BackendMoeFused> ExpertStack<B> {
         max_per_expert: usize,
         tokens: usize,
     ) -> Result<()> {
-        let weight = self.gate_stacked.as_ref().ok_or_else(|| {
+        let weight = self.gate_stacked.as_deref().ok_or_else(|| {
             FerrumError::unsupported("ExpertStack::gemm_gate: gate_stacked not loaded")
         })?;
         match args_buf {
-            Some(args) => B::gemm_quant_moe_id_indirect(
+            Some(args) => weight.gemm_moe_id_indirect(
                 ctx,
                 src1,
-                weight,
                 ids,
                 tpe,
                 dst,
@@ -242,18 +242,7 @@ impl<B: QuantLlmBackend + BackendMoeFused> ExpertStack<B> {
                 max_per_expert,
                 tokens,
             ),
-            None => B::gemm_quant_moe_id(
-                ctx,
-                src1,
-                weight,
-                ids,
-                tpe,
-                dst,
-                1,
-                top_k,
-                max_per_expert,
-                tokens,
-            ),
+            None => weight.gemm_moe_id(ctx, src1, ids, tpe, dst, 1, top_k, max_per_expert, tokens),
         }
     }
 
@@ -271,14 +260,13 @@ impl<B: QuantLlmBackend + BackendMoeFused> ExpertStack<B> {
         max_per_expert: usize,
         tokens: usize,
     ) -> Result<()> {
-        let weight = self.up_stacked.as_ref().ok_or_else(|| {
+        let weight = self.up_stacked.as_deref().ok_or_else(|| {
             FerrumError::unsupported("ExpertStack::gemm_up: up_stacked not loaded")
         })?;
         match args_buf {
-            Some(args) => B::gemm_quant_moe_id_indirect(
+            Some(args) => weight.gemm_moe_id_indirect(
                 ctx,
                 src1,
-                weight,
                 ids,
                 tpe,
                 dst,
@@ -288,18 +276,7 @@ impl<B: QuantLlmBackend + BackendMoeFused> ExpertStack<B> {
                 max_per_expert,
                 tokens,
             ),
-            None => B::gemm_quant_moe_id(
-                ctx,
-                src1,
-                weight,
-                ids,
-                tpe,
-                dst,
-                1,
-                top_k,
-                max_per_expert,
-                tokens,
-            ),
+            None => weight.gemm_moe_id(ctx, src1, ids, tpe, dst, 1, top_k, max_per_expert, tokens),
         }
     }
 
@@ -318,14 +295,13 @@ impl<B: QuantLlmBackend + BackendMoeFused> ExpertStack<B> {
         max_per_expert: usize,
         tokens: usize,
     ) -> Result<()> {
-        let weight = self.down_stacked.as_ref().ok_or_else(|| {
+        let weight = self.down_stacked.as_deref().ok_or_else(|| {
             FerrumError::unsupported("ExpertStack::gemm_down: down_stacked not loaded")
         })?;
         match args_buf {
-            Some(args) => B::gemm_quant_moe_id_indirect(
+            Some(args) => weight.gemm_moe_id_indirect(
                 ctx,
                 src1,
-                weight,
                 ids,
                 tpe,
                 dst,
@@ -335,10 +311,9 @@ impl<B: QuantLlmBackend + BackendMoeFused> ExpertStack<B> {
                 max_per_expert,
                 tokens,
             ),
-            None => B::gemm_quant_moe_id(
+            None => weight.gemm_moe_id(
                 ctx,
                 src1,
-                weight,
                 ids,
                 tpe,
                 dst,
@@ -369,13 +344,12 @@ impl<B: QuantLlmBackend + BackendMoeFused> ExpertStack<B> {
         src1_outer_stride: usize,
         src1_inner_stride: usize,
     ) -> Result<()> {
-        let weight = self.gate_stacked.as_ref().ok_or_else(|| {
+        let weight = self.gate_stacked.as_deref().ok_or_else(|| {
             FerrumError::unsupported("ExpertStack::gemv_gate_batched: gate_stacked not loaded")
         })?;
-        B::gemv_quant_moe_id_batched(
+        weight.gemv_moe_id_batched(
             ctx,
             input,
-            weight,
             ids,
             dst,
             m,
@@ -398,13 +372,12 @@ impl<B: QuantLlmBackend + BackendMoeFused> ExpertStack<B> {
         src1_outer_stride: usize,
         src1_inner_stride: usize,
     ) -> Result<()> {
-        let weight = self.up_stacked.as_ref().ok_or_else(|| {
+        let weight = self.up_stacked.as_deref().ok_or_else(|| {
             FerrumError::unsupported("ExpertStack::gemv_up_batched: up_stacked not loaded")
         })?;
-        B::gemv_quant_moe_id_batched(
+        weight.gemv_moe_id_batched(
             ctx,
             input,
-            weight,
             ids,
             dst,
             m,
@@ -427,13 +400,12 @@ impl<B: QuantLlmBackend + BackendMoeFused> ExpertStack<B> {
         src1_outer_stride: usize,
         src1_inner_stride: usize,
     ) -> Result<()> {
-        let weight = self.down_stacked.as_ref().ok_or_else(|| {
+        let weight = self.down_stacked.as_deref().ok_or_else(|| {
             FerrumError::unsupported("ExpertStack::gemv_down_batched: down_stacked not loaded")
         })?;
-        B::gemv_quant_moe_id_batched(
+        weight.gemv_moe_id_batched(
             ctx,
             input,
-            weight,
             ids,
             dst,
             m,
@@ -457,20 +429,19 @@ impl<B: QuantLlmBackend + BackendMoeFused> ExpertStack<B> {
         src1_outer_stride: usize,
         src1_inner_stride: usize,
     ) -> Result<()> {
-        let gate = self.gate_stacked.as_ref().ok_or_else(|| {
+        let gate = self.gate_stacked.as_deref().ok_or_else(|| {
             FerrumError::unsupported(
                 "ExpertStack::gemv_gate_up_silu_batched_fused: gate_stacked not loaded",
             )
         })?;
-        let up = self.up_stacked.as_ref().ok_or_else(|| {
+        let up = self.up_stacked.as_deref().ok_or_else(|| {
             FerrumError::unsupported(
                 "ExpertStack::gemv_gate_up_silu_batched_fused: up_stacked not loaded",
             )
         })?;
-        B::gemv_quant_moe_id_gate_up_silu_batched(
+        gate.gemv_moe_id_gate_up_silu_batched(
             ctx,
             input,
-            gate,
             up,
             ids,
             silu_out,
@@ -500,14 +471,13 @@ impl<B: QuantLlmBackend + BackendMoeFused> ExpertStack<B> {
         top_k: usize,
         src1_stride: usize,
     ) -> Result<()> {
-        let weight = self.gate_stacked.as_ref().ok_or_else(|| {
+        let weight = self.gate_stacked.as_deref().ok_or_else(|| {
             FerrumError::unsupported("ExpertStack::gemv_gate_offset: gate_stacked not loaded")
         })?;
-        B::gemv_quant_moe_id_offset(
+        weight.gemv_moe_id_offset(
             ctx,
             src1,
             src1_offset,
-            weight,
             ids,
             ids_offset,
             dst,
@@ -529,14 +499,13 @@ impl<B: QuantLlmBackend + BackendMoeFused> ExpertStack<B> {
         top_k: usize,
         src1_stride: usize,
     ) -> Result<()> {
-        let weight = self.up_stacked.as_ref().ok_or_else(|| {
+        let weight = self.up_stacked.as_deref().ok_or_else(|| {
             FerrumError::unsupported("ExpertStack::gemv_up_offset: up_stacked not loaded")
         })?;
-        B::gemv_quant_moe_id_offset(
+        weight.gemv_moe_id_offset(
             ctx,
             src1,
             src1_offset,
-            weight,
             ids,
             ids_offset,
             dst,
@@ -558,14 +527,13 @@ impl<B: QuantLlmBackend + BackendMoeFused> ExpertStack<B> {
         top_k: usize,
         src1_stride: usize,
     ) -> Result<()> {
-        let weight = self.down_stacked.as_ref().ok_or_else(|| {
+        let weight = self.down_stacked.as_deref().ok_or_else(|| {
             FerrumError::unsupported("ExpertStack::gemv_down_offset: down_stacked not loaded")
         })?;
-        B::gemv_quant_moe_id_offset(
+        weight.gemv_moe_id_offset(
             ctx,
             src1,
             src1_offset,
-            weight,
             ids,
             ids_offset,
             dst,


### PR DESCRIPTION
## Summary

\`type QuantStore: Send + Sync\` on the base \`Backend\` trait was load-bearing only on Metal — CUDA had \`type QuantStore = ()\` placeholder, CPU had \`CpuQuantStore::Q4K\` used only by \`load_quant\`/\`gemm_quant\` (already returning \`Box<dyn Linear<Self>>\`). The 7 MoE-stacked methods on \`BackendQuantGguf\` (\`gemv_quant_moe_id*\` / \`gemm_quant_moe_id*\`) were the entire reason \`QuantStore\` existed on the trait.

Sibling cutover to PR #123's Marlin Linear refactor:

**New** — \`crate::stacked_expert::StackedExpertGgufLinear<B>\` trait (\`crates/ferrum-kernels/src/stacked_expert.rs\`):
- 7 methods mirroring the deleted Backend methods (5 GEMV variants + 2 GEMM variants)
- \`as_any()\` hook for cross-impl downcast in fused \`gate_up_silu*\` methods

**New** — \`MetalStackedExpertGgufLinear\` impl (\`crates/ferrum-kernels/src/quant_linear/metal_gguf_moe.rs\`):
- Wraps existing \`MetalQuantStore::Q4KExperts\` / \`Q6KExperts\` variants
- Each method body is a thin wrapper over the existing \`dispatch_gemv_moe_id*\` / \`dispatch_gemm_moe_id*\` free functions — kernel calls byte-identical

**Removed**:
- \`type QuantStore: Send + Sync\` from \`Backend\` (+ \`type QuantStore = ...\` lines on CPU/Metal impls; CUDA had \`()\`)
- 7 MoE-id methods from \`BackendQuantGguf\` trait + Metal impls
- \`type QuantStore\` reference in \`metal_gemm_quant_dispatch\` (changed to direct \`&MetalQuantStore\`)

**Changed**:
- \`Backend::load_quant_experts\` return type: \`Result<Self::QuantStore>\` → \`Result<Box<dyn StackedExpertGgufLinear<Self>>>\`
- \`ExpertStack<B>\` fields \`gate_stacked\` / \`up_stacked\` / \`down_stacked\`: \`Option<B::QuantStore>\` → \`Option<Box<dyn StackedExpertGgufLinear<B>>>\`
- 15 \`ExpertStack\` wrapper methods rewrite \`B::gemv_quant_moe_id*(weight, ...)\` to \`weight.gemv_moe_id*(...)\`

Net: **Backend trait surface area drops by 7 methods + 1 associated type**. Adding a new k-quant flavour for MoE = new variant inside the backend's concrete \`StackedExpertGgufLinear\` impl, NO Backend trait churn. Same Dim-3 polymorphism contract that PR #123 established for Marlin single-linear, now extended to MoE-stacked GGUF.

GPTQ's \`type GptqStore\` stays for now — its load inputs are split arrays (qweight/scales/qzeros), needs a matched follow-up PR.

## Test plan

- [x] \`cargo check --workspace --no-default-features\` clean (Mac CPU-only)
- [x] \`cargo check --workspace --all-targets --features metal\` clean
- [x] \`cargo test --workspace --no-default-features\` — full pass
- [x] \`cargo test --features metal -p ferrum-models --test moe_bucketed_parity_test\` passes
- [x] Metal smoke: Qwen3-0.6B safetensors c=1 = 58.2 tok/s (regression check on non-MoE path)
- [ ] **Metal MoE smoke: Qwen3-30B-A3B Q4_K_M (you have it locally — verify the new \`StackedExpertGgufLinear\` path actually drives the GPU kernel)**
- [ ] CUDA cargo check (Vast pod was offline at submission — type-system clean: CUDA's \`type QuantStore = ()\` had no consumers; all 7 deleted methods were Unsupported defaults on CUDA)

## Diff

- 8 files changed, 746 insertions(+), 759 deletions(-)
- 2 new files: \`stacked_expert.rs\` (154 lines) + \`quant_linear/metal_gguf_moe.rs\` (504 lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)