### PR TITLE
refactor(kernels): add MarlinExpertStack<B> trait (Phase C step 1)

### DIFF
--- a/crates/ferrum-kernels/src/lib.rs
+++ b/crates/ferrum-kernels/src/lib.rs
@@ -12,6 +12,9 @@ pub use linear::Linear;
 pub mod stacked_expert;
 pub use stacked_expert::StackedExpertGgufLinear;
 
+pub mod marlin_expert_stack;
+pub use marlin_expert_stack::MarlinExpertStack;
+
 pub mod quant_linear;
 
 pub mod attention;

--- a/crates/ferrum-kernels/src/marlin_expert_stack.rs
+++ b/crates/ferrum-kernels/src/marlin_expert_stack.rs
@@ -1,0 +1,102 @@
+//! `MarlinExpertStack<B>` — abstraction for "N MoE experts' Marlin
+//! GPTQ-INT4 tiles stored contiguously, dispatched as bucketed batched
+//! GEMM or vLLM fused MoE kernel".
+//!
+//! Phase C sibling to `StackedExpertGgufLinear<B>` (GGUF) and `Linear<B>`
+//! (single-tensor). Same goal: drop `type GptqStore` from the `Backend`
+//! trait by routing dispatch through a `Box<dyn MarlinExpertStack<B>>`
+//! returned by the loader — so future backends only need to implement
+//! this trait, not edit the `Backend` supertrait stack.
+//!
+//! Concrete impls (added in Phase C step 2):
+//!   - `quant_linear::cuda_marlin_stack::CudaMarlinExpertStack` wraps
+//!     `Arc<GptqStoreCuda>` and dispatches to `marlin_gemm_with_offset_strided`
+//!     (bucketed) or `marlin_moe_wna16` (vLLM fused).
+//!   - CPU dequant path stays per-Linear (no batched MoE Marlin kernel).
+//!
+//! The trait surface is intentionally small — three GEMM methods + a
+//! workspace zero + an expert-view constructor. Each maps 1:1 to an
+//! existing `Backend::moe_gemm_phase_*` method that Phase C step 3
+//! will delete from the trait.
+
+use crate::backend::Backend;
+use crate::Linear;
+use ferrum_types::Result;
+use std::sync::Arc;
+
+/// MoE-stacked Marlin INT4 expert tile: holds N experts' weights for one
+/// matmul role (gate_up / down) in one contiguous repacked Marlin buffer,
+/// dispatches per-expert column-slice GEMMs in a single fused launch
+/// (vLLM marlin_moe_wna16) or as a bucketed batched call.
+pub trait MarlinExpertStack<B: Backend>: Send + Sync {
+    /// Per-expert output width (N tile cols).
+    fn n_per_expert(&self) -> usize;
+    /// Input width (K), common across experts.
+    fn k(&self) -> usize;
+    /// Number of experts packed into the tile.
+    fn num_experts(&self) -> usize;
+
+    /// Downcast hook — used at FFN dispatch boundaries where the
+    /// caller needs to reach into the concrete store to e.g. share
+    /// workspace memory across phases. Standard `dyn Any` pattern.
+    fn as_any(&self) -> &dyn std::any::Any;
+
+    /// Bulk-zero the per-expert Marlin workspace mutex slots. Call ONCE
+    /// before a batch of bucketed `gemm_phase_batched` calls — saves
+    /// the per-call cuMemsetD32Async (one launch each → one launch
+    /// total). At c=32 with 128 active experts × 2 phases × 48 layers
+    /// that's ~12k memset launches/token reduced to ~96.
+    fn zero_workspace(&self, ctx: &mut B::Context) -> Result<()>;
+
+    /// Batched per-expert offset GEMM. `dispatches[i] =
+    /// (expert_idx, in_row_offset, out_row_offset, m)`. Runs each
+    /// expert's `(m × K) @ tile[expert] = m × n_per_expert` slice;
+    /// CUDA backend overlaps via multi-stream round-robin.
+    #[allow(clippy::too_many_arguments)]
+    fn gemm_phase_batched(
+        &self,
+        ctx: &mut B::Context,
+        input: &B::Buffer,
+        dispatches: &[(usize, usize, usize, usize)],
+        output: &mut B::Buffer,
+        k: usize,
+    ) -> Result<()>;
+
+    /// vLLM `marlin_moe_wna16` fused GEMM (single launch, per-block
+    /// expert routing inside the kernel). Caller responsibilities:
+    /// - `output` MUST be pre-zeroed (atomic-add path doesn't self-zero).
+    /// - `sorted_token_ids` / `expert_ids` / `num_tokens_past_padded`
+    ///   come from `moe_align_block_size`.
+    /// - `prob_m` is the unique-token count (top_k=1 with pre-gathered
+    ///   rows ⇒ equals `total_pairs`).
+    /// Backends without vLLM Marlin return `Err(unsupported)`.
+    #[allow(clippy::too_many_arguments)]
+    fn gemm_phase_vllm(
+        &self,
+        _ctx: &mut B::Context,
+        _input: &B::Buffer,
+        _sorted_token_ids: &B::Buffer,
+        _expert_ids: &B::Buffer,
+        _num_tokens_past_padded: &B::Buffer,
+        _output: &mut B::Buffer,
+        _prob_m: usize,
+        _moe_block_size: usize,
+        _top_k: usize,
+    ) -> Result<()> {
+        Err(ferrum_types::FerrumError::unsupported(
+            "MarlinExpertStack::gemm_phase_vllm not implemented for this backend",
+        ))
+    }
+
+    /// Build a single-expert `Linear<B>` view onto this stack's
+    /// `[expert_offset .. expert_offset + expert_n)` column slice.
+    /// Used for per-expert dispatch outside the MoE phase batching
+    /// (e.g. shared-experts code paths). `expert_offset` and `expert_n`
+    /// MUST be multiples of the backend's Marlin N tile (64 on CUDA).
+    fn make_expert_linear(
+        self: Arc<Self>,
+        expert_offset: usize,
+        expert_n: usize,
+        bias_host: Option<&[f32]>,
+    ) -> Result<Box<dyn Linear<B> + Send + Sync>>;
+}


### PR DESCRIPTION
## Summary

Phase C step 1 of dropping \`type GptqStore\` from the \`Backend\` trait — lays the foundation by defining a new trait-object pattern \`MarlinExpertStack<B>\`. Mirrors the existing \`StackedExpertGgufLinear<B>\` (GGUF) and \`Linear<B>\` (single-tensor) patterns.

The loader (eventually) returns \`Box<dyn MarlinExpertStack<B>>\` instead of an opaque store type, so adding a new Marlin-capable backend stays self-contained — no \`Backend\` supertrait edits.

## Trait surface (5 methods + 3 size accessors)

- \`n_per_expert\` / \`k\` / \`num_experts\` — sizing
- \`as_any\` — downcast hook for cross-stack peek (rare, FFN dispatch boundary)
- \`zero_workspace\` — bulk pre-zero per-expert Marlin workspace before bucketed batches (replaces \`Backend::marlin_zero_stacked_workspace\`)
- \`gemm_phase_batched\` — per-expert offset GEMM dispatch (replaces \`Backend::moe_gemm_phase_batched\`)
- \`gemm_phase_vllm\` — fused \`marlin_moe_wna16\` single-launch (replaces \`Backend::moe_gemm_phase_vllm\`; default returns unsupported)
- \`make_expert_linear\` — single-expert \`Linear<B>\` view (replaces \`Backend::make_stacked_expert_linear\`)

## What's next

- **Step 2**: \`CudaMarlinExpertStack\` impl wrapping \`Arc<GptqStoreCuda>\`, dispatching to the existing kernel free functions.
- **Step 3**: Migrate \`ExpertStack<B>::gate_up_gptq_stacked\` field from \`Option<Arc<B::GptqStore>>\` to \`Option<Arc<dyn MarlinExpertStack<B>>>\`. Update \`moe/dispatch.rs\` callers.
- **Step 4**: Delete \`Backend::moe_gemm_phase_*\` / \`make_stacked_expert_linear\` / \`marlin_zero_stacked_workspace\` / \`gemm_gptq*\` from the trait. Delete \`type GptqStore\`.

This PR is pure-additive — no callers yet. Lets the type-design conversation happen separately from the migration work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)