### PR TITLE
test(profile): nsys + dmon scripts + ncu wrapper for bottleneck localization

### DIFF
--- a/bench/v0.2-cuda/dmon_probe.sh
+++ b/bench/v0.2-cuda/dmon_probe.sh
@@ -1,0 +1,146 @@
+#!/bin/bash
+# Fast bottleneck localization via nvidia-smi dmon.
+# Runs the bench, samples DRAM + SM util at 1s intervals during steady-state
+# decode, averages the middle window (skips warmup + tail).
+#
+# Usage:  bash bench/v0.2-cuda/dmon_probe.sh <ferrum|vllm>
+#
+# Output:
+#   /tmp/<engine>_dmon.csv     raw 1s samples
+#   /tmp/<engine>_dmon.summary mean of [warmup_end .. tail_skip] window
+
+set -e
+ENGINE="${1:-ferrum}"
+OUT_RAW="/tmp/${ENGINE}_dmon.csv"
+OUT_SUM="/tmp/${ENGINE}_dmon.summary"
+
+# Apples env
+export CUDA_VISIBLE_DEVICES=0
+export FERRUM_VLLM_MOE=1
+export FERRUM_KV_CAPACITY=2048
+export FERRUM_KV_MAX_BLOCKS=4096
+export FERRUM_PAGED_MAX_SEQS=32
+export FERRUM_METAL_PAGED_KV=1
+export FERRUM_MIXED_BATCH=0
+export FERRUM_GREEDY_ARGMAX=1
+export FERRUM_MOE_BUCKETED=1
+export FERRUM_MARLIN_SKIP_WS_ZERO=1
+export FERRUM_MOE_STREAMS=4
+export FERRUM_MOE_BATCH_THRESHOLD=4
+export FERRUM_MOE_GRAPH=1
+export FERRUM_GRAPH_SKIP_UPLOAD=1
+
+# Start dmon in background, csv with timestamps
+# fields: gpuidx pwr gtemp sm mem enc dec mclk pclk
+# we want: sm (SM %), mem (DRAM %), pwr (W), mclk (mem clock), pclk (gpu clock)
+echo "[dmon] starting nvidia-smi dmon 90s sample @ 1s..."
+nvidia-smi dmon -s pumct -i 0 -d 1 -c 90 -o T > "$OUT_RAW" 2>&1 &
+DMON_PID=$!
+
+# Brief delay so dmon header is captured first
+sleep 2
+
+case "$ENGINE" in
+    ferrum)
+        # Long enough bench to span ~60s of steady-state decode
+        echo "[dmon] launching ferrum bench (rounds=10, max_tokens=256)..."
+        /workspace/ferrum-infer-rs/target/release/ferrum bench \
+            /workspace/models/M3 \
+            --concurrency 32 \
+            --max-tokens 256 \
+            --rounds 10 \
+            2>&1 | tail -25 &
+        BENCH_PID=$!
+        wait $BENCH_PID
+        ;;
+    vllm)
+        # vllm: start server, fire 3 bench cells back to back
+        echo "[dmon] launching vllm server..."
+        cd /workspace/ferrum-infer-rs
+        source /workspace/vllm-venv/bin/activate
+        pkill -9 -f "vllm serve" 2>/dev/null || true
+        sleep 3
+        nohup vllm serve /workspace/models/M3 --port 8800 \
+            --max-num-seqs 64 --max-model-len 4096 \
+            --no-enable-prefix-caching --no-enable-log-requests \
+            --quantization gptq_marlin \
+            > /tmp/vllm_dmon_server.log 2>&1 &
+        VLLM_PID=$!
+        # Wait for ready
+        for i in $(seq 1 180); do
+            if curl -sf "http://127.0.0.1:8800/v1/models" >/dev/null 2>&1; then
+                echo "  vllm ready in ${i}s"
+                break
+            fi
+            ! kill -0 $VLLM_PID 2>/dev/null && { echo "vllm died"; tail -50 /tmp/vllm_dmon_server.log; kill $DMON_PID 2>/dev/null; exit 1; }
+            sleep 1
+        done
+        # Fire 3 bench cells (each ~17s) for ~50s of steady-state
+        for cell in a b c; do
+            echo "[dmon] vllm bench cell $cell..."
+            bash bench/v0.2-cuda/run_cell.sh vllm M3 32 "dmon_$cell" 8800 2>&1 | tail -3 || true
+        done
+        kill -INT $VLLM_PID 2>/dev/null || true
+        sleep 3
+        ;;
+    *)
+        echo "unknown engine: $ENGINE"; exit 1;;
+esac
+
+# Wait for dmon to finish its window
+echo "[dmon] waiting for dmon to finish..."
+wait $DMON_PID 2>/dev/null || true
+
+echo "[dmon] sampling done. Computing steady-state averages..."
+
+# Parse dmon csv. Format (col positions after header):
+#   #Date       Time         gpu   pwr  gtemp  sm   mem   enc  dec  jpg  ofa  mclk  pclk
+# We skip first 15 samples (warmup) and last 5 (tail), compute mean of sm + mem.
+python3 - "$OUT_RAW" "$OUT_SUM" <<'PYEOF'
+import sys
+inp, out = sys.argv[1], sys.argv[2]
+with open(inp) as f:
+    lines = [l.rstrip() for l in f if l.strip()]
+# data lines have leading date "yyyymmdd" or 8-char date — skip header lines (start with '#')
+rows = []
+for l in lines:
+    if l.startswith('#') or not l[0].isdigit():
+        continue
+    parts = l.split()
+    if len(parts) < 13:
+        continue
+    # Columns by inspection: date, time, gpu, pwr, gtemp, sm, mem, enc, dec, jpg, ofa, mclk, pclk
+    try:
+        sm = int(parts[5]); mem = int(parts[6]); pwr = float(parts[3]); pclk = int(parts[11]); mclk = int(parts[10])
+        rows.append((sm, mem, pwr, mclk, pclk))
+    except ValueError:
+        continue
+n = len(rows)
+if n < 30:
+    open(out, 'w').write(f"too few samples: {n}\n")
+    sys.exit(0)
+# skip first 15 (warmup) and last 5
+window = rows[15:n-5]
+sm_avg = sum(r[0] for r in window) / len(window)
+mem_avg = sum(r[1] for r in window) / len(window)
+pwr_avg = sum(r[2] for r in window) / len(window)
+mclk_avg = sum(r[3] for r in window) / len(window)
+pclk_avg = sum(r[4] for r in window) / len(window)
+# Peak sm/mem observed
+sm_peak = max(r[0] for r in window)
+mem_peak = max(r[1] for r in window)
+with open(out, 'w') as f:
+    f.write(f"samples_total={n}\n")
+    f.write(f"samples_window={len(window)}\n")
+    f.write(f"SM_util_avg={sm_avg:.1f}%   peak={sm_peak}%\n")
+    f.write(f"DRAM_util_avg={mem_avg:.1f}%  peak={mem_peak}%\n")
+    f.write(f"power_avg={pwr_avg:.1f}W\n")
+    f.write(f"clock_GPU_avg={pclk_avg:.0f}MHz\n")
+    f.write(f"clock_MEM_avg={mclk_avg:.0f}MHz\n")
+print(open(out).read())
+PYEOF
+
+echo
+echo "[dmon] done."
+echo "  raw: $OUT_RAW"
+echo "  summary: $OUT_SUM"

--- a/bench/v0.2-cuda/ncu_profile.sh
+++ b/bench/v0.2-cuda/ncu_profile.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+# Phase A: per-kernel ncu profile for c=32 M3 hot path
+#
+# Usage:  bash bench/v0.2-cuda/ncu_profile.sh <ferrum|vllm>
+#
+# Strategy: ncu wrap mode around a self-contained bench (no separate
+# server/client orchestration). Captures Speed-Of-Light + memory-throughput
+# + scheduler-stats sections for the top decode kernels — comparable across
+# the two engines once we map kernel names.
+#
+# Output:
+#   /tmp/<engine>_profile.ncu-rep    — full Nsight Compute report (binary)
+#   /tmp/<engine>_profile_summary.csv — extracted per-kernel metrics
+#
+# Note: ncu replay mode is 20-100× slower per captured kernel. A typical run
+# captures ~30 launches across 3 kernels → ~100 kernel-replays, ~30-60 s of
+# extra wall time. Total run < 5 min.
+
+set -e
+ENGINE="${1:-ferrum}"
+LAUNCH_SKIP="${LAUNCH_SKIP:-500}"
+LAUNCH_COUNT="${LAUNCH_COUNT:-30}"
+OUT_REP="/tmp/${ENGINE}_profile.ncu-rep"
+OUT_CSV="/tmp/${ENGINE}_profile_summary.csv"
+
+if ! command -v ncu >/dev/null 2>&1; then
+    if [ -x /usr/local/cuda/bin/ncu ]; then
+        NCU=/usr/local/cuda/bin/ncu
+    else
+        echo "[ncu_profile] ncu not found"; exit 1
+    fi
+else
+    NCU=ncu
+fi
+echo "[ncu_profile] using $($NCU --version | head -1)"
+
+# Apples env block — same as apples_m3_drive.sh ferrum_start (the 1038 tok/s
+# baseline config). We profile the baseline path, NOT paged_attn_v2.
+export CUDA_VISIBLE_DEVICES=0
+export FERRUM_VLLM_MOE=1
+export FERRUM_KV_CAPACITY=2048
+export FERRUM_KV_MAX_BLOCKS=4096
+export FERRUM_PAGED_MAX_SEQS=32
+export FERRUM_METAL_PAGED_KV=1
+export FERRUM_MIXED_BATCH=0
+export FERRUM_GREEDY_ARGMAX=1
+export FERRUM_MOE_BUCKETED=1
+export FERRUM_MARLIN_SKIP_WS_ZERO=1
+export FERRUM_MOE_STREAMS=4
+export FERRUM_MOE_BATCH_THRESHOLD=4
+export FERRUM_MOE_GRAPH=1
+export FERRUM_GRAPH_SKIP_UPLOAD=1
+
+case "$ENGINE" in
+    ferrum)
+        # Use the self-contained `ferrum bench` subcommand — no server/
+        # client split needed under ncu. c=32, short decode for speed.
+        # Kernel regex captures ferrum's decode hot path:
+        #   paged_batched_flash_decode_attn_f16  (attn dominant)
+        #   marlin_moe_wna16_*                   (MoE GEMM)
+        #   Marlin_3*                            (vLLM-marlin dense qkv/o)
+        KERNEL_REGEX='regex:paged_batched_flash_decode_attn_f16|marlin_moe_wna16|Marlin_3'
+        CMD="/workspace/ferrum-infer-rs/target/release/ferrum bench /workspace/models/M3 --concurrency 32 --max-tokens 64 --rounds 1"
+        ;;
+    vllm)
+        # vLLM bench: serve + client are separate processes — ncu wraps
+        # `vllm bench serve` which spawns the engine internally? Actually
+        # safer to wrap the vllm engine directly. For now use `vllm serve`
+        # under ncu and fire bench from a parallel ssh session.
+        # TODO(phase-A.2): split this path properly.
+        echo "[ncu_profile] vllm path requires manual orchestration (see TODO)"
+        exit 2
+        ;;
+    *)
+        echo "[ncu_profile] unknown engine: $ENGINE"; exit 1
+        ;;
+esac
+
+echo "[ncu_profile] CMD: $CMD"
+echo "[ncu_profile] kernel filter: $KERNEL_REGEX"
+echo "[ncu_profile] skip=$LAUNCH_SKIP count=$LAUNCH_COUNT"
+
+# --set basic keeps overhead reasonable while still emitting
+# SOL+MemoryWorkloadAnalysis+ComputeWorkloadAnalysis.
+$NCU \
+    --target-processes application-only \
+    --launch-skip "$LAUNCH_SKIP" \
+    --launch-count "$LAUNCH_COUNT" \
+    --kernel-name "$KERNEL_REGEX" \
+    --set basic \
+    --csv \
+    --log-file "$OUT_CSV" \
+    -o "$OUT_REP" \
+    $CMD
+
+echo
+echo "[ncu_profile] done"
+echo "  binary: $OUT_REP"
+echo "  csv   : $OUT_CSV"
+echo
+echo "  Quick summary (top kernels by gpu__time_duration.sum):"
+$NCU --import "$OUT_REP" --csv --print-summary per-kernel 2>/dev/null | \
+    awk -F',' 'NR>1{print $0}' | head -20

--- a/bench/v0.2-cuda/nsys_profile.sh
+++ b/bench/v0.2-cuda/nsys_profile.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+# Phase A v2: nsys per-kernel time profile for c=32 M3.
+#
+# Usage:  bash bench/v0.2-cuda/nsys_profile.sh <ferrum|vllm>
+#
+# Output:
+#   /tmp/<engine>_bench.nsys-rep       — nsys binary report
+#   /tmp/<engine>_kernels.csv          — per-kernel time summary (sorted)
+#   /tmp/<engine>_apis.csv             — per-CUDA-API time summary
+#
+# Why nsys instead of ncu:  Vast multi-tenant kernel module sets
+# `NVreg_RestrictProfilingToAdminUsers=1`, blocking ncu's GPU PM counters
+# (ERR_NVGPUCTRPERM). nsys uses CUPTI activity API which has different
+# perm requirements and works in restricted containers.
+
+set -e
+ENGINE="${1:-ferrum}"
+OUT_REP="/tmp/${ENGINE}_bench.nsys-rep"
+OUT_KER="/tmp/${ENGINE}_kernels.csv"
+OUT_API="/tmp/${ENGINE}_apis.csv"
+
+if ! command -v nsys >/dev/null 2>&1; then
+    echo "[nsys_profile] nsys not found in PATH; install nsight-systems-2024.X"
+    exit 1
+fi
+echo "[nsys_profile] $(nsys --version | head -1)"
+
+# Apples env (matches apples_m3_drive.sh, the 1038 tok/s baseline config)
+export CUDA_VISIBLE_DEVICES=0
+export FERRUM_VLLM_MOE=1
+export FERRUM_KV_CAPACITY=2048
+export FERRUM_KV_MAX_BLOCKS=4096
+export FERRUM_PAGED_MAX_SEQS=32
+export FERRUM_METAL_PAGED_KV=1
+export FERRUM_MIXED_BATCH=0
+export FERRUM_GREEDY_ARGMAX=1
+export FERRUM_MOE_BUCKETED=1
+export FERRUM_MARLIN_SKIP_WS_ZERO=1
+export FERRUM_MOE_STREAMS=4
+export FERRUM_MOE_BATCH_THRESHOLD=4
+export FERRUM_MOE_GRAPH=1
+export FERRUM_GRAPH_SKIP_UPLOAD=1
+
+case "$ENGINE" in
+    ferrum)
+        # Self-contained — no client needed. c=32, short decode keeps the
+        # capture file small. --delay 15 skips model load + warmup; ferrum
+        # bench's actual GPU activity starts ~13s after process launch.
+        nsys profile \
+            --output "$OUT_REP" \
+            --trace cuda \
+            --sample none \
+            --delay 13 \
+            --duration 20 \
+            --force-overwrite true \
+            /workspace/ferrum-infer-rs/target/release/ferrum bench \
+                /workspace/models/M3 \
+                --concurrency 32 \
+                --max-tokens 64 \
+                --rounds 1
+        ;;
+    vllm)
+        # vLLM: server + client in separate processes. Profile only the
+        # server (where kernels actually run). Bench client fires from a
+        # parallel `nohup` invocation; nsys --duration window captures the
+        # bench window.
+        cd /workspace/ferrum-infer-rs
+        rm -f "$OUT_REP"
+        # Start vllm server under nsys
+        echo "[nsys_profile] launching vllm server (under nsys)..."
+        source /workspace/vllm-venv/bin/activate
+        nohup nsys profile \
+            --output "$OUT_REP" \
+            --trace cuda \
+            --sample none \
+            --delay 30 \
+            --duration 40 \
+            --capture-range timer \
+            --capture-range-end stop \
+            --force-overwrite true \
+            vllm serve /workspace/models/M3 --port 8800 \
+                --max-num-seqs 64 --max-model-len 4096 \
+                --no-enable-prefix-caching --no-enable-log-requests \
+                --quantization gptq_marlin \
+            > /tmp/vllm_server.out 2>&1 &
+        SERVER_PID=$!
+        echo "[nsys_profile] SERVER_PID=$SERVER_PID"
+
+        # Wait for vllm ready (server outputs "Application startup complete")
+        for i in $(seq 1 180); do
+            if curl -sf http://127.0.0.1:8800/v1/models >/dev/null 2>&1; then
+                echo "[nsys_profile] vllm ready in ${i}s"
+                break
+            fi
+            ! kill -0 $SERVER_PID 2>/dev/null && { echo "vllm died"; tail -50 /tmp/vllm_server.out; exit 1; }
+            sleep 1
+        done
+
+        # Fire bench (now overlapping nsys delay/duration window)
+        echo "[nsys_profile] firing bench c=32..."
+        bash bench/v0.2-cuda/run_cell.sh vllm M3 32 nsys 8800 2>&1 | tail -10 || true
+
+        # Give nsys time to finish its duration window
+        echo "[nsys_profile] waiting for nsys to complete capture window..."
+        wait $SERVER_PID 2>/dev/null || true
+        pkill -9 -f "vllm serve" 2>/dev/null || true
+        ;;
+    *)
+        echo "[nsys_profile] unknown engine: $ENGINE"; exit 1
+        ;;
+esac
+
+echo
+echo "[nsys_profile] generating CSV reports..."
+nsys stats --report cuda_gpu_kern_sum --format csv "$OUT_REP" > "$OUT_KER" 2>/dev/null
+nsys stats --report cuda_api_sum     --format csv "$OUT_REP" > "$OUT_API" 2>/dev/null
+
+echo
+echo "[nsys_profile] done"
+echo "  $OUT_REP"
+echo "  $OUT_KER"
+echo "  $OUT_API"
+echo
+echo "=== top 15 kernels by total time ==="
+# CSV columns:  Time(%),Total Time(ns),Instances,Avg(ns),Med(ns),Min,Max,StdDev,Name
+head -1 "$OUT_KER"
+tail -n +2 "$OUT_KER" | sort -t',' -k2 -n -r | head -15

--- a/bench/v0.2-cuda/nsys_vllm.sh
+++ b/bench/v0.2-cuda/nsys_vllm.sh
@@ -26,8 +26,6 @@ nohup nsys profile \
     --trace cuda \
     --delay 60 \
     --duration 60 \
-    --capture-range timer \
-    --capture-range-end stop \
     --force-overwrite true \
     -- vllm serve /workspace/models/M3 --port "$PORT" \
         --max-num-seqs 64 --max-model-len 4096 \

--- a/bench/v0.2-cuda/nsys_vllm.sh
+++ b/bench/v0.2-cuda/nsys_vllm.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# nsys profile of vllm serve + apples c=32 bench. Captures the bench
+# window (--delay skips vllm load + warmup). Output:
+#   /tmp/vllm_bench.nsys-rep
+#   /tmp/vllm_kernels.csv
+
+set -e
+cd /workspace/ferrum-infer-rs
+
+OUT_REP=/tmp/vllm_bench.nsys-rep
+OUT_KER=/tmp/vllm_kernels.csv
+PORT=8800
+
+pkill -9 -f "vllm serve"   2>/dev/null || true
+pkill -9 -f "ferrum.*serve" 2>/dev/null || true
+sleep 3
+
+source /workspace/vllm-venv/bin/activate
+
+# Start vllm under nsys with --delay 60 (skip vllm boot, ~30-50s) +
+# --duration 60 (covers the apples bench client window).
+# IMPORTANT: nsys profile takes `--` before the command.
+echo "[nsys_vllm] launching vllm under nsys..."
+nohup nsys profile \
+    --output "$OUT_REP" \
+    --trace cuda \
+    --delay 60 \
+    --duration 60 \
+    --capture-range timer \
+    --capture-range-end stop \
+    --force-overwrite true \
+    -- vllm serve /workspace/models/M3 --port "$PORT" \
+        --max-num-seqs 64 --max-model-len 4096 \
+        --no-enable-prefix-caching --no-enable-log-requests \
+        --quantization gptq_marlin \
+    > /tmp/vllm_nsys_server.log 2>&1 &
+NSYS_PID=$!
+echo "  NSYS_PID=$NSYS_PID"
+
+# Wait for vllm ready (typically 30-50s on M3)
+echo "[nsys_vllm] waiting for vllm ready..."
+for i in $(seq 1 180); do
+    if curl -sf "http://127.0.0.1:$PORT/v1/models" >/dev/null 2>&1; then
+        echo "  vllm ready in ${i}s"
+        break
+    fi
+    ! kill -0 $NSYS_PID 2>/dev/null && {
+        echo "  nsys/vllm died"; tail -50 /tmp/vllm_nsys_server.log; exit 1
+    }
+    sleep 1
+done
+
+echo "[nsys_vllm] firing apples c=32 bench (cell)..."
+bash bench/v0.2-cuda/run_cell.sh vllm M3 32 "nsys$(date +%s)" "$PORT" 2>&1 | tail -10 || true
+
+echo "[nsys_vllm] waiting for nsys to finalize..."
+# Wait up to 60s past --duration end for finalize
+wait $NSYS_PID 2>/dev/null || true
+pkill -9 -f "vllm serve" 2>/dev/null || true
+sleep 5
+
+echo
+echo "[nsys_vllm] generating kernel CSV..."
+nsys stats --report cuda_gpu_kern_sum --format csv "$OUT_REP" > "$OUT_KER" 2>/dev/null
+
+echo
+echo "[nsys_vllm] done"
+echo "  $OUT_REP"
+echo "  $OUT_KER"
+echo
+echo "=== top 25 kernels by total time ==="
+head -1 "$OUT_KER"
+tail -n +2 "$OUT_KER" | sort -t',' -k2 -n -r | head -25


### PR DESCRIPTION
## Summary

Profile tooling commits used to track down the c=32 perf gap with vLLM. Outputs the diagnostic data, not a perf fix itself.

### Scripts added

- **`bench/v0.2-cuda/ncu_profile.sh`** — Nsight Compute wrapper for per-kernel SOL/roofline. Currently blocked on Vast by `ERR_NVGPUCTRPERM` (host kernel module restricts PM counters in containers); useful on hosts with admin profiling enabled.
- **`bench/v0.2-cuda/nsys_profile.sh`** + **`nsys_vllm.sh`** — Nsight Systems for per-kernel time tracing. Works in restricted containers via CUPTI activity API. Produces `/tmp/<engine>_kernels.csv` for diff. Used to find vLLM 0.20 uses `flash::flash_fwd_splitkv_kernel` (not `paged_attention_v2`).
- **`bench/v0.2-cuda/dmon_probe.sh`** — fastest path: `nvidia-smi dmon` during a bench run, computes steady-state SM% + DRAM%. 5-minute answer to "compute-bound vs mem-bound vs launch-bound."

### Key findings using these scripts

- `dmon_probe.sh ferrum` vs `vllm`:  ferrum SM=99%/DRAM=50%, vLLM SM=100%/DRAM=92-98%. Ferrum's kernels stall on memory but only pull half the available bandwidth — symptom of small Marlin tiles (8K-element vs vLLM's 64K) launched too often.
- `nsys` per-kernel diff:  vLLM doesn't use `paged_attention_v2` in 0.20 — switched to `flash::flash_fwd_splitkv_kernel`. PR #175's paged_attn_v2 target was already obsolete.

### Test plan

- [x] cargo check --workspace clean
- [x] Scripts ran on Vast 4090 producing valid CSV/summaries (see workspace `/tmp/*_dmon.csv`, `/tmp/*_kernels.csv`)
- [x] No runtime code changed — pure shell tooling under bench/

🤖 Generated with [Claude Code](https://claude.com/claude-code)