### PR TITLE
refactor(buffer): drop F16-assuming CudaBuf forwarders (Phase D step 1)

### DIFF
--- a/crates/ferrum-kernels/src/backend/buffer.rs
+++ b/crates/ferrum-kernels/src/backend/buffer.rs
@@ -256,38 +256,6 @@ impl CudaBuf {
         CudaBuf::I8(s)
     }
 
-    /// Forwarders that assume F16 — the common case for the existing
-    /// CUDA kernel call sites. Each panics on a non-F16 variant; the
-    /// migration to per-dtype-aware callsites is the rest of Phase B-2.
-    pub fn slice<R: std::ops::RangeBounds<usize>>(
-        &self,
-        range: R,
-    ) -> cudarc::driver::CudaView<'_, f16> {
-        self.as_f16().slice(range)
-    }
-    pub fn slice_mut<R: std::ops::RangeBounds<usize>>(
-        &mut self,
-        range: R,
-    ) -> cudarc::driver::CudaViewMut<'_, f16> {
-        self.as_f16_mut().slice_mut(range)
-    }
-    /// Forward to inner CudaSlice's device_ptr — only valid for F16
-    /// variant (panic otherwise). Used by kernel launch sites that
-    /// need a raw `(u64, _guard)` device pointer pair.
-    pub fn device_ptr<'a>(
-        &'a self,
-        stream: &'a std::sync::Arc<cudarc::driver::CudaStream>,
-    ) -> (u64, cudarc::driver::SyncOnDrop<'a>) {
-        use cudarc::driver::DevicePtr;
-        self.as_f16().device_ptr(stream)
-    }
-    pub fn device_ptr_mut<'a>(
-        &'a mut self,
-        stream: &'a std::sync::Arc<cudarc::driver::CudaStream>,
-    ) -> (u64, cudarc::driver::SyncOnDrop<'a>) {
-        use cudarc::driver::DevicePtrMut;
-        self.as_f16_mut().device_ptr_mut(stream)
-    }
     /// Bit-reinterpret the underlying buffer as a view of another type.
     /// Dispatches on the active variant so callers don't have to know
     /// which inner `CudaSlice<T>` holds the bytes — handy when integer

--- a/crates/ferrum-kernels/src/backend/cuda/mod.rs
+++ b/crates/ferrum-kernels/src/backend/cuda/mod.rs
@@ -482,7 +482,7 @@ impl Backend for CudaBackend {
             // PARTIAL read (len < buf capacity), e.g. reading only 4 rows
             // out of a batch_logits buffer sized for max_batch. Slice the
             // device buffer so its reported length matches `len`.
-            let view = buf.slice(0..len);
+            let view = buf.as_f16().slice(0..len);
             stream.memcpy_dtoh(&view, &mut host).expect("cuda dtoh");
             stream.synchronize().expect("cuda dtoh sync");
             host.into_iter().map(|x| x.to_f32()).collect()
@@ -581,9 +581,9 @@ impl Backend for CudaBackend {
         // cuBLAS is set to CUBLAS_POINTER_MODE_DEVICE (see ensure_blas_handle)
         // so alpha/beta are read from device memory. Using the process-global
         // alpha_f32/beta_f32 slices keeps pointers stable for graph capture.
-        let (a_ptr, _rec_a) = b.device_ptr(&ctx.stream); // cuBLAS arg "A" = weight = our `b`
-        let (b_ptr, _rec_b) = a.device_ptr(&ctx.stream); // cuBLAS arg "B" = input = our `a`
-        let (c_ptr, _rec_c) = out.device_ptr_mut(&ctx.stream);
+        let (a_ptr, _rec_a) = b.as_f16().device_ptr(&ctx.stream); // cuBLAS arg "A" = weight = our `b`
+        let (b_ptr, _rec_b) = a.as_f16().device_ptr(&ctx.stream); // cuBLAS arg "B" = input = our `a`
+        let (c_ptr, _rec_c) = out.as_f16_mut().device_ptr_mut(&ctx.stream);
         let blas_guard = blas_slot().read().expect("BLAS poisoned");
         let slot = blas_guard.as_ref().expect("BLAS not init");
         let (alpha_ptr, _ga) = slot.alpha_f32.device_ptr(&ctx.stream);
@@ -783,8 +783,8 @@ impl Backend for CudaBackend {
         dst_offset: usize,
         len: usize,
     ) {
-        let src_view = src.slice(src_offset..src_offset + len);
-        let mut dst_view = dst.slice_mut(dst_offset..dst_offset + len);
+        let src_view = src.as_f16().slice(src_offset..src_offset + len);
+        let mut dst_view = dst.as_f16_mut().slice_mut(dst_offset..dst_offset + len);
         ctx.stream
             .memcpy_dtod(&src_view, &mut dst_view)
             .expect("copy_slice dtod");
@@ -984,7 +984,7 @@ impl Backend for CudaBackend {
         let grid_x = (per_item as u32 + block_dim - 1) / block_dim;
         with_batched_scratch_mut(|slot_g| {
             for i in 0..m {
-                let (cp, _) = caches[i].device_ptr(&stream);
+                let (cp, _) = caches[i].as_f16().device_ptr(&stream);
                 slot_g.host_cache_ptrs[host_start + i] = cp;
             }
             // Async memcpy host_slice → device per-slot region. Recorded
@@ -1075,8 +1075,8 @@ impl Backend for CudaBackend {
         let shared_bytes = (max_valid_kv.min(capacity).max(1) as u32) * 4;
         with_batched_scratch_mut(|slot_g| {
             for i in 0..m {
-                let (kp, _) = k_caches[i].device_ptr(&stream);
-                let (vp, _) = v_caches[i].device_ptr(&stream);
+                let (kp, _) = k_caches[i].as_f16().device_ptr(&stream);
+                let (vp, _) = v_caches[i].as_f16().device_ptr(&stream);
                 slot_g.host_k_ptrs[host_start + i] = kp;
                 slot_g.host_v_ptrs[host_start + i] = vp;
             }
@@ -1490,8 +1490,8 @@ impl Backend for CudaBackend {
         let in_byte_off = in_row_offset * 2 * intermediate * std::mem::size_of::<half::f16>();
         let out_byte_off = out_row_offset * intermediate * std::mem::size_of::<half::f16>();
 
-        let (gu_base, _g) = gate_up.device_ptr(&stream);
-        let (out_base, _g2) = out.device_ptr_mut(&stream);
+        let (gu_base, _g) = gate_up.as_f16().device_ptr(&stream);
+        let (out_base, _g2) = out.as_f16_mut().device_ptr_mut(&stream);
         let gu_ptr = gu_base + in_byte_off as u64;
         let out_ptr = out_base + out_byte_off as u64;
 
@@ -1602,7 +1602,7 @@ impl Backend for CudaBackend {
     fn zero_buffer(ctx: &mut Self::Context, buf: &mut Self::Buffer, len: usize) -> Result<()> {
         use cudarc::driver::DevicePtr;
         let stream = ctx.stream.clone();
-        let (ptr, _g) = buf.device_ptr(&stream);
+        let (ptr, _g) = buf.as_f16().device_ptr(&stream);
         unsafe {
             cudarc::driver::sys::cuMemsetD16Async(
                 ptr as cudarc::driver::sys::CUdeviceptr,

--- a/crates/ferrum-kernels/src/backend/cuda/paged.rs
+++ b/crates/ferrum-kernels/src/backend/cuda/paged.rs
@@ -550,8 +550,8 @@ impl BackendPagedKv for CudaBackend {
             let k_off = li * BATCHED_SCRATCH_CAP;
             let v_off = (li + super::MAX_LAYERS_FOR_GRAPH) * BATCHED_SCRATCH_CAP;
             for i in 0..m {
-                let (kp, _) = k_caches[li * m + i].device_ptr(&stream);
-                let (vp, _) = v_caches[li * m + i].device_ptr(&stream);
+                let (kp, _) = k_caches[li * m + i].as_f16().device_ptr(&stream);
+                let (vp, _) = v_caches[li * m + i].as_f16().device_ptr(&stream);
                 ctx.batched_host_cache_ptrs[k_off + i] = kp;
                 ctx.batched_host_cache_ptrs[v_off + i] = vp;
                 ctx.batched_host_k_ptrs[k_off + i] = kp;
@@ -677,9 +677,9 @@ impl BackendPagedKv for CudaBackend {
         // CudaBuf::U32, the kernel reads them as `int*` — same wire-level
         // behavior as the prior f16-bit-tunneled layout but with a
         // dtype tag that prevents byte-count miscalculation.
-        let qv = q.slice(..);
-        let kp = k_pool.slice(..);
-        let vp = v_pool.slice(..);
+        let qv = q.as_f16().slice(..);
+        let kp = k_pool.as_f16().slice(..);
+        let vp = v_pool.as_f16().slice(..);
         let csq = cu_seqlens_q.as_u32().slice(..);
         let po = pos_offsets.as_u32().slice(..);
         let bt = block_tables.as_u32().slice(..);
@@ -946,9 +946,9 @@ impl BackendPagedKv for CudaBackend {
         );
         let scale: f32 = 1.0 / (head_dim as f32).sqrt();
         let stream = ctx.stream.clone();
-        let qv = q.slice(..);
-        let kp = k_pool.slice(..);
-        let vp = v_pool.slice(..);
+        let qv = q.as_f16().slice(..);
+        let kp = k_pool.as_f16().slice(..);
+        let vp = v_pool.as_f16().slice(..);
         // block_tables / valid_kv_lens are CudaBuf::U32 (typed since B-2);
         // slice the U32 variant to give the kernel an int* it can read.
         let bt = block_tables.as_u32().slice(..);


### PR DESCRIPTION
## Summary

Phase D step 1 of the typed-buffer cleanup (Phase B-2 #163 just merged). Removes the F16-assuming forwarders on \`CudaBuf\`:
- \`slice()\` / \`slice_mut()\`
- \`device_ptr()\` / \`device_ptr_mut()\`

These were added in B-2 to minimise callsite churn — they silently delegated to \`as_f16().slice(..)\` and panicked on non-F16 variants. A latent footgun that nearly bit the paged-decode int-scratch path during B-2.

## Change

At every callsite, write the explicit access mode: \`buf.as_f16().slice(..)\` for FP16 activations, \`buf.as_u32().slice(..)\` for int scratch. The dtype assumption now lives at the use site, where it's reviewable.

\`CudaBuf::transmute<T>\` stays (variant-aware) — bit-reinterpret access works regardless of underlying variant.

## Validation

- \`cargo check --workspace --features metal\` clean (Mac)
- \`cargo check -p ferrum-kernels --features cuda\` clean (validated on RTX 4090 pod before consolidation)

## What's next in Phase D

- Replace \`Backend::alloc_u32\` / \`write_u32\` with a typed \`Backend::alloc(Dtype, n)\` + \`write_typed_u32\`. Migrate the 5 callers in kv_layer.rs + paged.rs. Then delete the legacy methods.
- Same for \`from_slice_i32\` / \`write_i32_into\` / \`write_f32_into\` — the default impls bit-cast through f16 numeric conversion (broken on CUDA, works only because all non-zero callers happen to write zeros).

🤖 Generated with [Claude Code](https://claude.com/claude-code)