### PR TITLE
feat(cuda): add experimental vllm-paged-attn-v2 feature (OFF by default)

### DIFF
--- a/bench/v0.2-cuda/test_paged_attn_v2.sh
+++ b/bench/v0.2-cuda/test_paged_attn_v2.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+# Quick c=32 bench with FERRUM_USE_VLLM_PAGED_ATTN=1 to validate the
+# paged_attention_v2 port lands the expected -2-3 ms TPOT win vs the
+# baseline (1038 tok/s at commit 4a17a17, recorded 2026-05-12).
+#
+# Mirrors apples_m3_drive.sh::ferrum_start env block + adds
+# FERRUM_USE_VLLM_PAGED_ATTN=1.
+
+set -e
+cd /workspace/ferrum-infer-rs
+
+PORT=8801
+RUN_R=$(date +%s)
+LOG=bench/v0.2-cuda/results/ferrum__M3__c32__pa2_r${RUN_R}.server.log
+mkdir -p bench/v0.2-cuda/results
+
+pkill -9 -f "ferrum.*serve" 2>/dev/null || true
+pkill -9 -f "vllm serve"    2>/dev/null || true
+sleep 3
+
+echo "=== starting ferrum w/ FERRUM_USE_VLLM_PAGED_ATTN=1 ==="
+CUDA_VISIBLE_DEVICES=0 \
+FERRUM_VLLM_MOE=1 \
+FERRUM_KV_CAPACITY=2048 \
+FERRUM_KV_MAX_BLOCKS=4096 \
+FERRUM_PAGED_MAX_SEQS=32 \
+FERRUM_METAL_PAGED_KV=1 \
+FERRUM_MIXED_BATCH=0 \
+FERRUM_GREEDY_ARGMAX=1 \
+FERRUM_MOE_BUCKETED=1 \
+FERRUM_MARLIN_SKIP_WS_ZERO=1 \
+FERRUM_MOE_STREAMS=4 \
+FERRUM_MOE_BATCH_THRESHOLD=4 \
+FERRUM_USE_VLLM_PAGED_ATTN=1 \
+  /workspace/ferrum-infer-rs/target/release/ferrum serve \
+    --model /workspace/models/M3 --port "$PORT" \
+    --gpu-memory-utilization 0.95 \
+  > "$LOG" 2>&1 &
+FPID=$!
+echo "FPID=$FPID LOG=$LOG"
+
+for i in $(seq 1 240); do
+  curl -sf "http://127.0.0.1:$PORT/v1/models" >/dev/null 2>&1 && { echo "[ferrum] ready in ${i}s"; break; }
+  ! kill -0 "$FPID" 2>/dev/null && { echo "[ferrum] died"; tail -80 "$LOG"; exit 1; }
+  sleep 1
+done
+
+echo "=== prewarm ==="
+curl -sf -m 60 -X POST "http://127.0.0.1:$PORT/v1/chat/completions" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"x","messages":[{"role":"user","content":"hi"}],"max_tokens":4,"temperature":0}' > /dev/null
+
+source /workspace/vllm-venv/bin/activate
+echo "=== bench c=32 r=${RUN_R} ==="
+rm -f bench/v0.2-cuda/results/ferrum__M3__c32__r${RUN_R}.*
+bash bench/v0.2-cuda/run_cell.sh ferrum M3 32 "${RUN_R}" "$PORT" 2>&1 | tail -30
+
+echo
+echo "=== result json ==="
+F=bench/v0.2-cuda/results/ferrum__M3__c32__r${RUN_R}.json
+if [ -f "$F" ]; then
+  python3 -c "
+import json, sys
+d = json.load(open('$F'))
+print(f\"output_throughput={d.get('output_throughput',0):.1f} tok/s\")
+print(f\"mean_tpot_ms={d.get('mean_tpot_ms',0):.2f}\")
+print(f\"p99_tpot_ms={d.get('p99_tpot_ms',0):.2f}\")
+print(f\"completed={d.get('completed',0)} failed={d.get('failed',0)}\")
+"
+else
+  echo "MISSING: $F"
+fi
+
+kill -INT "$FPID" 2>/dev/null; sleep 3
+pkill -9 -f "ferrum.*serve" 2>/dev/null || true

--- a/bench/v0.2-cuda/test_paged_attn_v2.sh
+++ b/bench/v0.2-cuda/test_paged_attn_v2.sh
@@ -31,6 +31,8 @@ FERRUM_MOE_BUCKETED=1 \
 FERRUM_MARLIN_SKIP_WS_ZERO=1 \
 FERRUM_MOE_STREAMS=4 \
 FERRUM_MOE_BATCH_THRESHOLD=4 \
+FERRUM_MOE_GRAPH=1 \
+FERRUM_GRAPH_SKIP_UPLOAD=1 \
 FERRUM_USE_VLLM_PAGED_ATTN=1 \
   /workspace/ferrum-infer-rs/target/release/ferrum serve \
     --model /workspace/models/M3 --port "$PORT" \

--- a/crates/ferrum-cli/Cargo.toml
+++ b/crates/ferrum-cli/Cargo.toml
@@ -88,6 +88,7 @@ cuda = ["ferrum-engine/cuda", "ferrum-kernels/cuda", "ferrum-quantization/cuda"]
 marlin = ["cuda"]  # backward compat alias
 vllm-marlin = ["cuda", "ferrum-kernels/vllm-marlin"]  # Phase 12 — vLLM gptq_marlin port (opt-in)
 vllm-moe-marlin = ["cuda", "ferrum-kernels/vllm-moe-marlin"]  # Stage 14 — vLLM marlin_moe_wna16 port (opt-in)
+vllm-paged-attn-v2 = ["cuda", "ferrum-kernels/vllm-paged-attn-v2"]  # 2026-05-12 — vLLM paged_attention_v2 port (opt-in, runtime-gated via FERRUM_USE_VLLM_PAGED_ATTN=1)
 tensor-parallel = ["cuda"]  # backward compat alias
 # Triton-rs PTX path swap for the LLM decode kernels. Requires cuda.
 triton-kernels = ["cuda", "ferrum-engine/triton-kernels"]

--- a/crates/ferrum-kernels/kernels/vllm_attn/attention_kernels.cuh
+++ b/crates/ferrum-kernels/kernels/vllm_attn/attention_kernels.cuh
@@ -31,10 +31,10 @@
 
 #ifdef USE_ROCM
   #include <hip/hip_bf16.h>
-  #include "../quantization/w8a8/fp8/amd/quant_utils.cuh"
+  #include "quant_utils_stub.cuh"  // ferrum: stub — we never instantiate FP8 KV
 typedef __hip_bfloat16 __nv_bfloat16;
 #else
-  #include "../quantization/w8a8/fp8/nvidia/quant_utils.cuh"
+  #include "quant_utils_stub.cuh"  // ferrum: stub — we never instantiate FP8 KV
 #endif
 
 #define MAX(a, b) ((a) > (b) ? (a) : (b))

--- a/crates/ferrum-kernels/kernels/vllm_attn/attention_utils.cuh
+++ b/crates/ferrum-kernels/kernels/vllm_attn/attention_utils.cuh
@@ -18,7 +18,7 @@
  */
 #pragma once
 
-#include "../cuda_compat.h"
+#include "include/cuda_compat.h"
 #include "attention_dtypes.h"
 
 #include <float.h>

--- a/crates/ferrum-kernels/kernels/vllm_attn/dtype_fp8.cuh
+++ b/crates/ferrum-kernels/kernels/vllm_attn/dtype_fp8.cuh
@@ -3,6 +3,7 @@
 #include "attention_generic.cuh"
 
 #include <stdint.h>
+#include <string>  // ferrum: original vendored from torch context; add for std::string
 #ifdef ENABLE_FP8
   #ifndef USE_ROCM
     #include <cuda_fp8.h>

--- a/crates/ferrum-kernels/kernels/vllm_attn/launcher.cu
+++ b/crates/ferrum-kernels/kernels/vllm_attn/launcher.cu
@@ -66,21 +66,30 @@ extern "C" void ferrum_vllm_paged_attention_v2_f16_h128_b16(
 
     dim3 grid(num_heads, num_seqs, max_num_partitions);
     dim3 block(NUM_THREADS);
+    // vLLM's dtype machinery (`Vec<uint16_t,N>::Type`, `from_float(uint16_t&, float)`)
+    // is specialized for `uint16_t` as the half-precision scalar — never
+    // `__half` directly. Cast our __half pointers to uint16_t* for the kernel
+    // call. Bitwise identical, just template-matching plumbing.
     vllm::paged_attention_v2_kernel<
-        __half, __half, HEAD_SIZE, BLOCK_SIZE, NUM_THREADS, KV_DTYPE,
+        uint16_t, uint16_t, HEAD_SIZE, BLOCK_SIZE, NUM_THREADS, KV_DTYPE,
         IS_BLOCK_SPARSE, PARTITION_SIZE>
         <<<grid, block, shared_mem_size, stream>>>(
-            exp_sums, max_logits, tmp_out, query, key_cache, value_cache,
-            num_kv_heads, scale, block_tables, seq_lens,
-            max_num_blocks_per_seq, alibi_slopes_ptr, q_stride,
-            kv_block_stride, kv_head_stride, k_scale_ptr, v_scale_ptr,
-            tp_rank, blocksparse_local_blocks, blocksparse_vert_stride,
-            blocksparse_block_size, blocksparse_head_sliding_step);
+            exp_sums, max_logits, reinterpret_cast<uint16_t*>(tmp_out),
+            reinterpret_cast<const uint16_t*>(query),
+            reinterpret_cast<const uint16_t*>(key_cache),
+            reinterpret_cast<const uint16_t*>(value_cache), num_kv_heads,
+            scale, block_tables, seq_lens, max_num_blocks_per_seq,
+            alibi_slopes_ptr, q_stride, kv_block_stride, kv_head_stride,
+            k_scale_ptr, v_scale_ptr, tp_rank, blocksparse_local_blocks,
+            blocksparse_vert_stride, blocksparse_block_size,
+            blocksparse_head_sliding_step);
 
     dim3 reduce_grid(num_heads, num_seqs);
     int reduce_shared_mem_size = 2 * max_num_partitions * sizeof(float);
     vllm::paged_attention_v2_reduce_kernel<
-        __half, HEAD_SIZE, NUM_THREADS, PARTITION_SIZE>
+        uint16_t, HEAD_SIZE, NUM_THREADS, PARTITION_SIZE>
         <<<reduce_grid, block, reduce_shared_mem_size, stream>>>(
-            out, exp_sums, max_logits, tmp_out, seq_lens, max_num_partitions);
+            reinterpret_cast<uint16_t*>(out), exp_sums, max_logits,
+            reinterpret_cast<const uint16_t*>(tmp_out), seq_lens,
+            max_num_partitions);
 }

--- a/crates/ferrum-kernels/kernels/vllm_attn/quant_utils_stub.cuh
+++ b/crates/ferrum-kernels/kernels/vllm_attn/quant_utils_stub.cuh
@@ -1,0 +1,30 @@
+// FP8 quantization stub for ferrum's vendored vLLM paged-attention v2.
+//
+// vLLM's `attention_kernels.cuh` includes
+// `../quantization/w8a8/fp8/nvidia/quant_utils.cuh` to get `fp8::scaled_convert`
+// — used when `KV_DTYPE != kAuto`. Ferrum's single instantiation
+// (HEAD=128, BLOCK=16, FP16, KV_DTYPE=kAuto) never reaches those paths, so we
+// provide a minimal stub that satisfies the include without pulling in the
+// whole w8a8 vendored subtree.
+//
+// If you later add FP8 KV cache, replace this stub with the real vendored file
+// from vllm/csrc/quantization/w8a8/fp8/nvidia/quant_utils.cuh.
+#pragma once
+
+#include <cuda_fp16.h>
+
+namespace vllm {
+namespace fp8 {
+
+// Identity-conversion stubs — referenced inside `if constexpr` guarded by
+// `KV_DTYPE != kAuto`. The compiler still has to parse the template body even
+// when the branch is dead, so the signatures must exist. Returning the input
+// unchanged keeps semantics sound if someone accidentally instantiates with
+// FP8 KV without rebuilding the real header.
+template <typename Tout, typename Tin, int KV_DTYPE>
+__inline__ __device__ Tout scaled_convert(const Tin& x, const float scale) {
+    return static_cast<Tout>(x);
+}
+
+}  // namespace fp8
+}  // namespace vllm

--- a/crates/ferrum-kernels/src/backend/cuda/vllm_paged_attn.rs
+++ b/crates/ferrum-kernels/src/backend/cuda/vllm_paged_attn.rs
@@ -172,19 +172,23 @@ pub fn dispatch_paged_attention_v2(
         let (v_dp, _v_recs) = v_cache.device_ptr(stream);
         let (bt_dp, _bt_recs) = block_tables.device_ptr(stream);
         let (sl_dp, _sl_recs) = seq_lens.device_ptr(stream);
+        // cudarc 0.19's `device_ptr*` returns `(u64, _records)` where the
+        // u64 is the raw device address. Cast u64 → typed pointer directly
+        // (the intermediate `as *const _` form fails to infer the element
+        // type when the destination is `*const c_void`).
         let raw_stream = stream.cu_stream() as *mut std::ffi::c_void;
         ferrum_vllm_paged_attention_v2_f16_h128_b16(
-            out_dp as *mut _ as *mut std::ffi::c_void,
-            es_dp as *mut _ as *mut std::ffi::c_void,
-            ml_dp as *mut _ as *mut std::ffi::c_void,
-            to_dp as *mut _ as *mut std::ffi::c_void,
-            q_dp as *const _ as *const std::ffi::c_void,
-            k_dp as *const _ as *const std::ffi::c_void,
-            v_dp as *const _ as *const std::ffi::c_void,
+            out_dp as *mut std::ffi::c_void,
+            es_dp as *mut std::ffi::c_void,
+            ml_dp as *mut std::ffi::c_void,
+            to_dp as *mut std::ffi::c_void,
+            q_dp as *const std::ffi::c_void,
+            k_dp as *const std::ffi::c_void,
+            v_dp as *const std::ffi::c_void,
             num_kv_heads as i32,
             scale,
-            bt_dp as *const _ as *const std::ffi::c_void,
-            sl_dp as *const _ as *const std::ffi::c_void,
+            bt_dp as *const std::ffi::c_void,
+            sl_dp as *const std::ffi::c_void,
             num_seqs as i32,
             num_heads as i32,
             max_num_blocks_per_seq as i32,


### PR DESCRIPTION
## Summary

Adds the **infrastructure** for vLLM's `paged_attention_v2` port — Cargo feature, build.rs, kernel sources, trait methods, model dispatch. Default OFF; opt-in via `FERRUM_USE_VLLM_PAGED_ATTN=1` env var (plus the compile-time `vllm-paged-attn-v2` feature).

### Why it's marked experimental, not production

Empirically on Vast 4090, Qwen3-30B-A3B-GPTQ-Int4, c=32:

| run | out_tps | p50 ms | p99 ms | mean ms |
|---|---:|---:|---:|---:|
| baseline (v2 OFF)    | **972** | **23** | 751  | 46  |
| v2 ON + MOE_GRAPH    | 757     | 25     | 1345 | 120 |
| v2 ON, no MOE_GRAPH  | 773     | 26     | 1058 | 115 |

p50 unchanged (kernel itself is competitive) but mean/p99 regress 2-3× → -22% throughput. Root causes identified:

1. **Prefill attn reads wrong layout**: `forward_layer` falls back to v1 `paged_decode_attention` when `tokens > 1`, but K was written in vLLM layout by `split_qkv_norm_rope_into_paged_cache_vllm` → reads garbage during prefill.
2. **V cache write non-coalesced**: vLLM V layout `[blocks, heads, head_dim, block_size]` puts block_size last; per-token writes from 32 threads land on stride-16 → no 128-byte coalescing.
3. **No throughput win at our shape**: ferrum's existing `paged_batched_flash_decode_attn` is already bandwidth-bound at 115 µs/call (~80% of HBM peak at kv_len=700). vLLM's v2 split-K only wins when SM-bound (kv_len >> 2K, OR very small batch). Our c=32 max_kv_len ≈ 700 isn't either.

### What lands here

- `crates/ferrum-kernels/kernels/vllm_attn/` — vendored vLLM v0.20.2 paged_attention_v2 sources (torch-stripped, Apache 2.0 headers retained)
- `vllm_attn/quant_utils_stub.cuh` — minimal FP8 quant stub so the kAuto template instantiates without dragging in the full vLLM w8a8 subtree
- `kernels/split_qkv_norm_rope_into_paged_cache_vllm.cu` — companion writer that lays K/V in vLLM's tile layout
- `crates/ferrum-kernels/src/backend/cuda/vllm_paged_attn.rs` — Rust extern "C" wrapper + process-global scratch (mirrors MARLIN_GATHER_SCRATCH pattern for graph-replay stability)
- 3 new methods on `BackendPagedKv` trait, default `unsupported`; CudaBackend overrides under `#[cfg(feature = "vllm-paged-attn-v2")]`
- `Qwen3MoeModel.use_vllm_paged_attn` cached at construction; 4 dispatch sites branch on the flag

### Why land it as infrastructure

The shape regime where v2 wins (long kv_len / small batch) is plausible for future workloads. Keeping the wiring + build feature lets us re-test cheaply when (a) the prefill path is fixed and (b) we hit a workload where v2 has real upside. Removing it would mean redoing ~600 lines of work to opt-in again.

### Test plan

- [x] cargo check --workspace clean on Mac
- [x] cargo build --release --features cuda,vllm-moe-marlin,vllm-paged-attn-v2 -p ferrum-cli  (on Vast 4090)
- [x] Bench c=32 with FERRUM_USE_VLLM_PAGED_ATTN=1 — runs to completion, no crashes, 128/128 OK
- [x] Bench c=32 with v2 OFF on same build — confirms baseline unchanged (972 tok/s)
- [ ] Future: prefill path layout-aware fix
- [ ] Future: nsys + ncu apples-to-apples diff vs vLLM to identify the actual 5ms/iter gap

🤖 Generated with [Claude Code](https://claude.com/claude-code)