### PR TITLE
fix(backend): write_u32 default panics instead of silent no-op (footgun)

### DIFF
--- a/crates/ferrum-kernels/src/backend/traits.rs
+++ b/crates/ferrum-kernels/src/backend/traits.rs
@@ -701,12 +701,21 @@ pub trait Backend: Send + Sync + Sized + 'static {
     /// [`Self::alloc_u32`]. Used for live block_tables / context_lens
     /// updates between decode steps.
     ///
-    /// Default: reads back, mutates host-side, writes back. Metal
-    /// backend overrides with a direct memcpy on the StorageModeShared
-    /// buffer.
-    fn write_u32(_ctx: &mut Self::Context, _dst: &mut Self::Buffer, _data: &[u32]) {
-        // No-op default — most backends won't exercise this path until
-        // they implement paged_decode_attention.
+    /// Default: **panics** — backends MUST override if they support
+    /// paged-KV / batched decode (any path that writes block tables,
+    /// context lens, pos offsets, expert ids, or other u32 scratch).
+    /// The old no-op default was a silent-failure footgun: a backend
+    /// that forgot to override would have callers writing into a
+    /// buffer that stayed zero-initialised, producing garbage output
+    /// at the next read with NO error surfaced. Today CUDA and Metal
+    /// both override; CPU doesn't (CPU has no paged-KV impl either).
+    fn write_u32(_ctx: &mut Self::Context, _dst: &mut Self::Buffer, data: &[u32]) {
+        panic!(
+            "Backend::write_u32 default invoked for backend `{}` — data.len()={} would silently \
+             not be written. Backends that allocate u32 scratch via `alloc_u32` MUST override.",
+            std::any::type_name::<Self>(),
+            data.len()
+        );
     }
 
     /// Append new K/V into a pre-allocated head-major cache buffer.


### PR DESCRIPTION
## Summary

\`Backend::write_u32\`'s default was literally:

\`\`\`rust
fn write_u32(_ctx: &mut Self::Context, _dst: &mut Self::Buffer, _data: &[u32]) {
    // No-op default — most backends won't exercise this path until
    // they implement paged_decode_attention.
}
\`\`\`

If any backend implementing paged-KV / batched-decode forgot to override, callers writing block_tables / context_lens / pos_offsets / expert_ids / cu_seqlens_q would silently write into a buffer that stayed zero-initialised → garbage output, no error.

Today CUDA + Metal both override with real impls. CPU doesn't, but also doesn't run paged-KV. Future risk only — but a real footgun for new backends (AMD, Intel, etc.).

**Switch default to \`panic!\`** with a backend-name + data-len message. Same shape as the rest of the trait's "must override" methods. CUDA + Metal unaffected. CPU would now panic on a paged call — a clear error beats silent garbage.

This is the first concrete fix from the chat thread on Backend trait warts (alongside the typed-buffer migration scoped for the next session).

## Test plan
- [x] \`cargo check --workspace --features metal\` clean
- [x] \`cargo test --workspace --no-default-features\` — full pass (no caller invokes the default — CPU's no-paged-KV branch is gated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)