### PR TITLE
refactor(moe): ExpertStack uses MarlinExpertStack trait object (Phase C step 3)

### DIFF
--- a/crates/ferrum-kernels/src/backend/cpu.rs
+++ b/crates/ferrum-kernels/src/backend/cpu.rs
@@ -797,6 +797,23 @@ impl crate::backend::BackendQuantMarlin for CpuBackend {
             out_features: expert_n,
         }))
     }
+
+    fn make_marlin_expert_stack(
+        store: std::sync::Arc<Self::GptqStore>,
+        num_experts: usize,
+        n_per_expert: usize,
+        k: usize,
+    ) -> Result<std::sync::Arc<dyn crate::MarlinExpertStack<Self>>> {
+        Ok(std::sync::Arc::new(
+            crate::quant_linear::cpu_marlin_stack::CpuMarlinExpertStack::new(
+                store,
+                num_experts,
+                n_per_expert,
+                k,
+            ),
+        ))
+    }
+
     fn gemm_gptq_with_offset_strided(
         _ctx: &mut Self::Context,
         input: &Self::Buffer,

--- a/crates/ferrum-kernels/src/backend/cuda/quant.rs
+++ b/crates/ferrum-kernels/src/backend/cuda/quant.rs
@@ -823,6 +823,22 @@ impl BackendQuantMarlin for CudaBackend {
             },
         ))
     }
+
+    fn make_marlin_expert_stack(
+        store: std::sync::Arc<Self::GptqStore>,
+        num_experts: usize,
+        n_per_expert: usize,
+        k: usize,
+    ) -> Result<std::sync::Arc<dyn crate::MarlinExpertStack<Self>>> {
+        Ok(std::sync::Arc::new(
+            crate::quant_linear::cuda_marlin_stack::CudaMarlinExpertStack::new(
+                store,
+                num_experts,
+                n_per_expert,
+                k,
+            ),
+        ))
+    }
     #[cfg(feature = "marlin")]
     fn moe_gemm_phase_batched(
         ctx: &mut Self::Context,

--- a/crates/ferrum-kernels/src/backend/traits.rs
+++ b/crates/ferrum-kernels/src/backend/traits.rs
@@ -1072,6 +1072,27 @@ pub trait BackendQuantMarlin: Backend {
             "make_stacked_expert_linear not implemented for this backend",
         ))
     }
+
+    /// Phase C step 3: wrap a raw `Arc<Self::GptqStore>` into the
+    /// trait-object `MarlinExpertStack<Self>`. Lets callers go through
+    /// `store.gemm_phase_*` / `store.zero_workspace()` instead of
+    /// reaching into the per-backend `moe_gemm_phase_*` methods —
+    /// the eventual goal is to drop `type GptqStore` from this trait.
+    ///
+    /// Default returns unsupported. CUDA overrides with
+    /// `CudaMarlinExpertStack`. Backends without a stacked Marlin path
+    /// don't implement this; their model code falls back to per-expert
+    /// `Linear<B>` dispatch.
+    fn make_marlin_expert_stack(
+        _store: std::sync::Arc<Self::GptqStore>,
+        _num_experts: usize,
+        _n_per_expert: usize,
+        _k: usize,
+    ) -> Result<std::sync::Arc<dyn crate::MarlinExpertStack<Self>>> {
+        Err(FerrumError::unsupported(
+            "make_marlin_expert_stack not implemented for this backend",
+        ))
+    }
     /// Bulk-zero the per-expert Marlin workspace mutex slots for a
     /// stacked GptqStore. Call ONCE before a batch of
     /// `gemm_gptq_with_offset_strided_no_ws_zero` calls — saves the

--- a/crates/ferrum-kernels/src/quant_linear.rs
+++ b/crates/ferrum-kernels/src/quant_linear.rs
@@ -14,6 +14,7 @@
 
 pub mod cpu_dequant;
 pub mod cpu_gguf;
+pub mod cpu_marlin_stack;
 
 #[cfg(feature = "cuda")]
 pub mod cuda_marlin;

--- a/crates/ferrum-kernels/src/quant_linear/cpu_marlin_stack.rs
+++ b/crates/ferrum-kernels/src/quant_linear/cpu_marlin_stack.rs
@@ -1,0 +1,95 @@
+//! `MarlinExpertStack<CpuBackend>` impl on top of CPU's dequant-on-load
+//! GptqStore. Facade — delegates to the existing
+//! `BackendQuantMarlin::moe_gemm_phase_*` (default trait impl that loops
+//! calling `gemm_gptq_with_offset_strided` on CPU) and
+//! `make_stacked_expert_linear` methods.
+//!
+//! CPU has no real Marlin tiles; the impl exists so the bucketed MoE
+//! path's parity test (`tests/moe_bucketed_parity_test.rs`) still
+//! compiles after the Phase C trait-object migration. Phase C step 4
+//! inlines the kernel calls here and deletes the trait methods.
+
+use crate::backend::cpu::CpuBackend;
+use crate::marlin_expert_stack::MarlinExpertStack;
+use crate::Linear;
+use ferrum_types::Result;
+use std::sync::Arc;
+
+pub struct CpuMarlinExpertStack {
+    pub store: Arc<<CpuBackend as crate::backend::Backend>::GptqStore>,
+    pub num_experts: usize,
+    pub n_per_expert: usize,
+    pub k: usize,
+}
+
+impl CpuMarlinExpertStack {
+    pub fn new(
+        store: Arc<<CpuBackend as crate::backend::Backend>::GptqStore>,
+        num_experts: usize,
+        n_per_expert: usize,
+        k: usize,
+    ) -> Self {
+        Self {
+            store,
+            num_experts,
+            n_per_expert,
+            k,
+        }
+    }
+}
+
+impl MarlinExpertStack<CpuBackend> for CpuMarlinExpertStack {
+    fn n_per_expert(&self) -> usize {
+        self.n_per_expert
+    }
+    fn k(&self) -> usize {
+        self.k
+    }
+    fn num_experts(&self) -> usize {
+        self.num_experts
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn zero_workspace(&self, ctx: &mut <CpuBackend as crate::backend::Backend>::Context) -> Result<()> {
+        <CpuBackend as crate::backend::BackendQuantMarlin>::marlin_zero_stacked_workspace(
+            ctx, &self.store,
+        )
+    }
+
+    fn gemm_phase_batched(
+        &self,
+        ctx: &mut <CpuBackend as crate::backend::Backend>::Context,
+        input: &<CpuBackend as crate::backend::Backend>::Buffer,
+        dispatches: &[(usize, usize, usize, usize)],
+        output: &mut <CpuBackend as crate::backend::Backend>::Buffer,
+        k: usize,
+    ) -> Result<()> {
+        <CpuBackend as crate::backend::BackendQuantMarlin>::moe_gemm_phase_batched(
+            ctx,
+            input,
+            &self.store,
+            dispatches,
+            self.n_per_expert,
+            output,
+            k,
+        )
+    }
+
+    fn make_expert_linear(
+        self: Arc<Self>,
+        expert_offset: usize,
+        expert_n: usize,
+        bias_host: Option<&[f32]>,
+    ) -> Result<Box<dyn Linear<CpuBackend> + Send + Sync>> {
+        <CpuBackend as crate::backend::BackendQuantMarlin>::make_stacked_expert_linear(
+            self.store.clone(),
+            expert_offset,
+            expert_n,
+            self.k,
+            bias_host,
+        )
+    }
+}

--- a/crates/ferrum-models/src/models/qwen3_moe.rs
+++ b/crates/ferrum-models/src/models/qwen3_moe.rs
@@ -667,14 +667,31 @@ impl<B: MoeLlmBackend, K: KvDtypeKind> Qwen3MoeModel<B, K> {
                     )?,
                 ));
             }
+            // Wrap raw Marlin tile stores in trait objects (Phase C step 3) —
+            // dispatch goes through `gu_store.gemm_phase_*` / `zero_workspace`
+            // instead of `B::moe_gemm_phase_*` / `B::marlin_zero_stacked_workspace`.
+            let gate_up_marlin =
+                <B as ferrum_kernels::backend::BackendQuantMarlin>::make_marlin_expert_stack(
+                    gate_up_arc,
+                    cfg.num_experts,
+                    gate_up_n_per_expert,
+                    gate_up_k,
+                )?;
+            let down_marlin =
+                <B as ferrum_kernels::backend::BackendQuantMarlin>::make_marlin_expert_stack(
+                    down_arc,
+                    cfg.num_experts,
+                    down_n_per_expert,
+                    down_k,
+                )?;
             let experts = crate::moe::ExpertStack::<B> {
                 gate_up,
                 down,
                 gate_stacked: None,
                 up_stacked: None,
                 down_stacked: None,
-                gate_up_gptq_stacked: Some(gate_up_arc),
-                down_gptq_stacked: Some(down_arc),
+                gate_up_marlin_stack: Some(gate_up_marlin),
+                down_marlin_stack: Some(down_marlin),
             };
             moe_layers.push(Qwen3MoeLayerState { router, experts });
 
@@ -1311,8 +1328,8 @@ impl<B: MoeLlmBackend, K: KvDtypeKind> Qwen3MoeModel<B, K> {
 
         // CUDA Marlin bucketed path: shared GPTQ store per (gate_up, down)
         // role + offset GEMMs per expert. Disabled with FERRUM_MOE_BUCKETED=0.
-        let bucketed_path_available = moe_layer.experts.gate_up_gptq_stacked.is_some()
-            && moe_layer.experts.down_gptq_stacked.is_some()
+        let bucketed_path_available = moe_layer.experts.gate_up_marlin_stack.is_some()
+            && moe_layer.experts.down_marlin_stack.is_some()
             && std::env::var("FERRUM_MOE_BUCKETED").as_deref() != Ok("0");
 
         // Fast path for decode (tokens=1): the stacked decode impl
@@ -2799,8 +2816,8 @@ impl<B: MoeLlmBackend, K: KvDtypeKind> Qwen3MoeModel<B, K> {
                     h,
                 )?;
             }
-        } else if moe_layer.experts.gate_up_gptq_stacked.is_some()
-            && moe_layer.experts.down_gptq_stacked.is_some()
+        } else if moe_layer.experts.gate_up_marlin_stack.is_some()
+            && moe_layer.experts.down_marlin_stack.is_some()
             && std::env::var("FERRUM_MOE_BUCKETED").as_deref() != Ok("0")
         {
             // CUDA Marlin bucketed path (decode_batch m ≥ 1 entry).

--- a/crates/ferrum-models/src/moe/dispatch.rs
+++ b/crates/ferrum-models/src/moe/dispatch.rs
@@ -102,24 +102,37 @@ pub struct ExpertStack<B: QuantLlmBackend + BackendMoeFused> {
     pub up_stacked: Option<Box<dyn StackedExpertGgufLinear<B>>>,
     pub down_stacked: Option<Box<dyn StackedExpertGgufLinear<B>>>,
 
-    /// Stacked GPTQ Marlin stores for the bucketed CUDA path. When both
-    /// are Some, [`moe_forward_bucketed`] dispatches expert GEMMs as
-    /// column-slices of these shared tiles via
-    /// `B::gemm_gptq_with_offset_strided`. None on CPU / Metal / GGUF.
-    pub gate_up_gptq_stacked: Option<std::sync::Arc<B::GptqStore>>,
-    pub down_gptq_stacked: Option<std::sync::Arc<B::GptqStore>>,
+    /// Stacked Marlin GPTQ expert tiles for the bucketed CUDA path.
+    /// When both are Some, [`moe_forward_bucketed`] dispatches expert
+    /// GEMMs through trait-object methods (`store.gemm_phase_*` /
+    /// `store.zero_workspace`). None on CPU / Metal / GGUF.
+    ///
+    /// Phase C step 3: replaces `Option<Arc<B::GptqStore>>` with a
+    /// `Box<dyn MarlinExpertStack<B>>` trait object — kills the
+    /// `type GptqStore` leak through the model layer.
+    pub gate_up_marlin_stack:
+        Option<std::sync::Arc<dyn ferrum_kernels::MarlinExpertStack<B>>>,
+    pub down_marlin_stack:
+        Option<std::sync::Arc<dyn ferrum_kernels::MarlinExpertStack<B>>>,
 }
 
 impl<B: QuantLlmBackend + BackendMoeFused> ExpertStack<B> {
-    /// Returns the shared stacked GPTQ store for `gate_up` if loaded
-    /// via the bucketed/Marlin path. Used by [`moe_forward_bucketed`].
-    pub fn gate_up_stacked_store(&self, _expert_idx: usize) -> Option<&B::GptqStore> {
-        self.gate_up_gptq_stacked.as_deref()
+    /// Returns the shared stacked Marlin expert tile for `gate_up` if
+    /// loaded via the bucketed/Marlin path. Used by
+    /// [`moe_forward_bucketed`].
+    pub fn gate_up_stacked_store(
+        &self,
+        _expert_idx: usize,
+    ) -> Option<&std::sync::Arc<dyn ferrum_kernels::MarlinExpertStack<B>>> {
+        self.gate_up_marlin_stack.as_ref()
     }
 
     /// Same for `down`.
-    pub fn down_stacked_store(&self, _expert_idx: usize) -> Option<&B::GptqStore> {
-        self.down_gptq_stacked.as_deref()
+    pub fn down_stacked_store(
+        &self,
+        _expert_idx: usize,
+    ) -> Option<&std::sync::Arc<dyn ferrum_kernels::MarlinExpertStack<B>>> {
+        self.down_marlin_stack.as_ref()
     }
 
     // ── MoE GEMV dispatch (hides B::QuantStore + in_stride from callers) ──
@@ -607,8 +620,8 @@ impl<B: QuantLlmBackend + BackendMoeFused> ExpertStack<B> {
             gate_stacked: None,
             up_stacked: None,
             down_stacked: None,
-            gate_up_gptq_stacked: None,
-            down_gptq_stacked: None,
+            gate_up_marlin_stack: None,
+            down_marlin_stack: None,
         })
     }
 
@@ -848,8 +861,8 @@ impl<B: QuantLlmBackend + BackendMoeFused> ExpertStack<B> {
             gate_stacked,
             up_stacked,
             down_stacked,
-            gate_up_gptq_stacked: None,
-            down_gptq_stacked: None,
+            gate_up_marlin_stack: None,
+            down_marlin_stack: None,
         }))
     }
 
@@ -1380,7 +1393,7 @@ pub fn moe_forward_bucketed<B: QuantLlmBackend + BackendMoeFused>(
              (load via Qwen3MoeModel::new_safetensors)",
         )
     })?;
-    let _ = B::marlin_zero_stacked_workspace(ctx, gu_store);
+    let _ = gu_store.zero_workspace(ctx);
 
     // Decide path: vLLM marlin_moe_wna16 fused or our per-expert bucketed
     // GEMMs. The vLLM path needs (sorted_token_ids, expert_ids,
@@ -1463,27 +1476,22 @@ pub fn moe_forward_bucketed<B: QuantLlmBackend + BackendMoeFused>(
         // no caller-side zero needed (atomic_add fallback inside the
         // wrapper would also self-zero under slice_count > 1 / slice_idx
         // == 0; either way this is safe).
-        B::moe_gemm_phase_vllm(
+        gu_store.gemm_phase_vllm(
             ctx,
             x_packed,
-            gu_store,
             &routing.sorted_token_ids,
             &routing.expert_ids,
             &routing.num_tokens_past_padded,
             gate_up_packed,
             total_pairs_active,
-            gate_up_dim_per_expert,
-            hidden_size,
             VLLM_MOE_BLOCK_SIZE,
             1, // top_k=1: pre-gathered rows already index packed input directly
         )?;
     } else {
-        B::moe_gemm_phase_batched(
+        gu_store.gemm_phase_batched(
             ctx,
             x_packed,
-            gu_store,
             &phase1_dispatches,
-            gate_up_dim_per_expert,
             gate_up_packed,
             hidden_size,
         )?;
@@ -1523,7 +1531,7 @@ pub fn moe_forward_bucketed<B: QuantLlmBackend + BackendMoeFused>(
              (load via Qwen3MoeModel::new_safetensors)",
         )
     })?;
-    let _ = B::marlin_zero_stacked_workspace(ctx, d_store);
+    let _ = d_store.zero_workspace(ctx);
     let mut phase3_dispatches: Vec<(usize, usize, usize, usize)> = Vec::with_capacity(num_experts);
     for e in 0..num_experts {
         let m_e = plan.expert_offsets[e + 1] - plan.expert_offsets[e];
@@ -1540,27 +1548,22 @@ pub fn moe_forward_bucketed<B: QuantLlmBackend + BackendMoeFused>(
         None
     };
     if let Some(routing) = &vllm_routing {
-        B::moe_gemm_phase_vllm(
+        d_store.gemm_phase_vllm(
             ctx,
             silu_packed,
-            d_store,
             &routing.sorted_token_ids,
             &routing.expert_ids,
             &routing.num_tokens_past_padded,
             down_packed,
             total_pairs_active,
-            down_n_per_expert,
-            expert_intermediate,
             VLLM_MOE_BLOCK_SIZE,
             1,
         )?;
     } else {
-        B::moe_gemm_phase_batched(
+        d_store.gemm_phase_batched(
             ctx,
             silu_packed,
-            d_store,
             &phase3_dispatches,
-            down_n_per_expert,
             down_packed,
             expert_intermediate,
         )?;

--- a/crates/ferrum-models/tests/moe_bucketed_parity_test.rs
+++ b/crates/ferrum-models/tests/moe_bucketed_parity_test.rs
@@ -110,14 +110,31 @@ fn bucketed_matches_per_pair_dispatch() {
                 .expect("down StackedExpertLinear"),
         ));
     }
+    // Phase C step 3: ExpertStack now holds trait-object MarlinExpertStack
+    // (was Arc<B::GptqStore>). Build via the Backend constructor so the
+    // dispatch path goes through `store.gemm_phase_*` / `store.zero_workspace`.
+    let gate_up_stack = <CpuBackend as BackendQuantMarlin>::make_marlin_expert_stack(
+        gate_up_arc.clone(),
+        num_experts,
+        2 * inter,
+        hidden,
+    )
+    .expect("make_marlin_expert_stack gate_up");
+    let down_stack = <CpuBackend as BackendQuantMarlin>::make_marlin_expert_stack(
+        down_arc.clone(),
+        num_experts,
+        hidden,
+        inter,
+    )
+    .expect("make_marlin_expert_stack down");
     let experts = ExpertStack::<CpuBackend> {
         gate_up: gate_up_per_expert,
         down: down_per_expert,
         gate_stacked: None,
         up_stacked: None,
         down_stacked: None,
-        gate_up_gptq_stacked: Some(gate_up_arc.clone()),
-        down_gptq_stacked: Some(down_arc.clone()),
+        gate_up_marlin_stack: Some(gate_up_stack),
+        down_marlin_stack: Some(down_stack),
     };
 
     // Synthetic input + router logits.


### PR DESCRIPTION
Phase C step 3 — the migration step.

Replaces ExpertStack<B>'s opaque type-leak (Option<Arc<B::GptqStore>>) with the typed trait-object pattern (Option<Arc<dyn MarlinExpertStack<B>>>). Dispatch in moe/dispatch.rs goes through trait methods (store.gemm_phase_*, store.zero_workspace) instead of B::moe_gemm_phase_* / B::marlin_zero_stacked_workspace.

Changes:
- BackendQuantMarlin::make_marlin_expert_stack wraps Arc<GptqStore> in Arc<dyn MarlinExpertStack<B>>. Default unsupported; CUDA override returns Arc<CudaMarlinExpertStack> (added in #167).
- qwen3_moe.rs construction calls make_marlin_expert_stack per layer/tile.
- moe/dispatch.rs callers (4 GEMM + 2 zero_workspace) switch to trait-object dispatch.

Old B::moe_gemm_phase_* methods are now unused by model code but still on BackendQuantMarlin (kept for the facade impl in cuda_marlin_stack.rs). Phase C step 4 inlines the kernel bodies into the trait object and deletes the trait methods + type GptqStore.

cargo check --workspace --features metal clean on Mac; CUDA validation in flight on pod.