### PR TITLE
refactor(backend): drop type GptqStore — Phase C final (step 4e)

### DIFF
--- a/crates/ferrum-kernels/src/backend/cpu.rs
+++ b/crates/ferrum-kernels/src/backend/cpu.rs
@@ -116,7 +116,8 @@ pub enum CpuQuantStore {
 impl Backend for CpuBackend {
     type Buffer = Vec<f32>;
     type Context = ();
-    type GptqStore = CpuGptqStore;
+    // type GptqStore: removed in Phase C step 4e. CpuGptqStore is now
+    // a private (crate-internal) detail of CpuMarlinExpertStack.
 
     fn new_context() -> Self::Context {}
     fn sync(_ctx: &mut Self::Context) {}
@@ -745,7 +746,7 @@ impl crate::backend::BackendQuantMarlin for CpuBackend {
         group_size: usize,
         k: usize,
         n_per_expert: usize,
-    ) -> Result<Self::GptqStore> {
+    ) -> Result<std::sync::Arc<dyn crate::MarlinExpertStack<Self>>> {
         // Phase 3e/2 addition: dequant each expert independently, concat
         // along N (rows in [n, k] layout). Used by MoE parity tests.
         let num_experts = qweights.len();
@@ -762,21 +763,11 @@ impl crate::backend::BackendQuantMarlin for CpuBackend {
             let w_e = cpu_dequant_gptq(qw_e, sc_e, qz_e, bits, group_size, k, n_per_expert)?;
             all_w.extend_from_slice(&w_e);
         }
-        Ok(CpuGptqStore {
+        let store = std::sync::Arc::new(CpuGptqStore {
             weight_f32: all_w,
             k,
             n: total_n,
-        })
-    }
-    // Phase C step 4b: make_stacked_expert_linear inlined into
-    // CpuMarlinExpertStack::make_expert_linear.
-
-    fn make_marlin_expert_stack(
-        store: std::sync::Arc<Self::GptqStore>,
-        num_experts: usize,
-        n_per_expert: usize,
-        k: usize,
-    ) -> Result<std::sync::Arc<dyn crate::MarlinExpertStack<Self>>> {
+        });
         Ok(std::sync::Arc::new(
             crate::quant_linear::cpu_marlin_stack::CpuMarlinExpertStack::new(
                 store,
@@ -786,55 +777,63 @@ impl crate::backend::BackendQuantMarlin for CpuBackend {
             ),
         ))
     }
+    // Phase C step 4b: make_stacked_expert_linear inlined into
+    // CpuMarlinExpertStack::make_expert_linear.
+    // Phase C step 4e: make_marlin_expert_stack subsumed by load_gptq_stacked.
+    // gemm_gptq_with_offset_strided body moved to free function
+    // cpu_gemm_gptq_with_offset_strided below — called by
+    // CpuMarlinExpertStack::gemm_phase_batched.
+}
 
-    fn gemm_gptq_with_offset_strided(
-        _ctx: &mut Self::Context,
-        input: &Self::Buffer,
-        in_row_offset: usize,
-        weight: &Self::GptqStore,
-        expert_offset: usize,
-        expert_n: usize,
-        output: &mut Self::Buffer,
-        out_row_offset: usize,
-        m: usize,
-        k: usize,
-    ) -> Result<()> {
-        if expert_offset + expert_n > weight.n {
-            return Err(FerrumError::model(format!(
-                "gemm_gptq_with_offset_strided OOB: offset {expert_offset} + n {expert_n} > stacked_n {}",
-                weight.n
-            )));
-        }
-        if k != weight.k {
-            return Err(FerrumError::model(format!(
-                "gemm_gptq_with_offset_strided k mismatch: arg {k} vs weight.k {}",
-                weight.k
-            )));
-        }
-        // [m, K] input slice and [m, expert_n] output slice; weight
-        // [expert_n, K] taken from the column-slice of weight_f32.
-        let in_start = in_row_offset * k;
-        let in_end = (in_row_offset + m) * k;
-        let out_start = out_row_offset * expert_n;
-        let out_end = (out_row_offset + m) * expert_n;
-        let row_start = expert_offset * k;
-        let row_end = (expert_offset + expert_n) * k;
-        let weight_slice = weight.weight_f32[row_start..row_end].to_vec();
-        let in_slice = input[in_start..in_end].to_vec();
-        let mut out_slice = vec![0.0f32; m * expert_n];
-        let mut ctx_local = ();
-        Self::gemm(
-            &mut ctx_local,
-            &in_slice,
-            &weight_slice,
-            &mut out_slice,
-            m,
-            expert_n,
-            k,
-        );
-        output[out_start..out_end].copy_from_slice(&out_slice);
-        Ok(())
+/// Free-function form of the deleted
+/// `BackendQuantMarlin::gemm_gptq_with_offset_strided` (Phase C step 4e).
+/// Single caller: `CpuMarlinExpertStack::gemm_phase_batched`.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn cpu_gemm_gptq_with_offset_strided(
+    _ctx: &mut <CpuBackend as Backend>::Context,
+    input: &<CpuBackend as Backend>::Buffer,
+    in_row_offset: usize,
+    weight: &CpuGptqStore,
+    expert_offset: usize,
+    expert_n: usize,
+    output: &mut <CpuBackend as Backend>::Buffer,
+    out_row_offset: usize,
+    m: usize,
+    k: usize,
+) -> Result<()> {
+    if expert_offset + expert_n > weight.n {
+        return Err(FerrumError::model(format!(
+            "cpu_gemm_gptq_with_offset_strided OOB: offset {expert_offset} + n {expert_n} > stacked_n {}",
+            weight.n
+        )));
     }
+    if k != weight.k {
+        return Err(FerrumError::model(format!(
+            "cpu_gemm_gptq_with_offset_strided k mismatch: arg {k} vs weight.k {}",
+            weight.k
+        )));
+    }
+    let in_start = in_row_offset * k;
+    let in_end = (in_row_offset + m) * k;
+    let out_start = out_row_offset * expert_n;
+    let out_end = (out_row_offset + m) * expert_n;
+    let row_start = expert_offset * k;
+    let row_end = (expert_offset + expert_n) * k;
+    let weight_slice = weight.weight_f32[row_start..row_end].to_vec();
+    let in_slice = input[in_start..in_end].to_vec();
+    let mut out_slice = vec![0.0f32; m * expert_n];
+    let mut ctx_local = ();
+    CpuBackend::gemm(
+        &mut ctx_local,
+        &in_slice,
+        &weight_slice,
+        &mut out_slice,
+        m,
+        expert_n,
+        k,
+    );
+    output[out_start..out_end].copy_from_slice(&out_slice);
+    Ok(())
 }
 
 impl crate::backend::BackendQuantGguf for CpuBackend {

--- a/crates/ferrum-kernels/src/backend/cuda/mod.rs
+++ b/crates/ferrum-kernels/src/backend/cuda/mod.rs
@@ -338,7 +338,8 @@ impl Backend for CudaBackend {
     // by half (`alloc_u32` default was wrong on CUDA).
     type Buffer = crate::backend::CudaBuf;
     type Context = CudaState;
-    type GptqStore = GptqStoreCuda;
+    // type GptqStore: removed in Phase C step 4e. GptqStoreCuda is
+    // now a private (crate-internal) detail of CudaMarlinExpertStack.
 
     // ── Lifecycle ────────────────────────────────────────────────────────
 

--- a/crates/ferrum-kernels/src/backend/cuda/quant.rs
+++ b/crates/ferrum-kernels/src/backend/cuda/quant.rs
@@ -454,45 +454,10 @@ impl BackendQuantMarlin for CudaBackend {
             let _ = (ctx, required);
         }
     }
-    #[cfg(feature = "marlin")]
-    fn gemm_gptq_with_offset_strided(
-        ctx: &mut Self::Context,
-        input: &Self::Buffer,
-        in_row_offset: usize,
-        weight: &Self::GptqStore,
-        expert_offset: usize,
-        expert_n: usize,
-        output: &mut Self::Buffer,
-        out_row_offset: usize,
-        m: usize,
-        _k: usize,
-    ) -> Result<()> {
-        #[cfg(feature = "triton-kernels")]
-        let mw = match weight {
-            GptqStoreCuda::Marlin(mw) => mw,
-            GptqStoreCuda::Triton(_) => {
-                return Err(FerrumError::unsupported(
-                    "gemm_gptq_with_offset_strided: Triton w4a16 store has no \
-                     stride-aware variant; load MoE via Marlin (default)",
-                ));
-            }
-        };
-        #[cfg(not(feature = "triton-kernels"))]
-        let mw: &crate::marlin::MarlinWeight = weight;
-        let stream = ctx.stream.clone();
-        crate::marlin::marlin_gemm_with_offset_strided(
-            &stream,
-            input.as_f16(),
-            in_row_offset as i32,
-            mw,
-            output.as_f16_mut(),
-            out_row_offset as i32,
-            m as i32,
-            expert_offset as i32,
-            expert_n as i32,
-        )
-        .map_err(|e| FerrumError::model(format!("marlin offset_strided gemm: {e}")))
-    }
+    // Phase C step 4e: CUDA gemm_gptq_with_offset_strided dead code
+    // removed. The remaining caller (moe_gemm_phase_batched_impl
+    // serial/multi-stream path below) calls marlin_gemm_with_offset_strided
+    // directly.
     fn load_gptq(
         qweight: &[i32],
         scales: &[f32],
@@ -643,7 +608,7 @@ impl BackendQuantMarlin for CudaBackend {
         group_size: usize,
         k: usize,
         n_per_expert: usize,
-    ) -> Result<Self::GptqStore> {
+    ) -> Result<std::sync::Arc<dyn crate::MarlinExpertStack<Self>>> {
         if bits != 4 {
             return Err(FerrumError::unsupported(format!(
                 "CUDA GPTQ stacked: only bits=4 supported (got {bits})"
@@ -797,32 +762,22 @@ impl BackendQuantMarlin for CudaBackend {
         );
 
         #[cfg(feature = "triton-kernels")]
-        {
-            Ok(GptqStoreCuda::Marlin(marlin_weight))
-        }
+        let store: GptqStoreCuda = GptqStoreCuda::Marlin(marlin_weight);
         #[cfg(not(feature = "triton-kernels"))]
-        {
-            Ok(marlin_weight)
-        }
-    }
-    // Phase C step 4b: make_stacked_expert_linear inlined into
-    // CudaMarlinExpertStack::make_expert_linear.
-
-    fn make_marlin_expert_stack(
-        store: std::sync::Arc<Self::GptqStore>,
-        num_experts: usize,
-        n_per_expert: usize,
-        k: usize,
-    ) -> Result<std::sync::Arc<dyn crate::MarlinExpertStack<Self>>> {
+        let store: GptqStoreCuda = marlin_weight;
         Ok(std::sync::Arc::new(
             crate::quant_linear::cuda_marlin_stack::CudaMarlinExpertStack::new(
-                store,
+                std::sync::Arc::new(store),
                 num_experts,
                 n_per_expert,
                 k,
             ),
         ))
     }
+    // Phase C step 4b: make_stacked_expert_linear inlined into
+    // CudaMarlinExpertStack::make_expert_linear.
+    // Phase C step 4e: make_marlin_expert_stack subsumed by load_gptq_stacked
+    // (now returns the trait object directly).
     // Phase C step 4a: marlin_zero_stacked_workspace inlined into
     // CudaMarlinExpertStack::zero_workspace (quant_linear/cuda_marlin_stack.rs).
     // Phase C step 4c/4d: moe_gemm_phase_batched / moe_gemm_phase_vllm

--- a/crates/ferrum-kernels/src/backend/metal.rs
+++ b/crates/ferrum-kernels/src/backend/metal.rs
@@ -932,7 +932,9 @@ fn dispatch_part_gemv_offset(
 impl Backend for MetalBackend {
     type Buffer = MetalBuf;
     type Context = MetalContext;
-    type GptqStore = (); // Metal GPTQ not yet wired; load_gptq/gemm_gptq return unsupported.
+    // type GptqStore: removed in Phase C step 4e. Metal has no Marlin
+    // GPTQ path (GGUF is the quant story on Metal). Adding GPTQ later
+    // means impl-ing MarlinExpertStack<MetalBackend> + load_gptq_stacked.
 
     fn new_context() -> Self::Context {
         MetalContext {

--- a/crates/ferrum-kernels/src/backend/traits.rs
+++ b/crates/ferrum-kernels/src/backend/traits.rs
@@ -262,23 +262,16 @@ pub trait Backend: Send + Sync + Sized + 'static {
     /// Opaque per-backend GPTQ weight representation.
     ///   - CPU: dequantized f32 weights (run as regular GEMM)
     ///   - Metal: `()` — unsupported; `gemm_gptq` errors
-    ///   - CUDA: `MarlinWeight` — pre-repacked tiles + permuted scales
-    ///
-    /// Each backend repacks raw GPTQ tensors (qweight/scales/qzeros, all
-    /// i32/f16) into its preferred format at model load time, so inference
-    /// doesn't pay the repack cost per forward pass.
-    type GptqStore: Send + Sync;
-
-    // Note (Phase 3e/4): `type QuantStore` (GGUF k-quant storage) was removed
-    // — single-linear GGUF goes through `Box<dyn Linear<Self>>` (returned by
-    // `load_quant` / `load_quant_fused`), and stacked-expert MoE GGUF goes
-    // through `Box<dyn StackedExpertGgufLinear<Self>>` (returned by
-    // `load_quant_experts`). Backend trait no longer needs a backend-
-    // specific GGUF type, so adding a new k-quant flavour is purely a
-    // new enum variant inside the backend's concrete Linear impl.
-    // `type GptqStore` is still here because GPTQ load inputs are split
-    // arrays (qweight / scales / qzeros) — see PR D for the matching
-    // GPTQ cutover.
+    // Note (Phase 3e/4 + Phase C):
+    // - `type QuantStore` (GGUF k-quant storage) was removed in Phase 3e/4
+    //   — stacked-expert MoE GGUF goes through Box<dyn StackedExpertGgufLinear<Self>>
+    //   returned by `load_quant_experts`.
+    // - `type GptqStore` (Marlin/dequant GPTQ storage) was removed in Phase C
+    //   step 4e — stacked-expert Marlin MoE goes through
+    //   Arc<dyn MarlinExpertStack<Self>> returned by `load_gptq_stacked`,
+    //   and single-tensor GPTQ goes through Box<dyn Linear<Self>> returned
+    //   by `load_gptq`. Adding a new Marlin-capable backend is purely a
+    //   new MarlinExpertStack<NewBackend> impl — no Backend trait edits.
 
     /// Create a new execution context (begin accumulating work).
     fn new_context() -> Self::Context;
@@ -1032,6 +1025,17 @@ pub trait BackendQuantMarlin: Backend {
     ///
     /// Default returns Err(unsupported); override on backends with a
     /// per-expert MoE GPTQ path.
+    /// Phase C step 4e: returns the trait-object `MarlinExpertStack`
+    /// directly. Internally, each backend constructs its own opaque
+    /// repacked tile (Marlin: per-expert-then-concat; CPU: dequantized
+    /// f32 weight slab) and wraps it in the concrete
+    /// `{Cuda,Cpu}MarlinExpertStack` impl.
+    ///
+    /// Removing `Self::GptqStore` from the public API kills the type
+    /// leak that previously forced `ExpertStack<B>` to carry
+    /// `Option<Arc<B::GptqStore>>`. Adding a new Marlin backend now
+    /// only requires implementing this method + a fresh
+    /// `MarlinExpertStack<NewBackend>` impl — no Backend trait edits.
     #[allow(clippy::too_many_arguments)]
     fn load_gptq_stacked(
         _qweights: &[&[i32]],
@@ -1042,52 +1046,22 @@ pub trait BackendQuantMarlin: Backend {
         _group_size: usize,
         _k: usize,
         _n_per_expert: usize,
-    ) -> Result<Self::GptqStore> {
+    ) -> Result<std::sync::Arc<dyn crate::MarlinExpertStack<Self>>> {
         Err(FerrumError::unsupported(
             "load_gptq_stacked not implemented for this backend",
         ))
     }
-    // Phase C step 4b: BackendQuantMarlin::make_stacked_expert_linear
-    // was removed — its body is now inlined into
-    // `MarlinExpertStack::make_expert_linear` (concrete impls in
-    // `quant_linear/{cuda,cpu}_marlin_stack.rs`). Callers reach
-    // single-expert Linear views via
-    // `store.clone().make_expert_linear(offset, n, bias)`.
-
-    /// Phase C step 3: wrap a raw `Arc<Self::GptqStore>` into the
-    /// trait-object `MarlinExpertStack<Self>`. Lets callers go through
-    /// `store.gemm_phase_*` / `store.zero_workspace()` instead of
-    /// reaching into the per-backend `moe_gemm_phase_*` methods —
-    /// the eventual goal is to drop `type GptqStore` from this trait.
-    ///
-    /// Default returns unsupported. CUDA overrides with
-    /// `CudaMarlinExpertStack`. Backends without a stacked Marlin path
-    /// don't implement this; their model code falls back to per-expert
-    /// `Linear<B>` dispatch.
-    fn make_marlin_expert_stack(
-        _store: std::sync::Arc<Self::GptqStore>,
-        _num_experts: usize,
-        _n_per_expert: usize,
-        _k: usize,
-    ) -> Result<std::sync::Arc<dyn crate::MarlinExpertStack<Self>>> {
-        Err(FerrumError::unsupported(
-            "make_marlin_expert_stack not implemented for this backend",
-        ))
-    }
-    // Phase C step 4a: BackendQuantMarlin::marlin_zero_stacked_workspace
-    // was removed — its body is now inlined into
-    // `MarlinExpertStack::zero_workspace` (concrete impls in
-    // `quant_linear/{cuda,cpu}_marlin_stack.rs`). Callers reach the
-    // workspace-zero op via `store.zero_workspace(ctx)` instead.
-    /// Batched per-expert offset GEMM dispatch — runs N concurrent
-    /// Marlin calls across a stream pool to amortize launch overhead
-    /// and overlap small-m kernels that under-utilize SMs individually.
-    ///
-    // Phase C step 4c+4d: BackendQuantMarlin::moe_gemm_phase_batched
-    // and moe_gemm_phase_vllm removed — their bodies are now inlined
-    // into MarlinExpertStack::gemm_phase_batched / gemm_phase_vllm
-    // (concrete impls in quant_linear/{cuda,cpu}_marlin_stack.rs).
-    // Callers reach them via `store.gemm_phase_*(ctx, ...)`.
+    // Phase C step 4a: marlin_zero_stacked_workspace — body inlined into
+    // MarlinExpertStack::zero_workspace.
+    // Phase C step 4b: make_stacked_expert_linear — body inlined into
+    // MarlinExpertStack::make_expert_linear.
+    // Phase C step 4c+4d: moe_gemm_phase_batched + moe_gemm_phase_vllm —
+    // bodies inlined into MarlinExpertStack::gemm_phase_batched /
+    // gemm_phase_vllm (concrete impls in quant_linear/{cuda,cpu}_marlin_stack.rs).
+    // Phase C step 4e: make_marlin_expert_stack subsumed by
+    // load_gptq_stacked (now returns the trait object directly).
+    // gemm_gptq_with_offset_strided — body inlined into CpuMarlinExpertStack
+    // (the only remaining caller).
     /// Pre-grow any backend-internal scratch slots whose size depends
     /// on `m_total * intermediate_size` (the largest matmul fan-in
     /// inside `unified_forward_internal`). Default no-op. CUDA
@@ -1098,31 +1072,10 @@ pub trait BackendQuantMarlin: Backend {
     fn pregrow_marlin_gather_scratch(_ctx: &mut Self::Context, _required: usize) {
         // default: no scratch to pre-grow
     }
-    /// Variant of [`Backend::gemm_gptq_with_offset`] that also takes
-    /// row-offsets into the input and output buffers. Lets the bucketed
-    /// MoE dispatcher run an expert's column-slice GEMM against a
-    /// sub-range of the packed input/output buffers without needing a
-    /// buffer-view type.
-    ///
-    /// Default impl returns Err so backends without MoE batched dispatch
-    /// don't have to implement.
-    #[allow(clippy::too_many_arguments)]
-    fn gemm_gptq_with_offset_strided(
-        _ctx: &mut Self::Context,
-        _input: &Self::Buffer,
-        _in_row_offset: usize,
-        _weight: &Self::GptqStore,
-        _expert_offset: usize,
-        _expert_n: usize,
-        _output: &mut Self::Buffer,
-        _out_row_offset: usize,
-        _m: usize,
-        _k: usize,
-    ) -> Result<()> {
-        Err(ferrum_types::FerrumError::unsupported(
-            "gemm_gptq_with_offset_strided not implemented for this backend",
-        ))
-    }
+    // Phase C step 4e: gemm_gptq_with_offset_strided removed —
+    // body inlined into CpuMarlinExpertStack (the only caller after
+    // step 4c moved the multi-stream pool dispatch into the CUDA
+    // free function).
 }
 
 // ════════════════════════════════════════════════════════════════════════

--- a/crates/ferrum-kernels/src/quant_linear/cpu_marlin_stack.rs
+++ b/crates/ferrum-kernels/src/quant_linear/cpu_marlin_stack.rs
@@ -16,7 +16,7 @@ use ferrum_types::Result;
 use std::sync::Arc;
 
 pub struct CpuMarlinExpertStack {
-    pub store: Arc<<CpuBackend as crate::backend::Backend>::GptqStore>,
+    pub store: Arc<crate::backend::cpu::CpuGptqStore>,
     pub num_experts: usize,
     pub n_per_expert: usize,
     pub k: usize,
@@ -24,7 +24,7 @@ pub struct CpuMarlinExpertStack {
 
 impl CpuMarlinExpertStack {
     pub fn new(
-        store: Arc<<CpuBackend as crate::backend::Backend>::GptqStore>,
+        store: Arc<crate::backend::cpu::CpuGptqStore>,
         num_experts: usize,
         n_per_expert: usize,
         k: usize,
@@ -67,11 +67,11 @@ impl MarlinExpertStack<CpuBackend> for CpuMarlinExpertStack {
         output: &mut <CpuBackend as crate::backend::Backend>::Buffer,
         k: usize,
     ) -> Result<()> {
-        // Phase C step 4c: inlined from the default
-        // BackendQuantMarlin::moe_gemm_phase_batched impl — serial loop
-        // calling gemm_gptq_with_offset_strided per active expert.
+        // Phase C step 4c+4e: serial loop calling the moved-out CPU
+        // gemm_gptq_with_offset_strided free function. No longer
+        // routes through any Backend trait method.
         for (expert_idx, in_row_offset, out_row_offset, m) in dispatches {
-            <CpuBackend as crate::backend::BackendQuantMarlin>::gemm_gptq_with_offset_strided(
+            crate::backend::cpu::cpu_gemm_gptq_with_offset_strided(
                 ctx,
                 input,
                 *in_row_offset,

--- a/crates/ferrum-models/src/models/qwen3_moe.rs
+++ b/crates/ferrum-models/src/models/qwen3_moe.rs
@@ -635,33 +635,18 @@ impl<B: MoeLlmBackend, K: KvDtypeKind> Qwen3MoeModel<B, K> {
             } else {
                 &["gate_up_proj"]
             };
-            let (gate_up_store, gate_up_n_per_expert, gate_up_k) =
+            // Phase C step 4e: load_stacked_gptq_experts returns the
+            // trait-object MarlinExpertStack directly (no intermediate
+            // GptqStore type). The loader internally calls
+            // B::load_gptq_stacked which now returns
+            // Arc<dyn MarlinExpertStack<B>>.
+            let (gate_up_marlin, gate_up_n_per_expert, gate_up_k) =
                 loader.load_stacked_gptq_experts(&expert_prefix, cfg.num_experts, gate_up_projs)?;
-            let (down_store, down_n_per_expert, down_k) = loader.load_stacked_gptq_experts(
+            let (down_marlin, down_n_per_expert, down_k) = loader.load_stacked_gptq_experts(
                 &expert_prefix,
                 cfg.num_experts,
                 &["down_proj"],
             )?;
-            let gate_up_arc = std::sync::Arc::new(gate_up_store);
-            let down_arc = std::sync::Arc::new(down_store);
-
-            // Wrap raw Marlin tile stores in trait objects (Phase C step 3) —
-            // dispatch goes through `gu_store.gemm_phase_*` / `zero_workspace`
-            // instead of `B::moe_gemm_phase_*` / `B::marlin_zero_stacked_workspace`.
-            let gate_up_marlin =
-                <B as ferrum_kernels::backend::BackendQuantMarlin>::make_marlin_expert_stack(
-                    gate_up_arc,
-                    cfg.num_experts,
-                    gate_up_n_per_expert,
-                    gate_up_k,
-                )?;
-            let down_marlin =
-                <B as ferrum_kernels::backend::BackendQuantMarlin>::make_marlin_expert_stack(
-                    down_arc,
-                    cfg.num_experts,
-                    down_n_per_expert,
-                    down_k,
-                )?;
 
             // Per-expert Linear views — used by code paths that go
             // through `ExpertStack::gate_up[i]` / `down[i]` (single

--- a/crates/ferrum-models/tests/moe_bucketed_parity_test.rs
+++ b/crates/ferrum-models/tests/moe_bucketed_parity_test.rs
@@ -55,14 +55,14 @@ fn build_stacked(
     num_experts: usize,
     group_size: usize,
     base_seed: u64,
-) -> Arc<<CpuBackend as Backend>::GptqStore> {
+) -> Arc<dyn ferrum_kernels::MarlinExpertStack<CpuBackend>> {
     let parts: Vec<_> = (0..num_experts)
         .map(|e| synth_gptq(k, n_per_expert, group_size, base_seed + e as u64))
         .collect();
     let qweights: Vec<&[i32]> = parts.iter().map(|p| p.0.as_slice()).collect();
     let scales: Vec<&[f32]> = parts.iter().map(|p| p.1.as_slice()).collect();
     let qzeros: Vec<&[i32]> = parts.iter().map(|p| p.2.as_slice()).collect();
-    let store = <CpuBackend as BackendQuantMarlin>::load_gptq_stacked(
+    <CpuBackend as BackendQuantMarlin>::load_gptq_stacked(
         &qweights,
         &scales,
         &qzeros,
@@ -72,8 +72,7 @@ fn build_stacked(
         k,
         n_per_expert,
     )
-    .expect("CPU stacked load_gptq_stacked");
-    Arc::new(store)
+    .expect("CPU stacked load_gptq_stacked")
 }
 
 #[test]
@@ -85,27 +84,10 @@ fn bucketed_matches_per_pair_dispatch() {
     let batch = 5;
     let group_size = 32;
 
-    // Build stacked stores for gate_up (2 * inter cols per expert) and
-    // down (hidden cols per expert).
-    let gate_up_arc = build_stacked(hidden, 2 * inter, num_experts, group_size, 0xA);
-    let down_arc = build_stacked(inter, hidden, num_experts, group_size, 0xB);
-
-    // Phase C step 3: build trait-object MarlinExpertStack first;
-    // step 4b: StackedExpertLinear::new takes the stack directly.
-    let gate_up_stack = <CpuBackend as BackendQuantMarlin>::make_marlin_expert_stack(
-        gate_up_arc.clone(),
-        num_experts,
-        2 * inter,
-        hidden,
-    )
-    .expect("make_marlin_expert_stack gate_up");
-    let down_stack = <CpuBackend as BackendQuantMarlin>::make_marlin_expert_stack(
-        down_arc.clone(),
-        num_experts,
-        hidden,
-        inter,
-    )
-    .expect("make_marlin_expert_stack down");
+    // Build stacked MarlinExpertStacks (Phase C step 4e: build_stacked now
+    // returns the trait object directly).
+    let gate_up_stack = build_stacked(hidden, 2 * inter, num_experts, group_size, 0xA);
+    let down_stack = build_stacked(inter, hidden, num_experts, group_size, 0xB);
 
     // Per-expert StackedExpertLinear views built from the trait-object
     // stack (Phase C step 4b). Used by per-pair dispatch path.

--- a/crates/ferrum-quantization/src/native_safetensors.rs
+++ b/crates/ferrum-quantization/src/native_safetensors.rs
@@ -342,7 +342,11 @@ impl<B: Backend + BackendQuantMarlin> NativeSafetensorsLoader<B> {
         expert_prefix_fmt: &str,
         num_experts: usize,
         proj_names: &[&str],
-    ) -> Result<(B::GptqStore, usize, usize)> {
+    ) -> Result<(
+        std::sync::Arc<dyn ferrum_kernels::MarlinExpertStack<B>>,
+        usize,
+        usize,
+    )> {
         let qcfg = self.quant_config.as_ref().ok_or_else(|| {
             FerrumError::model(
                 "load_stacked_gptq_experts requires quantize_config.json".to_string(),

--- a/crates/ferrum-quantization/tests/gptq_parity_test.rs
+++ b/crates/ferrum-quantization/tests/gptq_parity_test.rs
@@ -274,6 +274,8 @@ fn cuda_stacked_offset_vs_per_expert() {
     let qw_refs: Vec<&[i32]> = experts.iter().map(|e| e.qweight.as_slice()).collect();
     let sc_refs: Vec<&[f32]> = experts.iter().map(|e| e.scales.as_slice()).collect();
     let qz_refs: Vec<&[i32]> = experts.iter().map(|e| e.qzeros.as_slice()).collect();
+    // Phase C step 4e: load_gptq_stacked now returns the trait-object
+    // MarlinExpertStack directly (no intermediate GptqStore type).
     let stacked = <CudaBackend as BackendQuantMarlin>::load_gptq_stacked(
         &qw_refs, &sc_refs, &qz_refs, None, 4, gs, k, n_per,
     )
@@ -284,7 +286,6 @@ fn cuda_stacked_offset_vs_per_expert() {
     let mut ctx = <CudaBackend as Backend>::new_context();
 
     // Run per-expert reference + offset variant for each expert; compare.
-    let stacked_arc = std::sync::Arc::new(stacked);
     for (e, lin) in per_expert.iter().enumerate() {
         let input_dev = CudaBackend::from_slice(&input);
         let mut ref_out_dev = CudaBackend::alloc(m * n_per);
@@ -294,17 +295,8 @@ fn cuda_stacked_offset_vs_per_expert() {
 
         let input_dev_off = CudaBackend::from_slice(&input);
         let mut off_out_dev = CudaBackend::alloc(m * n_per);
-        // Phase C step 4b: StackedExpertLinear takes a MarlinExpertStack
-        // trait object. Wrap the raw GptqStoreCuda first.
-        let off_stack = <CudaBackend as ferrum_kernels::backend::BackendQuantMarlin>::make_marlin_expert_stack(
-            stacked_arc.clone(),
-            num_experts,
-            n_per,
-            k,
-        )
-        .expect("make_marlin_expert_stack");
         let off_lin = ferrum_quantization::StackedExpertLinear::<CudaBackend>::new(
-            off_stack,
+            stacked.clone(),
             e * n_per,
             n_per,
         )
@@ -396,20 +388,10 @@ fn cpu_stacked_vs_per_expert_parity() {
     )
     .expect("stacked load_gptq_stacked");
 
-    // Slice-and-compare: for each expert, the stacked-store sliced view
-    // must equal the per-expert dedicated GEMM. Phase 3e/2: per-expert
-    // dispatch goes through `StackedExpertLinear<CpuBackend>::forward`.
-    let stacked_arc = std::sync::Arc::new(stacked_store);
-    // Phase C step 4b: wrap the raw GptqStore in a MarlinExpertStack
-    // trait object first; StackedExpertLinear::new takes the stack
-    // directly (no longer routes through B::make_stacked_expert_linear).
-    let stacked_stack = <CpuBackend as ferrum_kernels::backend::BackendQuantMarlin>::make_marlin_expert_stack(
-        stacked_arc.clone(),
-        num_experts,
-        n_per,
-        k,
-    )
-    .expect("make_marlin_expert_stack");
+    // Phase C step 4e: load_gptq_stacked returns Arc<dyn MarlinExpertStack>
+    // directly — `stacked_store` is already the trait object, no separate
+    // make_marlin_expert_stack wrap.
+    let stacked_stack = stacked_store;
     for (e, ref_out) in per_expert_outs.iter().enumerate() {
         let mut stacked_out = vec![0.0f32; m * n_per];
         let mut ctx = <CpuBackend as Backend>::new_context();


### PR DESCRIPTION
Final step of Phase C — eliminates Backend::GptqStore associated type.

## Changes
- Backend::GptqStore associated type removed
- BackendQuantMarlin::make_marlin_expert_stack removed (subsumed by load_gptq_stacked)  
- BackendQuantMarlin::gemm_gptq_with_offset_strided removed (CPU body moved to free fn)
- BackendQuantMarlin::load_gptq_stacked return type: Result<Arc<dyn MarlinExpertStack<Self>>> (was Result<Self::GptqStore>)
- CudaMarlinExpertStack/CpuMarlinExpertStack hold the concrete GptqStoreCuda/CpuGptqStore directly (crate-internal)

## Backend trait surface, final (Marlin family)
- fn load_gptq(...) -> Result<Box<dyn Linear<Self>>>
- fn load_gptq_stacked(...) -> Result<Arc<dyn MarlinExpertStack<Self>>>
- fn pregrow_marlin_gather_scratch(...)

Everything else (zero_workspace, gemm_phase_batched, gemm_phase_vllm, make_expert_linear) is on MarlinExpertStack — adding a new Marlin-capable backend = impl the trait, no Backend supertrait edits.

## Test summary
- cargo check --workspace --features metal clean (Mac)
- moe_bucketed_parity_test + gptq_parity_test pass
- CUDA pod validation in flight