### PR TITLE
refactor(backend): drop marlin_zero / make_stacked_expert_linear (Phase C step 4a+4b)

### DIFF
--- a/crates/ferrum-kernels/src/backend/cpu.rs
+++ b/crates/ferrum-kernels/src/backend/cpu.rs
@@ -768,35 +768,8 @@ impl crate::backend::BackendQuantMarlin for CpuBackend {
             n: total_n,
         })
     }
-    fn make_stacked_expert_linear(
-        store: std::sync::Arc<Self::GptqStore>,
-        expert_offset: usize,
-        expert_n: usize,
-        k: usize,
-        bias_host: Option<&[f32]>,
-    ) -> Result<Box<dyn crate::Linear<Self> + Send + Sync>> {
-        if expert_offset + expert_n > store.n {
-            return Err(FerrumError::model(format!(
-                "make_stacked_expert_linear OOB: offset {expert_offset} + n {expert_n} > stacked_n {}",
-                store.n
-            )));
-        }
-        if k != store.k {
-            return Err(FerrumError::model(format!(
-                "make_stacked_expert_linear k mismatch: arg {k} vs store.k {}",
-                store.k
-            )));
-        }
-        let row_start = expert_offset * k;
-        let row_end = (expert_offset + expert_n) * k;
-        let slice = store.weight_f32[row_start..row_end].to_vec();
-        Ok(Box::new(crate::quant_linear::cpu_dequant::CpuGptqLinear {
-            weight_f32: slice,
-            bias: bias_host.map(|b| b.to_vec()),
-            in_features: k,
-            out_features: expert_n,
-        }))
-    }
+    // Phase C step 4b: make_stacked_expert_linear inlined into
+    // CpuMarlinExpertStack::make_expert_linear.
 
     fn make_marlin_expert_stack(
         store: std::sync::Arc<Self::GptqStore>,

--- a/crates/ferrum-kernels/src/backend/cuda/quant.rs
+++ b/crates/ferrum-kernels/src/backend/cuda/quant.rs
@@ -805,24 +805,8 @@ impl BackendQuantMarlin for CudaBackend {
             Ok(marlin_weight)
         }
     }
-    fn make_stacked_expert_linear(
-        store: std::sync::Arc<Self::GptqStore>,
-        expert_offset: usize,
-        expert_n: usize,
-        k: usize,
-        bias_host: Option<&[f32]>,
-    ) -> Result<Box<dyn crate::Linear<Self> + Send + Sync>> {
-        let bias = bias_host.map(<Self as crate::backend::Backend>::from_slice);
-        Ok(Box::new(
-            crate::quant_linear::cuda_marlin::CudaMarlinStackedExpertLinear {
-                store,
-                expert_offset,
-                expert_n,
-                k,
-                bias,
-            },
-        ))
-    }
+    // Phase C step 4b: make_stacked_expert_linear inlined into
+    // CudaMarlinExpertStack::make_expert_linear.
 
     fn make_marlin_expert_stack(
         store: std::sync::Arc<Self::GptqStore>,
@@ -1052,32 +1036,8 @@ impl BackendQuantMarlin for CudaBackend {
         std::mem::forget(npp_view);
         r.map_err(|e| FerrumError::model(format!("marlin_gemm_moe_vllm: {e}")))
     }
-    #[cfg(feature = "marlin")]
-    fn marlin_zero_stacked_workspace(
-        ctx: &mut Self::Context,
-        weight: &Self::GptqStore,
-    ) -> Result<()> {
-        use cudarc::driver::DevicePtr;
-        #[cfg(feature = "triton-kernels")]
-        let mw = match weight {
-            GptqStoreCuda::Marlin(mw) => mw,
-            GptqStoreCuda::Triton(_) => {
-                return Err(FerrumError::unsupported(
-                    "marlin_zero_stacked_workspace: not applicable to Triton store",
-                ));
-            }
-        };
-        #[cfg(not(feature = "triton-kernels"))]
-        let mw: &crate::marlin::MarlinWeight = weight;
-        let stream = ctx.stream.clone();
-        let raw_stream = stream.cu_stream();
-        let (ws_ptr, _g) = mw.workspace.device_ptr(&stream);
-        let ws_len = mw.workspace.len();
-        unsafe {
-            cudarc::driver::sys::cuMemsetD32Async(ws_ptr, 0, ws_len, raw_stream);
-        }
-        Ok(())
-    }
+    // Phase C step 4a: marlin_zero_stacked_workspace inlined into
+    // CudaMarlinExpertStack::zero_workspace (quant_linear/cuda_marlin_stack.rs).
 }
 // CUDA does not ship GGUF k-quant kernels; inherit unsupported defaults.
 impl BackendQuantGguf for CudaBackend {}

--- a/crates/ferrum-kernels/src/backend/traits.rs
+++ b/crates/ferrum-kernels/src/backend/traits.rs
@@ -1047,31 +1047,12 @@ pub trait BackendQuantMarlin: Backend {
             "load_gptq_stacked not implemented for this backend",
         ))
     }
-    /// Build a per-expert column-slice `Linear<Self>` view on top of a
-    /// stacked GPTQ store. The store concatenates all experts' weights
-    /// along N; this factory selects columns
-    /// `[expert_offset .. expert_offset + expert_n)` for one expert.
-    ///
-    /// `expert_offset` and `expert_n` MUST be multiples of the backend's
-    /// natural N tile size (Marlin: 64). `bias_host` is per-expert.
-    /// Default returns Err(unsupported).
-    ///
-    /// Phase 3e/2: replaces the old `gemm_gptq_with_offset` trait
-    /// method dispatched from `StackedExpertLinear<B>::forward`. The
-    /// kernel call now lives inside the returned boxed Linear's
-    /// `forward` (CUDA: `CudaMarlinStackedExpertLinear`).
-    #[allow(clippy::too_many_arguments)]
-    fn make_stacked_expert_linear(
-        _store: std::sync::Arc<Self::GptqStore>,
-        _expert_offset: usize,
-        _expert_n: usize,
-        _k: usize,
-        _bias_host: Option<&[f32]>,
-    ) -> Result<Box<dyn crate::Linear<Self> + Send + Sync>> {
-        Err(FerrumError::unsupported(
-            "make_stacked_expert_linear not implemented for this backend",
-        ))
-    }
+    // Phase C step 4b: BackendQuantMarlin::make_stacked_expert_linear
+    // was removed — its body is now inlined into
+    // `MarlinExpertStack::make_expert_linear` (concrete impls in
+    // `quant_linear/{cuda,cpu}_marlin_stack.rs`). Callers reach
+    // single-expert Linear views via
+    // `store.clone().make_expert_linear(offset, n, bias)`.
 
     /// Phase C step 3: wrap a raw `Arc<Self::GptqStore>` into the
     /// trait-object `MarlinExpertStack<Self>`. Lets callers go through
@@ -1093,21 +1074,11 @@ pub trait BackendQuantMarlin: Backend {
             "make_marlin_expert_stack not implemented for this backend",
         ))
     }
-    /// Bulk-zero the per-expert Marlin workspace mutex slots for a
-    /// stacked GptqStore. Call ONCE before a batch of
-    /// `gemm_gptq_with_offset_strided_no_ws_zero` calls — saves the
-    /// per-call cuMemsetD32Async (one launch each → one launch total).
-    ///
-    /// At c=32 with 128 active experts × 2 (gate_up + down) × 48 layers:
-    /// 12 288 memset launches/token. Bulk-zeroing brings that to 96.
-    fn marlin_zero_stacked_workspace(
-        _ctx: &mut Self::Context,
-        _weight: &Self::GptqStore,
-    ) -> Result<()> {
-        Err(FerrumError::unsupported(
-            "marlin_zero_stacked_workspace not implemented for this backend",
-        ))
-    }
+    // Phase C step 4a: BackendQuantMarlin::marlin_zero_stacked_workspace
+    // was removed — its body is now inlined into
+    // `MarlinExpertStack::zero_workspace` (concrete impls in
+    // `quant_linear/{cuda,cpu}_marlin_stack.rs`). Callers reach the
+    // workspace-zero op via `store.zero_workspace(ctx)` instead.
     /// Batched per-expert offset GEMM dispatch — runs N concurrent
     /// Marlin calls across a stream pool to amortize launch overhead
     /// and overlap small-m kernels that under-utilize SMs individually.

--- a/crates/ferrum-kernels/src/quant_linear/cpu_marlin_stack.rs
+++ b/crates/ferrum-kernels/src/quant_linear/cpu_marlin_stack.rs
@@ -53,10 +53,10 @@ impl MarlinExpertStack<CpuBackend> for CpuMarlinExpertStack {
         self
     }
 
-    fn zero_workspace(&self, ctx: &mut <CpuBackend as crate::backend::Backend>::Context) -> Result<()> {
-        <CpuBackend as crate::backend::BackendQuantMarlin>::marlin_zero_stacked_workspace(
-            ctx, &self.store,
-        )
+    fn zero_workspace(&self, _ctx: &mut <CpuBackend as crate::backend::Backend>::Context) -> Result<()> {
+        // CPU GptqStore (dequant-on-load) has no per-expert workspace
+        // mutex slots — Marlin-specific GPU artefact. No-op.
+        Ok(())
     }
 
     fn gemm_phase_batched(
@@ -84,12 +84,28 @@ impl MarlinExpertStack<CpuBackend> for CpuMarlinExpertStack {
         expert_n: usize,
         bias_host: Option<&[f32]>,
     ) -> Result<Box<dyn Linear<CpuBackend> + Send + Sync>> {
-        <CpuBackend as crate::backend::BackendQuantMarlin>::make_stacked_expert_linear(
-            self.store.clone(),
-            expert_offset,
-            expert_n,
-            self.k,
-            bias_host,
-        )
+        // Inlined from BackendQuantMarlin::make_stacked_expert_linear
+        // (Phase C step 4b).
+        if expert_offset + expert_n > self.store.n {
+            return Err(ferrum_types::FerrumError::model(format!(
+                "make_expert_linear OOB: offset {expert_offset} + n {expert_n} > stacked_n {}",
+                self.store.n
+            )));
+        }
+        if self.k != self.store.k {
+            return Err(ferrum_types::FerrumError::model(format!(
+                "make_expert_linear k mismatch: arg {} vs store.k {}",
+                self.k, self.store.k
+            )));
+        }
+        let row_start = expert_offset * self.k;
+        let row_end = (expert_offset + expert_n) * self.k;
+        let slice = self.store.weight_f32[row_start..row_end].to_vec();
+        Ok(Box::new(crate::quant_linear::cpu_dequant::CpuGptqLinear {
+            weight_f32: slice,
+            bias: bias_host.map(|b| b.to_vec()),
+            in_features: self.k,
+            out_features: expert_n,
+        }))
     }
 }

--- a/crates/ferrum-kernels/src/quant_linear/cuda_marlin_stack.rs
+++ b/crates/ferrum-kernels/src/quant_linear/cuda_marlin_stack.rs
@@ -18,6 +18,7 @@
 use crate::backend::cuda::{CudaBackend, GptqStoreCuda};
 use crate::marlin_expert_stack::MarlinExpertStack;
 use crate::Linear;
+use cudarc::driver::DevicePtr;
 use ferrum_types::Result;
 use std::sync::Arc;
 
@@ -55,9 +56,30 @@ impl MarlinExpertStack<CudaBackend> for CudaMarlinExpertStack {
     }
 
     fn zero_workspace(&self, ctx: &mut <CudaBackend as crate::backend::Backend>::Context) -> Result<()> {
-        <CudaBackend as crate::backend::BackendQuantMarlin>::marlin_zero_stacked_workspace(
-            ctx, &self.store,
-        )
+        // Inlined from BackendQuantMarlin::marlin_zero_stacked_workspace
+        // (Phase C step 4a). Bulk-zeros the per-expert Marlin workspace
+        // mutex slots via a single cuMemsetD32Async — replaces the
+        // per-call workspace-zero that fired ~12k times per token
+        // (c=32 × 128 experts × 2 phases × 48 layers) with one launch.
+        #[cfg(feature = "triton-kernels")]
+        let mw = match self.store.as_ref() {
+            GptqStoreCuda::Marlin(mw) => mw,
+            GptqStoreCuda::Triton(_) => {
+                return Err(ferrum_types::FerrumError::unsupported(
+                    "zero_workspace: not applicable to Triton store",
+                ));
+            }
+        };
+        #[cfg(not(feature = "triton-kernels"))]
+        let mw: &crate::marlin::MarlinWeight = self.store.as_ref();
+        let stream = ctx.stream.clone();
+        let raw_stream = stream.cu_stream();
+        let (ws_ptr, _g) = mw.workspace.device_ptr(&stream);
+        let ws_len = mw.workspace.len();
+        unsafe {
+            cudarc::driver::sys::cuMemsetD32Async(ws_ptr, 0, ws_len, raw_stream);
+        }
+        Ok(())
     }
 
     fn gemm_phase_batched(
@@ -123,12 +145,20 @@ impl MarlinExpertStack<CudaBackend> for CudaMarlinExpertStack {
         expert_n: usize,
         bias_host: Option<&[f32]>,
     ) -> Result<Box<dyn Linear<CudaBackend> + Send + Sync>> {
-        <CudaBackend as crate::backend::BackendQuantMarlin>::make_stacked_expert_linear(
-            self.store.clone(),
-            expert_offset,
-            expert_n,
-            self.k,
-            bias_host,
-        )
+        // Inlined from BackendQuantMarlin::make_stacked_expert_linear
+        // (Phase C step 4b). The returned Linear<CudaBackend> is a
+        // single-expert column-slice view onto the shared stacked
+        // Marlin tile; its `forward` does the per-expert offset
+        // GEMM via crate::backend::cuda::marlin_gemm_with_perm.
+        let bias = bias_host.map(<CudaBackend as crate::backend::Backend>::from_slice);
+        Ok(Box::new(
+            crate::quant_linear::cuda_marlin::CudaMarlinStackedExpertLinear {
+                store: self.store.clone(),
+                expert_offset,
+                expert_n,
+                k: self.k,
+                bias,
+            },
+        ))
     }
 }

--- a/crates/ferrum-models/src/models/qwen3_moe.rs
+++ b/crates/ferrum-models/src/models/qwen3_moe.rs
@@ -645,28 +645,6 @@ impl<B: MoeLlmBackend, K: KvDtypeKind> Qwen3MoeModel<B, K> {
             let gate_up_arc = std::sync::Arc::new(gate_up_store);
             let down_arc = std::sync::Arc::new(down_store);
 
-            let mut gate_up: Vec<Box<dyn ferrum_quantization::Linear<B>>> =
-                Vec::with_capacity(cfg.num_experts);
-            let mut down: Vec<Box<dyn ferrum_quantization::Linear<B>>> =
-                Vec::with_capacity(cfg.num_experts);
-            for e in 0..cfg.num_experts {
-                gate_up.push(Box::new(
-                    ferrum_quantization::StackedExpertLinear::<B>::new(
-                        gate_up_arc.clone(),
-                        e * gate_up_n_per_expert,
-                        gate_up_n_per_expert,
-                        gate_up_k,
-                    )?,
-                ));
-                down.push(Box::new(
-                    ferrum_quantization::StackedExpertLinear::<B>::new(
-                        down_arc.clone(),
-                        e * down_n_per_expert,
-                        down_n_per_expert,
-                        down_k,
-                    )?,
-                ));
-            }
             // Wrap raw Marlin tile stores in trait objects (Phase C step 3) —
             // dispatch goes through `gu_store.gemm_phase_*` / `zero_workspace`
             // instead of `B::moe_gemm_phase_*` / `B::marlin_zero_stacked_workspace`.
@@ -684,6 +662,33 @@ impl<B: MoeLlmBackend, K: KvDtypeKind> Qwen3MoeModel<B, K> {
                     down_n_per_expert,
                     down_k,
                 )?;
+
+            // Per-expert Linear views — used by code paths that go
+            // through `ExpertStack::gate_up[i]` / `down[i]` (single
+            // expert, non-bucketed). StackedExpertLinear wraps the
+            // MarlinExpertStack trait object and dispatches via
+            // `stack.make_expert_linear(...)` per Phase C step 4b.
+            let mut gate_up: Vec<Box<dyn ferrum_quantization::Linear<B>>> =
+                Vec::with_capacity(cfg.num_experts);
+            let mut down: Vec<Box<dyn ferrum_quantization::Linear<B>>> =
+                Vec::with_capacity(cfg.num_experts);
+            for e in 0..cfg.num_experts {
+                gate_up.push(Box::new(
+                    ferrum_quantization::StackedExpertLinear::<B>::new(
+                        gate_up_marlin.clone(),
+                        e * gate_up_n_per_expert,
+                        gate_up_n_per_expert,
+                    )?,
+                ));
+                down.push(Box::new(
+                    ferrum_quantization::StackedExpertLinear::<B>::new(
+                        down_marlin.clone(),
+                        e * down_n_per_expert,
+                        down_n_per_expert,
+                    )?,
+                ));
+            }
+
             let experts = crate::moe::ExpertStack::<B> {
                 gate_up,
                 down,

--- a/crates/ferrum-models/tests/moe_bucketed_parity_test.rs
+++ b/crates/ferrum-models/tests/moe_bucketed_parity_test.rs
@@ -90,29 +90,8 @@ fn bucketed_matches_per_pair_dispatch() {
     let gate_up_arc = build_stacked(hidden, 2 * inter, num_experts, group_size, 0xA);
     let down_arc = build_stacked(inter, hidden, num_experts, group_size, 0xB);
 
-    // ExpertStack with both per-expert StackedExpertLinears AND the
-    // shared stores (per-pair path uses the former; bucketed path uses
-    // the latter).
-    let mut gate_up_per_expert: Vec<Box<dyn Linear<CpuBackend>>> = Vec::with_capacity(num_experts);
-    let mut down_per_expert: Vec<Box<dyn Linear<CpuBackend>>> = Vec::with_capacity(num_experts);
-    for e in 0..num_experts {
-        gate_up_per_expert.push(Box::new(
-            StackedExpertLinear::<CpuBackend>::new(
-                gate_up_arc.clone(),
-                e * 2 * inter,
-                2 * inter,
-                hidden,
-            )
-            .expect("gate_up StackedExpertLinear"),
-        ));
-        down_per_expert.push(Box::new(
-            StackedExpertLinear::<CpuBackend>::new(down_arc.clone(), e * hidden, hidden, inter)
-                .expect("down StackedExpertLinear"),
-        ));
-    }
-    // Phase C step 3: ExpertStack now holds trait-object MarlinExpertStack
-    // (was Arc<B::GptqStore>). Build via the Backend constructor so the
-    // dispatch path goes through `store.gemm_phase_*` / `store.zero_workspace`.
+    // Phase C step 3: build trait-object MarlinExpertStack first;
+    // step 4b: StackedExpertLinear::new takes the stack directly.
     let gate_up_stack = <CpuBackend as BackendQuantMarlin>::make_marlin_expert_stack(
         gate_up_arc.clone(),
         num_experts,
@@ -127,6 +106,21 @@ fn bucketed_matches_per_pair_dispatch() {
         inter,
     )
     .expect("make_marlin_expert_stack down");
+
+    // Per-expert StackedExpertLinear views built from the trait-object
+    // stack (Phase C step 4b). Used by per-pair dispatch path.
+    let mut gate_up_per_expert: Vec<Box<dyn Linear<CpuBackend>>> = Vec::with_capacity(num_experts);
+    let mut down_per_expert: Vec<Box<dyn Linear<CpuBackend>>> = Vec::with_capacity(num_experts);
+    for e in 0..num_experts {
+        gate_up_per_expert.push(Box::new(
+            StackedExpertLinear::<CpuBackend>::new(gate_up_stack.clone(), e * 2 * inter, 2 * inter)
+                .expect("gate_up StackedExpertLinear"),
+        ));
+        down_per_expert.push(Box::new(
+            StackedExpertLinear::<CpuBackend>::new(down_stack.clone(), e * hidden, hidden)
+                .expect("down StackedExpertLinear"),
+        ));
+    }
     let experts = ExpertStack::<CpuBackend> {
         gate_up: gate_up_per_expert,
         down: down_per_expert,

--- a/crates/ferrum-quantization/src/gptq.rs
+++ b/crates/ferrum-quantization/src/gptq.rs
@@ -85,24 +85,26 @@ pub struct StackedExpertLinear<B: Backend + BackendQuantMarlin> {
 }
 
 impl<B: Backend + BackendQuantMarlin> StackedExpertLinear<B> {
+    /// Phase C step 4b: takes the trait-object MarlinExpertStack
+    /// directly (was `Arc<B::GptqStore>` + `B::make_stacked_expert_linear`).
     pub fn new(
-        store: Arc<B::GptqStore>,
+        stack: Arc<dyn ferrum_kernels::MarlinExpertStack<B>>,
         expert_offset: usize,
         expert_n: usize,
-        k: usize,
     ) -> Result<Self> {
-        let inner = B::make_stacked_expert_linear(store, expert_offset, expert_n, k, None)?;
+        let k = stack.k();
+        let inner = stack.make_expert_linear(expert_offset, expert_n, None)?;
         Ok(Self { inner, k, expert_n })
     }
 
     pub fn new_with_bias(
-        store: Arc<B::GptqStore>,
+        stack: Arc<dyn ferrum_kernels::MarlinExpertStack<B>>,
         expert_offset: usize,
         expert_n: usize,
-        k: usize,
         bias: &[f32],
     ) -> Result<Self> {
-        let inner = B::make_stacked_expert_linear(store, expert_offset, expert_n, k, Some(bias))?;
+        let k = stack.k();
+        let inner = stack.make_expert_linear(expert_offset, expert_n, Some(bias))?;
         Ok(Self { inner, k, expert_n })
     }
 }

--- a/crates/ferrum-quantization/tests/gptq_parity_test.rs
+++ b/crates/ferrum-quantization/tests/gptq_parity_test.rs
@@ -294,13 +294,19 @@ fn cuda_stacked_offset_vs_per_expert() {
 
         let input_dev_off = CudaBackend::from_slice(&input);
         let mut off_out_dev = CudaBackend::alloc(m * n_per);
-        // Phase 3e/2: gemm_gptq_with_offset is gone; per-expert dispatch
-        // lives inside StackedExpertLinear<CudaBackend>::forward.
-        let off_lin = ferrum_quantization::StackedExpertLinear::<CudaBackend>::new(
+        // Phase C step 4b: StackedExpertLinear takes a MarlinExpertStack
+        // trait object. Wrap the raw GptqStoreCuda first.
+        let off_stack = <CudaBackend as ferrum_kernels::backend::BackendQuantMarlin>::make_marlin_expert_stack(
             stacked_arc.clone(),
-            e * n_per,
+            num_experts,
             n_per,
             k,
+        )
+        .expect("make_marlin_expert_stack");
+        let off_lin = ferrum_quantization::StackedExpertLinear::<CudaBackend>::new(
+            off_stack,
+            e * n_per,
+            n_per,
         )
         .expect("StackedExpertLinear::new");
         ferrum_kernels::Linear::<CudaBackend>::forward(
@@ -394,14 +400,23 @@ fn cpu_stacked_vs_per_expert_parity() {
     // must equal the per-expert dedicated GEMM. Phase 3e/2: per-expert
     // dispatch goes through `StackedExpertLinear<CpuBackend>::forward`.
     let stacked_arc = std::sync::Arc::new(stacked_store);
+    // Phase C step 4b: wrap the raw GptqStore in a MarlinExpertStack
+    // trait object first; StackedExpertLinear::new takes the stack
+    // directly (no longer routes through B::make_stacked_expert_linear).
+    let stacked_stack = <CpuBackend as ferrum_kernels::backend::BackendQuantMarlin>::make_marlin_expert_stack(
+        stacked_arc.clone(),
+        num_experts,
+        n_per,
+        k,
+    )
+    .expect("make_marlin_expert_stack");
     for (e, ref_out) in per_expert_outs.iter().enumerate() {
         let mut stacked_out = vec![0.0f32; m * n_per];
         let mut ctx = <CpuBackend as Backend>::new_context();
         let stacked_lin = ferrum_quantization::StackedExpertLinear::<CpuBackend>::new(
-            stacked_arc.clone(),
+            stacked_stack.clone(),
             e * n_per,
             n_per,
-            k,
         )
         .expect("StackedExpertLinear::new");
         ferrum_kernels::Linear::<CpuBackend>::forward(


### PR DESCRIPTION
Phase C step 4a+4b.

Deletes BackendQuantMarlin::marlin_zero_stacked_workspace and BackendQuantMarlin::make_stacked_expert_linear from the trait. Their bodies are inlined into MarlinExpertStack::{zero_workspace, make_expert_linear} (concrete impls in quant_linear/{cuda,cpu}_marlin_stack.rs from #167).

API change: ferrum_quantization::StackedExpertLinear::new signature
- before: (Arc<B::GptqStore>, expert_offset, expert_n, k)
- after:  (Arc<dyn MarlinExpertStack<B>>, expert_offset, expert_n)

The stack carries k via stack.k(), and the inner Linear comes from the trait-method stack.make_expert_linear() instead of B::make_stacked_expert_linear.

Callers updated: qwen3_moe.rs new_safetensors + moe_bucketed_parity_test.rs + gptq_parity_test.rs (3 sites total). Build the trait-object stack first via B::make_marlin_expert_stack, then pass to StackedExpertLinear::new.

cargo check + targeted tests pass clean on Mac (Metal). CUDA pod validation pending.