### PR TITLE
fix(cuda): vllm-moe-marlin path post Phase C/D refactor

### DIFF
--- a/crates/ferrum-kernels/src/backend/cuda/moe.rs
+++ b/crates/ferrum-kernels/src/backend/cuda/moe.rs
@@ -290,14 +290,12 @@ impl BackendMoeFused for CudaBackend {
         expert_ids: &[i32],
         num_tokens_past_padded: &[i32],
     ) -> Result<crate::backend::traits::MoeRouting<Self>> {
-        use cudarc::driver::sys::CUdeviceptr;
         use cudarc::driver::CudaSlice;
-        use cudarc::driver::DevicePtr;
 
-        // Per-call alloc + leak. Persistent buffers (one-alloc + reuse)
-        // were attempted as Stage 13c-1 but hit a CUDA driver edge case
-        // — leaving the bench-validated path in place for now.
-        // TODO(stage-13c-redo): retry with stream sync between forwards.
+        // Phase D step 2+3: B::Buffer is now CudaBuf (typed enum),
+        // so we can store the i32 routing buffers directly in
+        // CudaBuf::I32 instead of leaking through f16 upgrade_device_ptr.
+        // No more mem::forget leak — the I32 slices own their memory.
         let stream = ctx.stream.clone();
         let st: CudaSlice<i32> = stream
             .clone_htod(sorted_token_ids)
@@ -308,32 +306,11 @@ impl BackendMoeFused for CudaBackend {
         let npp: CudaSlice<i32> = stream
             .clone_htod(num_tokens_past_padded)
             .map_err(|e| FerrumError::model(format!("htod num_tokens_past_padded: {e}")))?;
-        let (st_ptr, eid_ptr, npp_ptr) = {
-            let (st_ptr, _g0) = st.device_ptr(&stream);
-            let (eid_ptr, _g1) = eid.device_ptr(&stream);
-            let (npp_ptr, _g2) = npp.device_ptr(&stream);
-            (st_ptr, eid_ptr, npp_ptr)
-        };
-        let st_f16: CudaSlice<f16> = unsafe { stream.upgrade_device_ptr(st_ptr as CUdeviceptr, 0) };
-        let eid_f16: CudaSlice<f16> =
-            unsafe { stream.upgrade_device_ptr(eid_ptr as CUdeviceptr, 0) };
-        let npp_f16: CudaSlice<f16> =
-            unsafe { stream.upgrade_device_ptr(npp_ptr as CUdeviceptr, 0) };
-        // Forget the i32 owning slices so the memory survives — the f16
-        // views above point at the same allocation. Acceptable leak: a
-        // few KB per layer × 48 layers/forward × forwards/sec = ~MB/s
-        // sustained, freed only at process exit. Not ideal but works.
-        // TODO(stage-13c-redo): re-attempt persistent buffers once we
-        // understand why memcpy_htod / cuMemcpyHtoDAsync rejects the
-        // 2nd call's params under our driver version.
-        std::mem::forget(st);
-        std::mem::forget(eid);
-        std::mem::forget(npp);
 
         Ok(crate::backend::traits::MoeRouting {
-            sorted_token_ids: st_f16,
-            expert_ids: eid_f16,
-            num_tokens_past_padded: npp_f16,
+            sorted_token_ids: crate::backend::CudaBuf::from_i32(st),
+            expert_ids: crate::backend::CudaBuf::from_i32(eid),
+            num_tokens_past_padded: crate::backend::CudaBuf::from_i32(npp),
         })
     }
 }

--- a/crates/ferrum-kernels/src/backend/cuda/quant.rs
+++ b/crates/ferrum-kernels/src/backend/cuda/quant.rs
@@ -636,7 +636,7 @@ impl BackendQuantMarlin for CudaBackend {
         #[cfg(feature = "vllm-moe-marlin")]
         if use_vllm_moe() {
             let stream = default_stream();
-            let store = crate::vllm_marlin::load_stacked_gptq_vllm_marlin(
+            let mw = crate::vllm_marlin::load_stacked_gptq_vllm_marlin(
                 &stream,
                 qweights,
                 scales,
@@ -649,7 +649,19 @@ impl BackendQuantMarlin for CudaBackend {
             tracing::info!(
                 "GPTQ stacked load (vLLM marlin path): {num_experts} experts × N={n_per_expert} × K={k} (gs={group_size})",
             );
-            return Ok(store);
+            // Phase C step 4e: wrap in trait-object MarlinExpertStack.
+            #[cfg(feature = "triton-kernels")]
+            let store: GptqStoreCuda = GptqStoreCuda::Marlin(mw);
+            #[cfg(not(feature = "triton-kernels"))]
+            let store: GptqStoreCuda = mw;
+            return Ok(std::sync::Arc::new(
+                crate::quant_linear::cuda_marlin_stack::CudaMarlinExpertStack::new(
+                    std::sync::Arc::new(store),
+                    num_experts,
+                    n_per_expert,
+                    k,
+                ),
+            ));
         }
 
         // Triton path: would need a stacked variant — not implemented.
@@ -947,29 +959,27 @@ pub(crate) fn moe_gemm_phase_vllm_impl(
     #[cfg(not(feature = "triton-kernels"))]
     let mw: &crate::marlin::MarlinWeight = weight;
 
-    use cudarc::driver::sys::CUdeviceptr;
     use cudarc::driver::CudaSlice;
-    use cudarc::driver::DevicePtr;
 
     let stream = ctx.stream.clone();
     let c_tmp_mut: &mut CudaSlice<f32> = ctx.vllm_moe_c_tmp();
 
-    let (st_ptr, _g0) = sorted_token_ids.device_ptr(&stream);
-    let (eid_ptr, _g1) = expert_ids.device_ptr(&stream);
-    let (npp_ptr, _g2) = num_tokens_past_padded.device_ptr(&stream);
-    let st_view: CudaSlice<i32> = unsafe { stream.upgrade_device_ptr(st_ptr as CUdeviceptr, 0) };
-    let eid_view: CudaSlice<i32> = unsafe { stream.upgrade_device_ptr(eid_ptr as CUdeviceptr, 0) };
-    let npp_view: CudaSlice<i32> = unsafe { stream.upgrade_device_ptr(npp_ptr as CUdeviceptr, 0) };
+    // Phase D step 2+3: upload_moe_routing now returns CudaBuf::I32
+    // directly — no more upgrade_device_ptr leak. Pass the typed
+    // CudaSlice<i32> refs straight to the kernel wrapper.
+    let st_ref = sorted_token_ids.as_i32();
+    let eid_ref = expert_ids.as_i32();
+    let npp_ref = num_tokens_past_padded.as_i32();
 
-    let r = crate::marlin::marlin_gemm_moe_vllm(
+    crate::marlin::marlin_gemm_moe_vllm(
         &stream,
-        input,
+        input.as_f16(),
         mw,
-        output,
+        output.as_f16_mut(),
         Some(c_tmp_mut),
-        &st_view,
-        &eid_view,
-        &npp_view,
+        st_ref,
+        eid_ref,
+        npp_ref,
         None,
         moe_block_size as i32,
         top_k as i32,
@@ -978,11 +988,8 @@ pub(crate) fn moe_gemm_phase_vllm_impl(
         prob_m as i32,
         n_per_expert as i32,
         k as i32,
-    );
-    std::mem::forget(st_view);
-    std::mem::forget(eid_view);
-    std::mem::forget(npp_view);
-    r.map_err(|e| FerrumError::model(format!("marlin_gemm_moe_vllm: {e}")))
+    )
+    .map_err(|e| FerrumError::model(format!("marlin_gemm_moe_vllm: {e}")))
 }
 // CUDA does not ship GGUF k-quant kernels; inherit unsupported defaults.
 impl BackendQuantGguf for CudaBackend {}


### PR DESCRIPTION
Phase C/D refactor didn't validate the vllm-moe-marlin feature-gated path (build only had --features cuda). Three issues found running the bench:

1. upload_moe_routing returned CudaSlice<f16> via upgrade_device_ptr (i32 storage tunneled through f16 view) — broken now that MoeRouting fields are B::Buffer = CudaBuf. Fix: clone_htod as CudaSlice<i32> directly + wrap in CudaBuf::from_i32. Drops the mem::forget leak that was a stage-13c TODO.

2. moe_gemm_phase_vllm_impl called .device_ptr / upgrade_device_ptr on CudaBuf-typed routing buffers. After the .device_ptr forwarder deletion in #165 those panicked. Fix: route through .as_i32() directly.

3. load_gptq_stacked vLLM marlin path returned bare MarlinWeight (was Self::GptqStore). After #171 it must return Arc<dyn MarlinExpertStack<Self>>. Fix: wrap MarlinWeight → GptqStoreCuda → Arc<CudaMarlinExpertStack>.

## Bench regression (Qwen3-30B-A3B-GPTQ-Int4, RTX 4090, ferrum bench-serve)

| c | new tok/s | baseline tok/s | Δ |
|---|----------:|---------------:|----:|
| 1  | 127.2 | 96.2  | +32% |
| 8  | 432.8 | 241.5 | +79% |
| 16 | 582.1 | 272.1 | +114% |
| 32 | 717.5 | 318.4 | +125% |

c=32 TPOT 39ms (was 94.75ms) — 2.4× speedup. 128/128 completed, fail=0. No functional regression; significant perf improvement (likely from cleaner dispatch path after Backend trait reduction).