### PR TITLE
feat(moe): block-level prefix cache for Qwen3MoeModel (prefix-cache phase 3/4)

### DIFF
--- a/bench/v0.2-cuda/gen_shared_prefix_jsonl.py
+++ b/bench/v0.2-cuda/gen_shared_prefix_jsonl.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Generate a shared-prefix prompts.jsonl in the same format as the
+existing apples bench prompts.jsonl. Drop-in replacement that lets us
+run `vllm bench serve` (the apples client) on a workload where
+prefix caching matters.
+
+128 prompts, each = SHARED_PREFIX (~200 tokens) + UNIQUE suffix (~5 tokens).
+"""
+import json
+import sys
+
+SHARED_PREFIX = (
+    "You are a precise, helpful technical assistant. "
+    "When answering questions you must follow these rules carefully:\n\n"
+    "1. Be accurate. If you don't know something, say so directly.\n"
+    "2. Be concise. Prefer short, direct answers over verbose ones.\n"
+    "3. Show reasoning for non-trivial claims, but keep it to one or two "
+    "sentences when possible.\n"
+    "4. For factual queries about programming, math, or systems, cite the "
+    "relevant concept by name (e.g., \"via the GIL\", \"by memoization\").\n"
+    "5. Avoid filler phrases like \"Great question!\" or \"I'd be happy to "
+    "help with that.\" Just answer.\n"
+    "6. If a question is ambiguous, name the ambiguity in one sentence "
+    "and pick the most likely interpretation.\n\n"
+    "User question: "
+)
+
+QUESTIONS = [
+    "What is GIL?", "Define amortized cost.", "Why quicksort O(n log n)?",
+    "What does ECC RAM mean?", "Explain TLB shootdown.", "What's CRDT?",
+    "Define MVCC.", "What is Raft?", "Explain Bloom filter.",
+    "What is a skip list?", "What's pre-order traversal?", "Explain CAS.",
+    "What is a B+ tree?", "Define cache line.", "What's NUMA?",
+    "Explain VMA.", "What is the kernel page table?", "Define eviction policy.",
+    "What's TCP slow start?", "Explain NAT punching.", "What is QUIC?",
+    "Define WAL.", "What's HSTS?", "Explain CRC32.",
+    "What's a Merkle tree?", "Define ABA problem.", "What's a memory fence?",
+    "Explain RCU.", "What's a futex?", "Define copy-on-write.",
+    "What's mmap used for?", "Explain epoll.",
+]
+prompts = [SHARED_PREFIX + q for q in (QUESTIONS * 4)[:128]]
+
+out_path = sys.argv[1] if len(sys.argv) > 1 else "shared_prefix_prompts.jsonl"
+with open(out_path, "w") as f:
+    for p in prompts:
+        f.write(json.dumps({"prompt": p}) + "\n")
+print(f"wrote {len(prompts)} prompts to {out_path}")
+print(f"shared prefix chars: {len(SHARED_PREFIX)}")

--- a/bench/v0.2-cuda/shared_prefix_bench.py
+++ b/bench/v0.2-cuda/shared_prefix_bench.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Shared-prefix workload bench for block-level prefix cache.
+
+128 chat requests, ALL sharing the same ~200-token system message,
+each with a UNIQUE 5-token user question. ferrum's block-level cache
+should hit on the first ~12 blocks (system msg) and only prefill the
+short user msg. Measures TTFT + throughput, prints comparison-ready
+JSON to stdout.
+
+Usage:
+  python3 shared_prefix_bench.py --base-url http://127.0.0.1:8801 \
+      --concurrency 32 --num-prompts 128 --max-tokens 64
+"""
+
+import argparse
+import asyncio
+import time
+import json
+import sys
+from typing import List
+
+# Pinned ~200-token system message. Token count is approximate;
+# what matters is the byte/token IDENTITY across all 128 requests so
+# the block hashes match.
+SYSTEM_PROMPT = """You are a precise, helpful technical assistant.
+When answering questions you must follow these rules carefully:
+
+1. Be accurate. If you don't know something, say so directly.
+2. Be concise. Prefer short, direct answers over verbose ones.
+3. Show reasoning for non-trivial claims, but keep it to one or two
+   sentences when possible.
+4. For factual queries about programming, math, or systems, cite the
+   relevant concept by name (e.g., "via the GIL", "by memoization").
+5. Avoid filler phrases like "Great question!" or "I'd be happy to
+   help with that." Just answer.
+6. If a question is ambiguous, name the ambiguity in one sentence
+   and pick the most likely interpretation."""
+
+# 128 short user questions. Length 4-8 tokens each.
+USER_QUESTIONS = [
+    "What is GIL?",
+    "Define amortized cost.",
+    "Why is quicksort O(n log n)?",
+    "What does ECC RAM mean?",
+    "Explain TLB shootdown.",
+    "What's CRDT?",
+    "Define MVCC.",
+    "What is Raft?",
+    "Explain Bloom filter.",
+    "What is a skip list?",
+    "What's pre-order traversal?",
+    "Explain CAS.",
+    "What is a B+ tree?",
+    "Define cache line.",
+    "What's NUMA?",
+    "Explain VMA.",
+    "What is the kernel page table?",
+    "Define eviction policy.",
+    "What's TCP slow start?",
+    "Explain NAT punching.",
+    "What is QUIC?",
+    "Define WAL.",
+    "What's HSTS?",
+    "Explain CRC32.",
+    "What's a Merkle tree?",
+    "Define ABA problem.",
+    "What's a memory fence?",
+    "Explain RCU.",
+    "What's a futex?",
+    "Define copy-on-write.",
+    "What's mmap used for?",
+    "Explain epoll.",
+]
+# Extend to 128 by duplicating; the SYSTEM prefix dominates anyway
+# (cache hit is on system msg, not user content).
+USER_QUESTIONS = (USER_QUESTIONS * 4)[:128]
+
+
+async def fire_one(session, url, model, system, user, max_tokens):
+    payload = {
+        "model": model,
+        "messages": [
+            {"role": "system", "content": system},
+            {"role": "user", "content": user},
+        ],
+        "max_tokens": max_tokens,
+        "temperature": 0,
+        "stream": False,
+    }
+    t_start = time.time()
+    async with session.post(url, json=payload) as resp:
+        resp_json = await resp.json()
+        t_end = time.time()
+    # ferrum returns usage.completion_tokens / prompt_tokens
+    usage = resp_json.get("usage", {})
+    return {
+        "wall_time_s": t_end - t_start,
+        "prompt_tokens": usage.get("prompt_tokens", 0),
+        "completion_tokens": usage.get("completion_tokens", 0),
+    }
+
+
+async def run(args):
+    import aiohttp
+
+    url = f"{args.base_url}/v1/chat/completions"
+    timeout = aiohttp.ClientTimeout(total=120)
+    sem = asyncio.Semaphore(args.concurrency)
+    results = []
+
+    async with aiohttp.ClientSession(timeout=timeout) as session:
+        async def gated(user):
+            async with sem:
+                return await fire_one(
+                    session, url, args.model, SYSTEM_PROMPT, user, args.max_tokens
+                )
+
+        prompts = USER_QUESTIONS[: args.num_prompts]
+        t0 = time.time()
+        results = await asyncio.gather(*[gated(u) for u in prompts])
+        t1 = time.time()
+
+    total_wall = t1 - t0
+    total_completion = sum(r["completion_tokens"] for r in results)
+    total_prompt = sum(r["prompt_tokens"] for r in results)
+    wall_times = sorted(r["wall_time_s"] for r in results)
+    median_wall = wall_times[len(wall_times) // 2]
+    p99_wall = wall_times[int(len(wall_times) * 0.99)]
+    throughput = total_completion / total_wall
+
+    summary = {
+        "num_prompts": len(results),
+        "concurrency": args.concurrency,
+        "max_tokens": args.max_tokens,
+        "total_wall_s": total_wall,
+        "total_completion_tokens": total_completion,
+        "total_prompt_tokens": total_prompt,
+        "throughput_tok_s": throughput,
+        "median_wall_s": median_wall,
+        "p99_wall_s": p99_wall,
+    }
+    print(json.dumps(summary, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    p = argparse.ArgumentParser()
+    p.add_argument("--base-url", default="http://127.0.0.1:8801")
+    p.add_argument("--model", default="x")
+    p.add_argument("--concurrency", type=int, default=32)
+    p.add_argument("--num-prompts", type=int, default=128)
+    p.add_argument("--max-tokens", type=int, default=64)
+    args = p.parse_args()
+    sys.exit(asyncio.run(run(args)))

--- a/bench/v0.2-cuda/test_envs.sh
+++ b/bench/v0.2-cuda/test_envs.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# Apples c=32 ferrum with extra env flags. Usage:
+#   test_envs.sh <label> [extra env exports]
+# Example:
+#   test_envs.sh chunked "FERRUM_CHUNKED_PREFILL=128"
+#   test_envs.sh device_route "FERRUM_MOE_DEVICE_ROUTE=1"
+#   test_envs.sh both "FERRUM_CHUNKED_PREFILL=128 FERRUM_MOE_DEVICE_ROUTE=1"
+
+set -e
+cd /workspace/ferrum-infer-rs
+LABEL="${1:-baseline}"
+EXTRA="${2:-}"
+
+PORT=8801
+RUN_R=$(date +%s)
+LOG=bench/v0.2-cuda/results/ferrum__M3__c32__${LABEL}_r${RUN_R}.server.log
+
+pkill -9 -f "ferrum.*serve" 2>/dev/null || true
+pkill -9 -f "vllm serve" 2>/dev/null || true
+sleep 3
+
+CMD="CUDA_VISIBLE_DEVICES=0 \
+FERRUM_VLLM_MOE=1 \
+FERRUM_KV_CAPACITY=2048 \
+FERRUM_KV_MAX_BLOCKS=4096 \
+FERRUM_PAGED_MAX_SEQS=32 \
+FERRUM_METAL_PAGED_KV=1 \
+FERRUM_GREEDY_ARGMAX=1 \
+FERRUM_MOE_BUCKETED=1 \
+FERRUM_MARLIN_SKIP_WS_ZERO=1 \
+FERRUM_MOE_STREAMS=4 \
+FERRUM_MOE_BATCH_THRESHOLD=4 \
+FERRUM_MOE_GRAPH=1 \
+FERRUM_GRAPH_SKIP_UPLOAD=1 \
+$EXTRA \
+  /workspace/ferrum-infer-rs/target/release/ferrum serve \
+    --model /workspace/models/M3 --port $PORT \
+    --gpu-memory-utilization 0.95"
+echo "[$LABEL] env: $EXTRA"
+eval "$CMD" > "$LOG" 2>&1 &
+FPID=$!
+
+for i in $(seq 1 240); do
+  curl -sf "http://127.0.0.1:$PORT/v1/models" >/dev/null 2>&1 && break
+  ! kill -0 "$FPID" 2>/dev/null && { echo "died"; tail -50 "$LOG"; exit 1; }
+  sleep 1
+done
+
+curl -sf -m 60 -X POST "http://127.0.0.1:$PORT/v1/chat/completions" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"x","messages":[{"role":"user","content":"hi"}],"max_tokens":4,"temperature":0}' > /dev/null
+
+source /workspace/vllm-venv/bin/activate
+bash bench/v0.2-cuda/run_cell.sh ferrum M3 32 "${LABEL}_${RUN_R}" "$PORT" 2>&1 | tail -3
+
+kill -INT "$FPID" 2>/dev/null; sleep 3
+pkill -9 -f "ferrum.*serve" 2>/dev/null || true

--- a/bench/v0.2-cuda/test_prefix_apples.sh
+++ b/bench/v0.2-cuda/test_prefix_apples.sh
@@ -1,0 +1,154 @@
+#!/bin/bash
+# Apples-to-apples bench comparing prefix cache implementations on
+# a SHARED-PREFIX workload. Uses the SAME vllm bench serve client
+# the canonical apples bench uses — only the dataset changes.
+#
+# 4 runs:
+#   ferrum_off : ferrum, FERRUM_PREFIX_CACHE=0
+#   ferrum_on  : ferrum, FERRUM_PREFIX_CACHE=1
+#   vllm_off   : vllm,   --no-enable-prefix-caching
+#   vllm_on    : vllm,   --enable-prefix-caching
+#
+# All use the SAME prompts.jsonl (rewritten to shared-prefix).
+# Original is backed up + restored at the end.
+
+set -e
+cd /workspace/ferrum-infer-rs
+PROMPTS=bench/v0.2-cuda/prompts.jsonl
+SHARED=bench/v0.2-cuda/shared_prefix_prompts.jsonl
+BACKUP=bench/v0.2-cuda/prompts.jsonl.apples_backup
+
+# 1. Generate the shared-prefix dataset
+python3 bench/v0.2-cuda/gen_shared_prefix_jsonl.py "$SHARED"
+
+# 2. Swap dataset (apples client reads this exact path)
+[ -f "$BACKUP" ] || cp "$PROMPTS" "$BACKUP"
+cp "$SHARED" "$PROMPTS"
+trap 'cp "$BACKUP" "$PROMPTS"; pkill -9 -f "ferrum.*serve" 2>/dev/null; pkill -9 -f "vllm serve" 2>/dev/null; true' EXIT
+
+start_ferrum() {
+    local prefix_cache="$1"
+    pkill -9 -f "ferrum.*serve" 2>/dev/null || true
+    pkill -9 -f "vllm serve" 2>/dev/null || true
+    sleep 3
+    CUDA_VISIBLE_DEVICES=0 \
+    FERRUM_VLLM_MOE=1 FERRUM_KV_CAPACITY=2048 FERRUM_KV_MAX_BLOCKS=4096 \
+    FERRUM_PAGED_MAX_SEQS=32 FERRUM_METAL_PAGED_KV=1 FERRUM_GREEDY_ARGMAX=1 \
+    FERRUM_MOE_BUCKETED=1 FERRUM_MARLIN_SKIP_WS_ZERO=1 FERRUM_MOE_STREAMS=4 \
+    FERRUM_MOE_BATCH_THRESHOLD=4 FERRUM_MOE_GRAPH=1 FERRUM_GRAPH_SKIP_UPLOAD=1 \
+    FERRUM_PREFIX_CACHE=$prefix_cache \
+      /workspace/ferrum-infer-rs/target/release/ferrum serve \
+        --model /workspace/models/M3 --port 8801 \
+        --gpu-memory-utilization 0.95 \
+      > /tmp/srv.log 2>&1 &
+    SRV_PID=$!
+    for i in $(seq 1 240); do
+        curl -sf http://127.0.0.1:8801/v1/models >/dev/null 2>&1 && return 0
+        ! kill -0 $SRV_PID 2>/dev/null && { echo "FERRUM DIED"; tail -50 /tmp/srv.log; exit 1; }
+        sleep 1
+    done
+    return 1
+}
+
+start_vllm() {
+    local prefix_flag="$1"  # "" for default-off, "--enable-prefix-caching" for on
+    pkill -9 -f "ferrum.*serve" 2>/dev/null || true
+    pkill -9 -f "vllm serve" 2>/dev/null || true
+    sleep 3
+    source /workspace/vllm-venv/bin/activate
+    local extra
+    if [ -z "$prefix_flag" ]; then
+        extra="--no-enable-prefix-caching"
+    else
+        extra=""  # vLLM default is enable-prefix-caching on, so don't pass --no
+    fi
+    vllm serve /workspace/models/M3 --port 8801 \
+        --max-num-seqs 64 --max-model-len 4096 \
+        $extra \
+        --no-enable-log-requests \
+        --quantization gptq_marlin \
+      > /tmp/srv.log 2>&1 &
+    SRV_PID=$!
+    for i in $(seq 1 240); do
+        curl -sf http://127.0.0.1:8801/v1/models >/dev/null 2>&1 && return 0
+        ! kill -0 $SRV_PID 2>/dev/null && { echo "VLLM DIED"; tail -50 /tmp/srv.log; exit 1; }
+        sleep 1
+    done
+    return 1
+}
+
+run_cell() {
+    local cell_id="$1"  # e.g. ferrum_off
+    local engine_for_script="$2"  # "ferrum" or "vllm" (just affects results filename)
+    # Prewarm with one short request
+    curl -sf -m 60 -X POST http://127.0.0.1:8801/v1/chat/completions \
+        -H "Content-Type: application/json" \
+        -d '{"model":"x","messages":[{"role":"user","content":"hi"}],"max_tokens":4,"temperature":0}' > /dev/null
+    # For prefix-cache hits to materialize the cache must be seeded by
+    # at least one full request first. Spend one slot on that.
+    curl -sf -m 120 -X POST http://127.0.0.1:8801/v1/chat/completions \
+        -H "Content-Type: application/json" \
+        -d "$(python3 -c '
+import json, sys
+prefix = open("'"$PROMPTS"'").read().splitlines()[0]
+p = json.loads(prefix)["prompt"]
+print(json.dumps({"model":"x","messages":[{"role":"user","content":p}],"max_tokens":4,"temperature":0}))
+')" > /dev/null
+    source /workspace/vllm-venv/bin/activate
+    bash bench/v0.2-cuda/run_cell.sh "$engine_for_script" M3 32 "${cell_id}" 8801 2>&1 | tail -3
+}
+
+mkdir -p bench/v0.2-cuda/results
+
+echo "=========================================="
+echo "[1/4] ferrum FERRUM_PREFIX_CACHE=0"
+echo "=========================================="
+start_ferrum 0
+run_cell "shared_ferrum_off" "ferrum"
+kill -INT $SRV_PID 2>/dev/null; sleep 3
+
+echo
+echo "=========================================="
+echo "[2/4] ferrum FERRUM_PREFIX_CACHE=1"
+echo "=========================================="
+start_ferrum 1
+run_cell "shared_ferrum_on" "ferrum"
+kill -INT $SRV_PID 2>/dev/null; sleep 3
+
+echo
+echo "=========================================="
+echo "[3/4] vllm --no-enable-prefix-caching"
+echo "=========================================="
+start_vllm ""
+run_cell "shared_vllm_off" "vllm"
+kill -INT $SRV_PID 2>/dev/null; sleep 3
+
+echo
+echo "=========================================="
+echo "[4/4] vllm (default prefix-caching ON)"
+echo "=========================================="
+start_vllm "enable"
+run_cell "shared_vllm_on" "vllm"
+kill -INT $SRV_PID 2>/dev/null; sleep 3
+
+echo
+echo "=========================================="
+echo "Summary"
+echo "=========================================="
+for c in shared_ferrum_off shared_ferrum_on shared_vllm_off shared_vllm_on; do
+    F=bench/v0.2-cuda/results/*__M3__c32__${c}.json
+    F=$(ls $F 2>/dev/null | head -1)
+    if [ -n "$F" ] && [ -f "$F" ]; then
+        python3 -c "
+import json
+d = json.load(open('$F'))
+print('${c}'.ljust(22),
+      f\"out={d.get('output_throughput',0):7.1f} tok/s\",
+      f\"p50={d.get('mean_tpot_ms',0):6.2f}ms\",
+      f\"p99={d.get('p99_tpot_ms',0):7.2f}ms\",
+      f\"ttft={d.get('mean_ttft_ms',0):6.0f}ms\")
+"
+    else
+        echo "${c}: no result file"
+    fi
+done

--- a/bench/v0.2-cuda/test_prefix_apples_ferrum_noseed.sh
+++ b/bench/v0.2-cuda/test_prefix_apples_ferrum_noseed.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+# Re-run ferrum's 2 cells WITHOUT seeding the cache, to match vllm's
+# default (no warmup-of-cache-only) behavior. The bench client itself
+# always does its own prewarm chat completion.
+set -e
+cd /workspace/ferrum-infer-rs
+
+# Apples dataset (shared-prefix) must be in place
+[ -f bench/v0.2-cuda/prompts.jsonl.apples_backup ] || cp bench/v0.2-cuda/prompts.jsonl bench/v0.2-cuda/prompts.jsonl.apples_backup
+python3 bench/v0.2-cuda/gen_shared_prefix_jsonl.py bench/v0.2-cuda/shared_prefix_prompts.jsonl
+cp bench/v0.2-cuda/shared_prefix_prompts.jsonl bench/v0.2-cuda/prompts.jsonl
+trap 'cp bench/v0.2-cuda/prompts.jsonl.apples_backup bench/v0.2-cuda/prompts.jsonl; pkill -9 -f "ferrum.*serve" 2>/dev/null; pkill -9 -f "VLLM" 2>/dev/null; true' EXIT
+
+start_ferrum() {
+    local prefix_cache="$1"
+    pkill -9 -f "ferrum.*serve" 2>/dev/null || true
+    pkill -9 -f "VLLM" 2>/dev/null || true
+    sleep 5
+    CUDA_VISIBLE_DEVICES=0 \
+    FERRUM_VLLM_MOE=1 FERRUM_KV_CAPACITY=2048 FERRUM_KV_MAX_BLOCKS=4096 \
+    FERRUM_PAGED_MAX_SEQS=32 FERRUM_METAL_PAGED_KV=1 FERRUM_GREEDY_ARGMAX=1 \
+    FERRUM_MOE_BUCKETED=1 FERRUM_MARLIN_SKIP_WS_ZERO=1 FERRUM_MOE_STREAMS=4 \
+    FERRUM_MOE_BATCH_THRESHOLD=4 FERRUM_MOE_GRAPH=1 FERRUM_GRAPH_SKIP_UPLOAD=1 \
+    FERRUM_PREFIX_CACHE=$prefix_cache \
+      /workspace/ferrum-infer-rs/target/release/ferrum serve \
+        --model /workspace/models/M3 --port 8801 \
+        --gpu-memory-utilization 0.95 \
+      > /tmp/srv.log 2>&1 &
+    SRV_PID=$!
+    for i in $(seq 1 240); do
+        curl -sf http://127.0.0.1:8801/v1/models >/dev/null 2>&1 && return 0
+        ! kill -0 $SRV_PID 2>/dev/null && { echo "DIED"; tail -50 /tmp/srv.log; exit 1; }
+        sleep 1
+    done
+    return 1
+}
+
+run_cell_noseed() {
+    local cell_id="$1"
+    # No application-level seeding — let the bench client's natural
+    # prewarm-of-1 (the run_cell.sh prewarm) be the ONLY priming, same
+    # as the vllm runs got.
+    source /workspace/vllm-venv/bin/activate
+    bash bench/v0.2-cuda/run_cell.sh ferrum M3 32 "${cell_id}" 8801 2>&1 | tail -3
+}
+
+echo "[1/2] ferrum FERRUM_PREFIX_CACHE=0  (NO SEED — cold start)"
+start_ferrum 0
+run_cell_noseed "shared_ferrum_off_coldstart"
+kill -INT $SRV_PID 2>/dev/null; sleep 3
+
+echo
+echo "[2/2] ferrum FERRUM_PREFIX_CACHE=1  (NO SEED — cold start)"
+start_ferrum 1
+run_cell_noseed "shared_ferrum_on_coldstart"
+kill -INT $SRV_PID 2>/dev/null; sleep 3
+
+echo
+echo "==========================================="
+echo "Summary (4-way fair: no seeding, cold start)"
+echo "==========================================="
+for c in shared_ferrum_off_coldstart shared_ferrum_on_coldstart shared_vllm_off shared_vllm_on; do
+    F=$(ls bench/v0.2-cuda/results/*__M3__c32__r${c}.json 2>/dev/null | head -1)
+    if [ -n "$F" ] && [ -f "$F" ]; then
+        python3 -c "
+import json
+d = json.load(open('$F'))
+print('${c}'.ljust(30),
+      f\"out={d.get('output_throughput',0):7.1f} tok/s\",
+      f\"p50={d.get('mean_tpot_ms',0):6.2f}ms\",
+      f\"p99={d.get('p99_tpot_ms',0):7.2f}ms\",
+      f\"ttft={d.get('mean_ttft_ms',0):6.0f}ms\")
+"
+    fi
+done

--- a/bench/v0.2-cuda/test_prefix_apples_vllm.sh
+++ b/bench/v0.2-cuda/test_prefix_apples_vllm.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+# vllm-only completion of the 4-way prefix bench. Run AFTER
+# test_prefix_apples.sh got ferrum results.
+set -e
+cd /workspace/ferrum-infer-rs
+MODEL=/workspace/models/M3
+
+start_vllm() {
+    local prefix_flag="$1"
+    pkill -9 -f "ferrum.*serve" 2>/dev/null || true
+    pkill -9 -f "vllm serve" 2>/dev/null || true
+    sleep 4
+    source /workspace/vllm-venv/bin/activate
+    local extra
+    if [ -z "$prefix_flag" ]; then
+        extra="--no-enable-prefix-caching"
+    else
+        extra=""
+    fi
+    vllm serve $MODEL --port 8801 \
+        --max-num-seqs 64 --max-model-len 4096 \
+        $extra --no-enable-log-requests \
+        --quantization gptq_marlin \
+      > /tmp/vllm_srv.log 2>&1 &
+    SRV_PID=$!
+    for i in $(seq 1 240); do
+        curl -sf http://127.0.0.1:8801/v1/models >/dev/null 2>&1 && return 0
+        ! kill -0 $SRV_PID 2>/dev/null && { echo "DIED"; tail -50 /tmp/vllm_srv.log; exit 1; }
+        sleep 1
+    done
+    return 1
+}
+
+run_cell_vllm() {
+    local cell_id="$1"
+    source /workspace/vllm-venv/bin/activate
+    bash bench/v0.2-cuda/run_cell.sh vllm M3 32 "${cell_id}" 8801 2>&1 | tail -3
+}
+
+echo "[3/4] vllm --no-enable-prefix-caching"
+start_vllm ""
+run_cell_vllm "shared_vllm_off"
+kill -INT $SRV_PID 2>/dev/null; sleep 3
+
+echo
+echo "[4/4] vllm (default prefix-caching ON)"
+start_vllm "enable"
+run_cell_vllm "shared_vllm_on"
+kill -INT $SRV_PID 2>/dev/null; sleep 3
+
+echo
+echo "=========================================="
+echo "Summary"
+echo "=========================================="
+for c in shared_ferrum_off shared_ferrum_on shared_vllm_off shared_vllm_on; do
+    F=$(ls bench/v0.2-cuda/results/*__M3__c32__r${c}.json 2>/dev/null | head -1)
+    if [ -n "$F" ] && [ -f "$F" ]; then
+        python3 -c "
+import json
+d = json.load(open('$F'))
+print('${c}'.ljust(22),
+      f\"out={d.get('output_throughput',0):7.1f} tok/s\",
+      f\"p50={d.get('mean_tpot_ms',0):6.2f}ms\",
+      f\"p99={d.get('p99_tpot_ms',0):7.2f}ms\",
+      f\"ttft={d.get('mean_ttft_ms',0):6.0f}ms\")
+"
+    fi
+done
+# Restore original prompts.jsonl (apples)
+BACKUP=bench/v0.2-cuda/prompts.jsonl.apples_backup
+[ -f "$BACKUP" ] && cp "$BACKUP" bench/v0.2-cuda/prompts.jsonl

--- a/bench/v0.2-cuda/test_prefix_cache.sh
+++ b/bench/v0.2-cuda/test_prefix_cache.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+# One-cell apples c=32 with FERRUM_PREFIX_CACHE=1 enabled to validate
+# block-level prefix cache on CUDA.
+# Compare against the static baseline 1051 tok/s (PR #177 dynamic
+# moe_block_size run, FERRUM_PREFIX_CACHE not set).
+
+set -e
+cd /workspace/ferrum-infer-rs
+
+PORT=8801
+RUN_R=$(date +%s)
+LOG=bench/v0.2-cuda/results/ferrum__M3__c32__prefix_r${RUN_R}.server.log
+mkdir -p bench/v0.2-cuda/results
+
+pkill -9 -f "ferrum.*serve" 2>/dev/null || true
+pkill -9 -f "vllm serve" 2>/dev/null || true
+sleep 3
+
+echo "[prefix] starting ferrum with FERRUM_PREFIX_CACHE=1"
+CUDA_VISIBLE_DEVICES=0 \
+FERRUM_VLLM_MOE=1 \
+FERRUM_KV_CAPACITY=2048 \
+FERRUM_KV_MAX_BLOCKS=4096 \
+FERRUM_PAGED_MAX_SEQS=32 \
+FERRUM_METAL_PAGED_KV=1 \
+FERRUM_GREEDY_ARGMAX=1 \
+FERRUM_MOE_BUCKETED=1 \
+FERRUM_MARLIN_SKIP_WS_ZERO=1 \
+FERRUM_MOE_STREAMS=4 \
+FERRUM_MOE_BATCH_THRESHOLD=4 \
+FERRUM_MOE_GRAPH=1 \
+FERRUM_GRAPH_SKIP_UPLOAD=1 \
+FERRUM_PREFIX_CACHE=1 \
+  /workspace/ferrum-infer-rs/target/release/ferrum serve \
+    --model /workspace/models/M3 --port "$PORT" \
+    --gpu-memory-utilization 0.95 \
+  > "$LOG" 2>&1 &
+FPID=$!
+echo "FPID=$FPID LOG=$LOG"
+
+for i in $(seq 1 240); do
+  curl -sf "http://127.0.0.1:$PORT/v1/models" >/dev/null 2>&1 && {
+    echo "ready in ${i}s"; break
+  }
+  ! kill -0 "$FPID" 2>/dev/null && {
+    echo "[prefix] ferrum died"; tail -80 "$LOG"; exit 1
+  }
+  sleep 1
+done
+
+echo "[prefix] prewarm"
+curl -sf -m 60 -X POST "http://127.0.0.1:$PORT/v1/chat/completions" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"x","messages":[{"role":"user","content":"hi"}],"max_tokens":4,"temperature":0}' \
+  > /dev/null
+
+source /workspace/vllm-venv/bin/activate
+
+echo "[prefix] apples c=32 cell"
+bash bench/v0.2-cuda/run_cell.sh ferrum M3 32 "prefix_${RUN_R}" "$PORT" 2>&1 | tail -10
+
+F=bench/v0.2-cuda/results/ferrum__M3__c32__prefix_${RUN_R}.json
+if [ -f "$F" ]; then
+  python3 -c "
+import json
+d = json.load(open('$F'))
+print(f\"output_throughput={d.get('output_throughput',0):.1f} tok/s\")
+print(f\"mean_tpot_ms={d.get('mean_tpot_ms',0):.2f}\")
+print(f\"p99_tpot_ms={d.get('p99_tpot_ms',0):.2f}\")
+print(f\"mean_ttft_ms={d.get('mean_ttft_ms',0):.1f}\")
+print(f\"completed={d.get('completed',0)} failed={d.get('failed',0)}\")
+"
+fi
+
+# Also dump prefix cache stats from the engine (if we can get them via
+# server endpoint; otherwise just print log tail showing cache hits)
+echo
+echo "[prefix] server log cache-related lines"
+grep -i "prefix.cache\|cache.hit" "$LOG" 2>/dev/null | tail -10 || true
+
+kill -INT "$FPID" 2>/dev/null
+sleep 3
+pkill -9 -f "ferrum.*serve" 2>/dev/null || true

--- a/bench/v0.2-cuda/test_prefix_shared.sh
+++ b/bench/v0.2-cuda/test_prefix_shared.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# Shared-system-prompt bench: 128 chat requests with same system msg,
+# unique user msg. Measures TTFT / throughput with FERRUM_PREFIX_CACHE
+# OFF vs ON to quantify the block-level prefix cache win.
+
+set -e
+cd /workspace/ferrum-infer-rs
+
+PORT=8801
+
+run_one() {
+    local label="$1"
+    local prefix_cache="$2"  # "0" or "1"
+    local log="bench/v0.2-cuda/results/shared_prefix_${label}.log"
+    pkill -9 -f "ferrum.*serve" 2>/dev/null || true
+    sleep 3
+
+    echo "=== [$label] FERRUM_PREFIX_CACHE=$prefix_cache ==="
+    CUDA_VISIBLE_DEVICES=0 \
+    FERRUM_VLLM_MOE=1 \
+    FERRUM_KV_CAPACITY=2048 \
+    FERRUM_KV_MAX_BLOCKS=4096 \
+    FERRUM_PAGED_MAX_SEQS=32 \
+    FERRUM_METAL_PAGED_KV=1 \
+    FERRUM_GREEDY_ARGMAX=1 \
+    FERRUM_MOE_BUCKETED=1 \
+    FERRUM_MARLIN_SKIP_WS_ZERO=1 \
+    FERRUM_MOE_STREAMS=4 \
+    FERRUM_MOE_BATCH_THRESHOLD=4 \
+    FERRUM_MOE_GRAPH=1 \
+    FERRUM_GRAPH_SKIP_UPLOAD=1 \
+    FERRUM_PREFIX_CACHE=$prefix_cache \
+      /workspace/ferrum-infer-rs/target/release/ferrum serve \
+        --model /workspace/models/M3 --port "$PORT" \
+        --gpu-memory-utilization 0.95 \
+      > "$log" 2>&1 &
+    local fpid=$!
+    for i in $(seq 1 240); do
+        curl -sf "http://127.0.0.1:$PORT/v1/models" >/dev/null 2>&1 && break
+        ! kill -0 "$fpid" 2>/dev/null && { echo "[$label] died"; tail -50 "$log"; exit 1; }
+        sleep 1
+    done
+    curl -sf -m 60 -X POST "http://127.0.0.1:$PORT/v1/chat/completions" \
+        -H "Content-Type: application/json" \
+        -d '{"model":"x","messages":[{"role":"user","content":"hi"}],"max_tokens":4,"temperature":0}' > /dev/null
+
+    # First request to seed the cache (only relevant when prefix_cache=1)
+    if [ "$prefix_cache" = "1" ]; then
+        echo "[$label] seeding cache with one prompt..."
+        python3 bench/v0.2-cuda/shared_prefix_bench.py \
+            --base-url "http://127.0.0.1:$PORT" \
+            --concurrency 1 --num-prompts 1 --max-tokens 4 >/dev/null
+    fi
+
+    echo "[$label] running 128 prompts c=32..."
+    python3 bench/v0.2-cuda/shared_prefix_bench.py \
+        --base-url "http://127.0.0.1:$PORT" \
+        --concurrency 32 --num-prompts 128 --max-tokens 64
+
+    kill -INT "$fpid" 2>/dev/null
+    sleep 3
+    pkill -9 -f "ferrum.*serve" 2>/dev/null || true
+}
+
+# Ensure aiohttp available
+pip install -q aiohttp 2>/dev/null || python3 -m pip install -q --user aiohttp 2>/dev/null || true
+
+run_one "off" "0"
+echo
+run_one "on" "1"

--- a/crates/ferrum-kernels/build.rs
+++ b/crates/ferrum-kernels/build.rs
@@ -188,10 +188,7 @@ fn compile_vllm_paged_attn(out_dir: &PathBuf) {
             .and_then(|s| s.to_str())
             .expect("cu filename");
         let obj = out_dir.join(format!("vllm_paged_attn_{stem}.o"));
-        eprintln!(
-            "[vllm-paged-attn-v2] compiling {src} -> {}",
-            obj.display()
-        );
+        eprintln!("[vllm-paged-attn-v2] compiling {src} -> {}", obj.display());
 
         let status = std::process::Command::new(&nvcc)
             .args(["-c", src, "-o"])
@@ -210,9 +207,7 @@ fn compile_vllm_paged_attn(out_dir: &PathBuf) {
                 "0",
             ])
             .status()
-            .unwrap_or_else(|e| {
-                panic!("[vllm-paged-attn-v2] nvcc spawn failed for {src}: {e}")
-            });
+            .unwrap_or_else(|e| panic!("[vllm-paged-attn-v2] nvcc spawn failed for {src}: {e}"));
         if !status.success() {
             panic!(
                 "[vllm-paged-attn-v2] nvcc failed compiling {src}. Disable \
@@ -245,7 +240,10 @@ fn compile_vllm_paged_attn(out_dir: &PathBuf) {
     }
     println!("cargo:rustc-link-lib=dylib=cudart");
     println!("cargo:rustc-link-lib=dylib=stdc++");
-    eprintln!("[vllm-paged-attn-v2] static lib built: {}", lib_file.display());
+    eprintln!(
+        "[vllm-paged-attn-v2] static lib built: {}",
+        lib_file.display()
+    );
 }
 
 fn compile_vllm_moe_marlin(out_dir: &PathBuf) {

--- a/crates/ferrum-kernels/src/backend/cuda/paged.rs
+++ b/crates/ferrum-kernels/src/backend/cuda/paged.rs
@@ -1228,9 +1228,7 @@ impl BackendPagedKv for CudaBackend {
             })
         }
         .map(|_| ())
-        .map_err(|e| {
-            FerrumError::model(format!("split_qkv_norm_rope_into_paged_cache_vllm: {e}"))
-        })
+        .map_err(|e| FerrumError::model(format!("split_qkv_norm_rope_into_paged_cache_vllm: {e}")))
     }
 
     #[cfg(feature = "vllm-paged-attn-v2")]

--- a/crates/ferrum-models/src/common/paged_pool.rs
+++ b/crates/ferrum-models/src/common/paged_pool.rs
@@ -20,30 +20,82 @@
 //!
 //! Each physical block has a `u16` ref count. `allocate` / `allocate_n`
 //! create a block with `ref_count = 1`. `free` decrements; when the count
-//! reaches zero the block returns to the free list (physical reuse).
-//! New API `acquire(block)` increments — used by the upcoming prefix cache
-//! when another sequence wants to share an already-resident block.
+//! reaches zero the block returns to the free list. `acquire(block)`
+//! increments — used by the prefix cache when another sequence wants to
+//! share an already-resident block.
 //!
 //! Backwards compatible: pre-prefix-cache callers don't touch `acquire`,
 //! so every block stays at ref=1 and `free` behaves identically to the
 //! old single-ref free.
 //!
-//! ## What's *not* here yet (deferred to Phase 2-4 of prefix cache):
-//! - **Block hash chain** + global hash → block_id table.
+//! ## Hash table (Phase 2 of block-level prefix cache)
+//!
+//! Each block can be tagged with a content-addressed `BlockHash` via
+//! [`BlockAllocator::register_block_hash`]. The hash is computed by
+//! chaining `parent_hash` with the block's tokens (see
+//! [`block_hash_chain`]) so identical prefixes across requests produce
+//! identical hash sequences.
+//!
+//! [`BlockAllocator::try_acquire_by_hash`] looks up a hash and bumps the
+//! ref count on hit. **Soft-free blocks** (ref=0 still in `free_list`
+//! with content intact) can be resurrected — this is what makes the cache
+//! actually useful across requests. `allocate` evicts a stale hash when
+//! a soft-free block is recycled with new content.
+//!
+//! ## What's *not* here yet (deferred to Phase 3-4 of prefix cache):
 //! - **Engine integration**: hashing incoming prompt blocks, looking up
 //!   matching prefix, splicing the existing blocks into the new seq's
-//!   block_table.
-//! - **Eviction policy**: when ref hits 0 the block becomes immediately
-//!   reusable; an LRU "soft-free" tier would let us keep recently-evicted
-//!   blocks hot for opportunistic prefix-cache hits before they're
-//!   overwritten by a new allocate.
+//!   block_table, running prefill only on the unmatched suffix.
+//! - **LRU eviction**: `free_list` is LIFO. Better policy would be
+//!   LRU-soft-free so the oldest (least likely to hit) blocks are
+//!   reused first. Today the most-recently-freed gets reused first
+//!   (pessimistic for cross-request reuse).
 //! - **Preemption**: when blocks run out we still just `Err`; real
 //!   scheduler would refuse-and-queue or evict.
 //! - Cross-process or cross-model pooling.
 
 use ferrum_kernels::backend::Backend;
-use ferrum_types::{FerrumError, Result};
+use ferrum_types::{FerrumError, Result, TokenId};
+use std::collections::HashMap;
+use std::hash::{Hash, Hasher};
 use std::sync::atomic::{AtomicUsize, Ordering};
+
+/// Hash identifying a content-addressable KV block. Computed from a chain
+/// of (parent_hash, block_tokens) — see [`block_hash_chain`].
+pub type BlockHash = u64;
+
+/// Compute the hash for one block, chained from its parent.
+///
+/// `parent` is the hash of the preceding block (0 for the first block).
+/// `tokens` are the `block_size` token ids in this block.
+///
+/// Uses Rust's default `SipHasher` for collision resistance with no extra
+/// deps. SipHash at ~1 GB/s processes a 16-token block (64 bytes) in tens
+/// of ns; per-request hashing of <200 blocks is well under a microsecond
+/// — invisible next to a prefill kernel.
+pub fn block_hash(parent: BlockHash, tokens: &[TokenId]) -> BlockHash {
+    let mut h = std::collections::hash_map::DefaultHasher::new();
+    parent.hash(&mut h);
+    for t in tokens {
+        t.get().hash(&mut h);
+    }
+    h.finish()
+}
+
+/// Compute the chained hash sequence for a token list, broken into
+/// `block_size`-token blocks. Trailing partial block (length <
+/// `block_size`) is dropped — partial blocks can't be looked up
+/// independently since their content depends on what gets appended next.
+pub fn block_hash_chain(tokens: &[TokenId], block_size: usize) -> Vec<BlockHash> {
+    let n = tokens.len() / block_size;
+    let mut out = Vec::with_capacity(n);
+    let mut parent: BlockHash = 0;
+    for chunk in tokens.chunks_exact(block_size) {
+        parent = block_hash(parent, chunk);
+        out.push(parent);
+    }
+    out
+}
 
 /// LIFO free-list block allocator. `O(1)` allocate / free, no fragmentation
 /// (all blocks are uniform size).
@@ -58,12 +110,25 @@ pub struct BlockAllocator {
     /// pool-sizing diagnostics in the bench harness.
     peak_in_use: AtomicUsize,
     /// Per-block reference count. `ref_counts[i] == 0` ⟺ block i is on
-    /// the free list. `allocate` sets to 1; `acquire` increments;
+    /// the free list (either freshly-uninitialized or soft-free with a
+    /// hash still registered). `allocate` sets to 1; `acquire` increments;
     /// `free` decrements and (only when reaching 0) returns the block
     /// to the free list. Width 16 bits — supports up to 65535 concurrent
     /// sharers of the same physical KV block, far past any realistic
     /// continuous batching cap.
     ref_counts: Vec<u16>,
+    /// Block-hash lookup. Contains entries for every block whose content
+    /// has been hash-registered via [`Self::register_block_hash`] — both
+    /// live (ref ≥ 1) and soft-free (ref = 0 but content not yet
+    /// overwritten). [`Self::try_acquire_by_hash`] hits this map; on hit
+    /// the entry is resurrected with ref = 1 if it was soft-free.
+    /// Survives across requests — this is what makes the prefix cache
+    /// actually useful.
+    hash_table: HashMap<BlockHash, u32>,
+    /// Reverse map block_id → hash, for cleanup. When a block's content
+    /// gets overwritten by `allocate` returning it on a fresh request,
+    /// we use this to erase its stale hash from `hash_table`.
+    block_to_hash: Vec<Option<BlockHash>>,
 }
 
 impl BlockAllocator {
@@ -79,6 +144,8 @@ impl BlockAllocator {
             capacity: num_blocks,
             peak_in_use: AtomicUsize::new(0),
             ref_counts: vec![0u16; num_blocks as usize],
+            hash_table: HashMap::new(),
+            block_to_hash: vec![None; num_blocks as usize],
         }
     }
 
@@ -97,6 +164,9 @@ impl BlockAllocator {
                     "allocate yielded block {b} with non-zero ref_count {}",
                     self.ref_counts[b as usize]
                 );
+                // Soft-free block with a stale hash → content will be
+                // overwritten, so erase the hash mapping.
+                self.evict_hash_if_any(b);
                 self.ref_counts[b as usize] = 1;
                 let in_use = self.capacity as usize - self.free_list.len();
                 self.peak_in_use.fetch_max(in_use, Ordering::Relaxed);
@@ -106,6 +176,22 @@ impl BlockAllocator {
                 "paged KV pool exhausted (capacity={} blocks, all in use)",
                 self.capacity
             ))),
+        }
+    }
+
+    /// Internal: erase any hash mapping for a block whose content is
+    /// about to be overwritten. No-op if the block had no hash registered.
+    fn evict_hash_if_any(&mut self, block: u32) {
+        if let Some(h) = self.block_to_hash[block as usize].take() {
+            // Only erase from hash_table if it still points at THIS block.
+            // (Defensive — a hash collision later registering the same h
+            // to a different block could mean the entry now points
+            // elsewhere; we shouldn't yank the live one.)
+            if let Some(&mapped) = self.hash_table.get(&h) {
+                if mapped == block {
+                    self.hash_table.remove(&h);
+                }
+            }
         }
     }
 
@@ -125,12 +211,75 @@ impl BlockAllocator {
                 self.ref_counts[b as usize] == 0,
                 "allocate_n yielded block {b} with non-zero ref_count"
             );
+            self.evict_hash_if_any(b);
             self.ref_counts[b as usize] = 1;
             out.push(b);
         }
         let in_use = self.capacity as usize - self.free_list.len();
         self.peak_in_use.fetch_max(in_use, Ordering::Relaxed);
         Ok(out)
+    }
+
+    /// Look up a hash in the prefix-cache table. If the hash maps to a
+    /// physical block (live or soft-free), bump its ref count and return
+    /// the block id. A soft-free block (ref=0 in free_list) is
+    /// resurrected — pulled out of the free list and ref set to 1.
+    /// Returns `None` on cache miss.
+    pub fn try_acquire_by_hash(&mut self, hash: BlockHash) -> Option<u32> {
+        let &block = self.hash_table.get(&hash)?;
+        let bi = block as usize;
+        if self.ref_counts[bi] == 0 {
+            // Soft-free: pull out of free_list (O(n) on free_list length;
+            // typically small — few hundred at peak utilisation).
+            if let Some(pos) = self.free_list.iter().rposition(|&b| b == block) {
+                self.free_list.swap_remove(pos);
+            } else {
+                // Inconsistency: ref=0 but not in free_list. Shouldn't
+                // happen unless someone bypassed the API. Treat as miss
+                // to avoid corruption.
+                debug_assert!(false, "block {block} has ref=0 but not in free_list");
+                return None;
+            }
+            self.ref_counts[bi] = 1;
+            let in_use = self.capacity as usize - self.free_list.len();
+            self.peak_in_use.fetch_max(in_use, Ordering::Relaxed);
+        } else {
+            self.acquire(block);
+        }
+        Some(block)
+    }
+
+    /// Associate a hash with a block (after its content is written).
+    /// If the block already had a hash, the old mapping is replaced.
+    /// Block must currently be live (ref ≥ 1).
+    pub fn register_block_hash(&mut self, block: u32, hash: BlockHash) {
+        let bi = block as usize;
+        debug_assert!(
+            self.ref_counts[bi] > 0,
+            "register_block_hash on block {block} with ref_count=0 (not allocated)"
+        );
+        // Replace prior hash if any.
+        if let Some(old_h) = self.block_to_hash[bi].replace(hash) {
+            if old_h != hash {
+                if let Some(&mapped) = self.hash_table.get(&old_h) {
+                    if mapped == block {
+                        self.hash_table.remove(&old_h);
+                    }
+                }
+            } else {
+                // Same hash being re-registered; nothing to clean up.
+                return;
+            }
+        }
+        // Last-writer-wins on collision (same hash different content —
+        // SipHash collisions on 64-token inputs are astronomically rare).
+        self.hash_table.insert(hash, block);
+    }
+
+    /// Read accessor for tests / debugging.
+    #[inline]
+    pub fn hash_table_size(&self) -> usize {
+        self.hash_table.len()
     }
 
     /// Increment the ref count for an already-allocated block. Used by
@@ -402,5 +551,109 @@ mod tests {
         assert_eq!(a.free_count(), 5);
         a.free(&blocks); // each ref=0, all released
         assert_eq!(a.free_count(), 8);
+    }
+
+    // ── Phase 2: hash table tests ────────────────────────────────────────
+
+    fn toks(ids: &[u32]) -> Vec<TokenId> {
+        ids.iter().map(|&i| TokenId::new(i)).collect()
+    }
+
+    #[test]
+    fn block_hash_chain_basic() {
+        let tokens = toks(&[1, 2, 3, 4, 5, 6, 7, 8]);
+        let chain = block_hash_chain(&tokens, 4);
+        assert_eq!(chain.len(), 2);
+        // Identical second block must produce a DIFFERENT chained hash
+        // because its parent (first block) is the same here but the
+        // chain order forces hash[1] = h(hash[0], tokens[4..8]).
+        assert_ne!(chain[0], chain[1]);
+    }
+
+    #[test]
+    fn block_hash_chain_identical_prefix_same_hashes() {
+        let a = toks(&[10, 20, 30, 40, 50, 60, 70, 80]);
+        let b = toks(&[10, 20, 30, 40, 99, 99, 99, 99]);
+        let ca = block_hash_chain(&a, 4);
+        let cb = block_hash_chain(&b, 4);
+        assert_eq!(ca[0], cb[0], "first block matches → same hash[0]");
+        assert_ne!(ca[1], cb[1], "second block differs → different hash[1]");
+    }
+
+    #[test]
+    fn block_hash_chain_drops_partial_trailing() {
+        let tokens = toks(&[1, 2, 3, 4, 5, 6, 7]); // 7 tokens, block_size=4 → 1 full
+        let chain = block_hash_chain(&tokens, 4);
+        assert_eq!(chain.len(), 1);
+    }
+
+    #[test]
+    fn hash_table_register_and_acquire_live() {
+        let mut a = BlockAllocator::new(4);
+        let b = a.allocate().unwrap();
+        let h = 0xDEAD_BEEFu64;
+        a.register_block_hash(b, h);
+        assert_eq!(a.hash_table_size(), 1);
+        // Re-acquire by hash: must bump ref (block is live)
+        let got = a.try_acquire_by_hash(h);
+        assert_eq!(got, Some(b));
+        assert_eq!(a.ref_count(b), 2);
+    }
+
+    #[test]
+    fn hash_table_soft_free_resurrection() {
+        let mut a = BlockAllocator::new(4);
+        let b = a.allocate().unwrap();
+        let h = 0xABCD_1234u64;
+        a.register_block_hash(b, h);
+        a.free(&[b]); // ref=0, block in free_list, hash STILL registered
+        assert_eq!(a.free_count(), 4);
+        assert_eq!(a.ref_count(b), 0);
+        // Cache hit on the soft-free block: must resurrect with ref=1
+        let got = a.try_acquire_by_hash(h);
+        assert_eq!(got, Some(b));
+        assert_eq!(a.ref_count(b), 1);
+        // The block is OFF the free_list now.
+        assert_eq!(a.free_count(), 3);
+    }
+
+    #[test]
+    fn hash_table_miss_returns_none() {
+        let mut a = BlockAllocator::new(4);
+        let b = a.allocate().unwrap();
+        a.register_block_hash(b, 1);
+        assert_eq!(a.try_acquire_by_hash(99), None);
+        // No side effects on miss
+        assert_eq!(a.ref_count(b), 1);
+    }
+
+    #[test]
+    fn hash_table_evicts_on_realloc() {
+        // Allocate, register hash, free → soft-free with hash. Then
+        // allocate a new block — the recycled one's hash must be erased
+        // because its content is about to be overwritten.
+        let mut a = BlockAllocator::new(2);
+        let b1 = a.allocate().unwrap();
+        let h = 0x1234u64;
+        a.register_block_hash(b1, h);
+        a.free(&[b1]); // soft-free
+        assert_eq!(a.hash_table_size(), 1);
+        // Allocate to consume the only free block — should recycle b1
+        // and evict its hash.
+        let b2 = a.allocate().unwrap();
+        assert_eq!(b2, b1, "LIFO should reuse b1");
+        assert_eq!(a.hash_table_size(), 0, "stale hash erased on realloc");
+        assert_eq!(a.try_acquire_by_hash(h), None);
+    }
+
+    #[test]
+    fn hash_table_replace_block_hash() {
+        let mut a = BlockAllocator::new(4);
+        let b = a.allocate().unwrap();
+        a.register_block_hash(b, 1);
+        a.register_block_hash(b, 2); // overwrite
+        assert_eq!(a.hash_table_size(), 1);
+        assert_eq!(a.try_acquire_by_hash(1), None);
+        assert_eq!(a.try_acquire_by_hash(2), Some(b));
     }
 }

--- a/crates/ferrum-models/src/common/paged_pool.rs
+++ b/crates/ferrum-models/src/common/paged_pool.rs
@@ -16,11 +16,29 @@
 //!   `Result::Err` so the scheduler can refuse the request rather than
 //!   panicking deep in the model forward.
 //!
-//! What's *not* here yet (deferred to Phase 4c / 5):
-//! - Prefix sharing: today a fresh `PagedSeqState` always allocates new
-//!   blocks even if its prompt overlaps another live sequence's.
-//! - Eviction / preemption: when blocks run out we just `Err`. A real
-//!   scheduler would either refuse-and-queue or evict the least-recently-used.
+//! ## Ref counting (Phase 1 of block-level prefix cache)
+//!
+//! Each physical block has a `u16` ref count. `allocate` / `allocate_n`
+//! create a block with `ref_count = 1`. `free` decrements; when the count
+//! reaches zero the block returns to the free list (physical reuse).
+//! New API `acquire(block)` increments — used by the upcoming prefix cache
+//! when another sequence wants to share an already-resident block.
+//!
+//! Backwards compatible: pre-prefix-cache callers don't touch `acquire`,
+//! so every block stays at ref=1 and `free` behaves identically to the
+//! old single-ref free.
+//!
+//! ## What's *not* here yet (deferred to Phase 2-4 of prefix cache):
+//! - **Block hash chain** + global hash → block_id table.
+//! - **Engine integration**: hashing incoming prompt blocks, looking up
+//!   matching prefix, splicing the existing blocks into the new seq's
+//!   block_table.
+//! - **Eviction policy**: when ref hits 0 the block becomes immediately
+//!   reusable; an LRU "soft-free" tier would let us keep recently-evicted
+//!   blocks hot for opportunistic prefix-cache hits before they're
+//!   overwritten by a new allocate.
+//! - **Preemption**: when blocks run out we still just `Err`; real
+//!   scheduler would refuse-and-queue or evict.
 //! - Cross-process or cross-model pooling.
 
 use ferrum_kernels::backend::Backend;
@@ -39,6 +57,13 @@ pub struct BlockAllocator {
     /// Watermark: how many blocks have been live at peak, useful for
     /// pool-sizing diagnostics in the bench harness.
     peak_in_use: AtomicUsize,
+    /// Per-block reference count. `ref_counts[i] == 0` ⟺ block i is on
+    /// the free list. `allocate` sets to 1; `acquire` increments;
+    /// `free` decrements and (only when reaching 0) returns the block
+    /// to the free list. Width 16 bits — supports up to 65535 concurrent
+    /// sharers of the same physical KV block, far past any realistic
+    /// continuous batching cap.
+    ref_counts: Vec<u16>,
 }
 
 impl BlockAllocator {
@@ -53,15 +78,26 @@ impl BlockAllocator {
             free_list,
             capacity: num_blocks,
             peak_in_use: AtomicUsize::new(0),
+            ref_counts: vec![0u16; num_blocks as usize],
         }
     }
 
     /// Allocate a single physical block. Returns `Err` when the pool is
     /// exhausted — caller is expected to refuse the request and queue
     /// it (or evict another seq, when that's wired up).
+    ///
+    /// New block starts with `ref_count = 1`. Drop one ref via `free()`
+    /// to return it to the pool, or call `acquire()` for additional
+    /// sharers.
     pub fn allocate(&mut self) -> Result<u32> {
         match self.free_list.pop() {
             Some(b) => {
+                debug_assert!(
+                    self.ref_counts[b as usize] == 0,
+                    "allocate yielded block {b} with non-zero ref_count {}",
+                    self.ref_counts[b as usize]
+                );
+                self.ref_counts[b as usize] = 1;
                 let in_use = self.capacity as usize - self.free_list.len();
                 self.peak_in_use.fetch_max(in_use, Ordering::Relaxed);
                 Ok(b)
@@ -74,6 +110,7 @@ impl BlockAllocator {
     }
 
     /// Bulk allocate. Atomic: either all `n` succeed or none are taken.
+    /// Each returned block starts at `ref_count = 1`.
     pub fn allocate_n(&mut self, n: usize) -> Result<Vec<u32>> {
         if self.free_list.len() < n {
             return Err(FerrumError::resource_exhausted(format!(
@@ -83,19 +120,71 @@ impl BlockAllocator {
         }
         let mut out = Vec::with_capacity(n);
         for _ in 0..n {
-            out.push(self.free_list.pop().unwrap());
+            let b = self.free_list.pop().unwrap();
+            debug_assert!(
+                self.ref_counts[b as usize] == 0,
+                "allocate_n yielded block {b} with non-zero ref_count"
+            );
+            self.ref_counts[b as usize] = 1;
+            out.push(b);
         }
         let in_use = self.capacity as usize - self.free_list.len();
         self.peak_in_use.fetch_max(in_use, Ordering::Relaxed);
         Ok(out)
     }
 
-    /// Return blocks to the free list. Caller is responsible for
-    /// ensuring no live sequence still references them; freeing a block
-    /// while it's still in a `PagedSeqState::blocks` will silently
-    /// corrupt the next allocation that gets it.
+    /// Increment the ref count for an already-allocated block. Used by
+    /// prefix-caching paths when a new sequence wants to share a block
+    /// that's already resident from a prior request.
+    ///
+    /// Panics in debug builds if the block is not currently allocated
+    /// (ref_count==0) — a release-build path that calls `acquire` on a
+    /// free block is a memory-safety bug we'd rather catch loudly.
+    pub fn acquire(&mut self, block: u32) {
+        let bi = block as usize;
+        debug_assert!(
+            self.ref_counts[bi] > 0,
+            "acquire on block {block} with ref_count=0 (not currently allocated)"
+        );
+        self.ref_counts[bi] = self.ref_counts[bi]
+            .checked_add(1)
+            .expect("BlockAllocator ref_count u16 overflow (>65535 sharers)");
+    }
+
+    /// Bulk acquire — convenience for prefix-cache hit paths that take a
+    /// list of physical block ids to share.
+    pub fn acquire_many(&mut self, blocks: &[u32]) {
+        for &b in blocks {
+            self.acquire(b);
+        }
+    }
+
+    /// Drop one ref from each block. Blocks whose ref_count hits 0 are
+    /// returned to the free list and become available for the next
+    /// `allocate*` call.
+    ///
+    /// Pre-prefix-cache callers see no behavioural change: every block
+    /// they hold starts at ref=1 (from `allocate`), and `free` drops it
+    /// to 0 — physically frees on the same call, same as before.
     pub fn free(&mut self, blocks: &[u32]) {
-        self.free_list.extend_from_slice(blocks);
+        for &b in blocks {
+            let bi = b as usize;
+            debug_assert!(
+                self.ref_counts[bi] > 0,
+                "free on block {b} with ref_count=0 (double-free)"
+            );
+            self.ref_counts[bi] -= 1;
+            if self.ref_counts[bi] == 0 {
+                self.free_list.push(b);
+            }
+        }
+    }
+
+    /// Read current ref count for a block. 0 means free, ≥1 means in
+    /// use by that many sequences.
+    #[inline]
+    pub fn ref_count(&self, block: u32) -> u16 {
+        self.ref_counts[block as usize]
     }
 
     pub fn free_count(&self) -> usize {
@@ -246,5 +335,72 @@ mod tests {
         assert_eq!(a.peak_in_use(), 5); // peak doesn't decrease
         let _ = a.allocate_n(3).unwrap();
         assert_eq!(a.peak_in_use(), 5);
+    }
+
+    #[test]
+    fn refcount_allocate_starts_at_one() {
+        let mut a = BlockAllocator::new(4);
+        let b = a.allocate().unwrap();
+        assert_eq!(a.ref_count(b), 1);
+    }
+
+    #[test]
+    fn refcount_acquire_increments() {
+        let mut a = BlockAllocator::new(4);
+        let b = a.allocate().unwrap();
+        a.acquire(b);
+        a.acquire(b);
+        assert_eq!(a.ref_count(b), 3);
+    }
+
+    #[test]
+    fn refcount_free_decrements_no_physical_release() {
+        let mut a = BlockAllocator::new(4);
+        let b = a.allocate().unwrap();
+        a.acquire(b); // ref=2
+        a.free(&[b]); // ref=1 — NOT yet returned to free_list
+        assert_eq!(a.ref_count(b), 1);
+        assert_eq!(a.free_count(), 3); // only 3 of original 4 blocks free
+    }
+
+    #[test]
+    fn refcount_free_physical_release_at_zero() {
+        let mut a = BlockAllocator::new(4);
+        let b = a.allocate().unwrap();
+        a.acquire(b); // ref=2
+        a.free(&[b]); // ref=1
+        a.free(&[b]); // ref=0 → physical release
+        assert_eq!(a.ref_count(b), 0);
+        assert_eq!(a.free_count(), 4);
+    }
+
+    #[test]
+    fn refcount_legacy_single_ref_behaviour_unchanged() {
+        // Pre-prefix-cache code never calls `acquire`. Verify that
+        // allocate+free behaves identically to the old version: block
+        // immediately returns to the pool.
+        let mut a = BlockAllocator::new(2);
+        let b = a.allocate().unwrap();
+        assert_eq!(a.free_count(), 1);
+        a.free(&[b]);
+        assert_eq!(a.free_count(), 2);
+        assert_eq!(a.ref_count(b), 0);
+        // Re-allocation reuses the slot (LIFO).
+        let b2 = a.allocate().unwrap();
+        assert_eq!(b2, b);
+    }
+
+    #[test]
+    fn refcount_bulk_acquire_and_release() {
+        let mut a = BlockAllocator::new(8);
+        let blocks = a.allocate_n(3).unwrap();
+        a.acquire_many(&blocks); // each ref=2
+        for &b in &blocks {
+            assert_eq!(a.ref_count(b), 2);
+        }
+        a.free(&blocks); // each ref=1, none physically released
+        assert_eq!(a.free_count(), 5);
+        a.free(&blocks); // each ref=0, all released
+        assert_eq!(a.free_count(), 8);
     }
 }

--- a/crates/ferrum-models/src/models/qwen3_moe.rs
+++ b/crates/ferrum-models/src/models/qwen3_moe.rs
@@ -36,6 +36,7 @@ use ferrum_kernels::backend::{
 use ferrum_quantization::WeightLoader;
 use ferrum_types::{FerrumError, Result};
 
+use crate::common::paged_pool::{block_hash_chain, BlockHash};
 use crate::common::{DecoderOnlyLLM, LlmRuntimeConfig};
 use crate::models::llama_family::{LlamaFamilyConfig, LlamaFamilyLayer, RopeCache};
 use crate::moe::{moe_forward, ExpertStack};
@@ -1665,12 +1666,222 @@ impl<B: MoeLlmBackend, K: KvDtypeKind> Qwen3MoeModel<B, K> {
         )
     }
 
+    /// Block-level prefix cache: try to splice cached prefix blocks into
+    /// `cache_id`'s KV state. Hashes `tokens` block-by-block, looks each
+    /// hash up in the shared `paged_block_alloc`'s hash table, and on
+    /// hit:
+    ///   1. acquires the cached physical block (ref+=1, resurrecting from
+    ///      soft-free if needed)
+    ///   2. swaps the fresh block (from prior `ensure_kv`) out of this
+    ///      seq's `block_indices[i]`, returns it to the pool
+    ///   3. writes the cached block id into `block_indices[i]` instead
+    ///
+    /// Returns the number of tokens that were already cached. After this
+    /// call the cache_id has `cache.len = returned * block_size`, so
+    /// `prefill_internal` reading `pos_offset` from `cache.len` naturally
+    /// continues from where prefix cache left off — the caller's prefill
+    /// only needs to process `tokens[returned..]`.
+    ///
+    /// MUST be called after `ensure_kv(cache_id)`. Returns 0 if non-paged
+    /// or paged_block_alloc is None.
+    pub(crate) fn try_acquire_prefix_cache(
+        &mut self,
+        cache_id: &str,
+        tokens: &[u32],
+    ) -> usize {
+        let Some(alloc_arc) = self.paged_block_alloc.as_ref() else {
+            return 0;
+        };
+        let caches = match self.kv_caches.get(cache_id) {
+            Some(c) => c,
+            None => return 0,
+        };
+        let block_size = caches.first().map(|c| c.block_size).unwrap_or(0);
+        if block_size == 0 {
+            return 0;
+        }
+
+        // Hash chain on input tokens (only full blocks — trailing partial
+        // block can't be cached as standalone).
+        let token_ids: Vec<ferrum_types::TokenId> =
+            tokens.iter().map(|&t| ferrum_types::TokenId::new(t)).collect();
+        let hashes: Vec<BlockHash> = block_hash_chain(&token_ids, block_size);
+        if hashes.is_empty() {
+            return 0;
+        }
+
+        // Probe matches from the front. Stop at first miss — we want the
+        // longest contiguous prefix; gaps would break the kv_len contract.
+        let mut alloc = alloc_arc.lock().unwrap_or_else(|p| p.into_inner());
+        let mut matched: Vec<u32> = Vec::with_capacity(hashes.len());
+        for &h in &hashes {
+            match alloc.try_acquire_by_hash(h) {
+                Some(b) => matched.push(b),
+                None => break,
+            }
+        }
+        if matched.is_empty() {
+            return 0;
+        }
+        let n_matched = matched.len();
+
+        // Free the freshly-allocated blocks that we're displacing —
+        // those `block_indices[0..n_matched]` slots get the cached IDs
+        // instead.
+        let displaced: Vec<u32> = caches
+            .first()
+            .map(|c| c.paged_block_indices[..n_matched].to_vec())
+            .unwrap_or_default();
+        alloc.free(&displaced);
+        drop(alloc);
+
+        // Splice matched into each layer's cache state and mirror to the
+        // device block_table buffer + context_lens.
+        let caches_mut = self.kv_caches.get_mut(cache_id).expect("cache present");
+        let max_blocks = caches_mut
+            .first()
+            .map(|c| c.paged_block_indices.len())
+            .unwrap_or(0);
+        let new_len = n_matched * block_size;
+        let mut ctx_tmp = B::new_context();
+        for c in caches_mut.iter_mut() {
+            // Replace first n_matched entries with cached IDs.
+            for (i, &b) in matched.iter().enumerate() {
+                c.paged_block_indices[i] = b;
+            }
+            c.len = new_len;
+            if let Some(bt) = c.block_table.as_mut() {
+                let mut padded = c.paged_block_indices.clone();
+                padded.resize(max_blocks, 0);
+                B::write_typed::<u32>(&mut ctx_tmp, bt, &padded);
+            }
+            if let Some(cl) = c.context_lens.as_mut() {
+                B::write_typed::<u32>(&mut ctx_tmp, cl, &[new_len as u32]);
+            }
+        }
+        B::sync(&mut ctx_tmp);
+
+        new_len
+    }
+
+    /// Register block hashes for content that was just written by the
+    /// prefill kernel. Called AFTER `prefill_internal`'s forward pass
+    /// completes so the resulting blocks can be cache-hit by future
+    /// requests with the same prompt prefix.
+    ///
+    /// `all_tokens` is the FULL prompt (the same `tokens` passed to
+    /// prefill, before prefix-cache slicing).
+    /// `prior_cached_tokens` is the count returned by
+    /// `try_acquire_prefix_cache` — those blocks already had their hashes
+    /// registered (we just acquired them); we only need to register the
+    /// NEW blocks past that point.
+    pub(crate) fn register_prefix_cache(
+        &mut self,
+        cache_id: &str,
+        all_tokens: &[u32],
+        prior_cached_tokens: usize,
+    ) {
+        let Some(alloc_arc) = self.paged_block_alloc.as_ref() else {
+            return;
+        };
+        let caches = match self.kv_caches.get(cache_id) {
+            Some(c) => c,
+            None => return,
+        };
+        let cache0 = match caches.first() {
+            Some(c) => c,
+            None => return,
+        };
+        let block_size = cache0.block_size;
+        if block_size == 0 {
+            return;
+        }
+
+        let token_ids: Vec<ferrum_types::TokenId> = all_tokens
+            .iter()
+            .map(|&t| ferrum_types::TokenId::new(t))
+            .collect();
+        let hashes: Vec<BlockHash> = block_hash_chain(&token_ids, block_size);
+        if hashes.is_empty() {
+            return;
+        }
+
+        let start_block = prior_cached_tokens / block_size;
+        let mut alloc = alloc_arc.lock().unwrap_or_else(|p| p.into_inner());
+        for i in start_block..hashes.len().min(cache0.paged_block_indices.len()) {
+            // Only register blocks whose content actually got written.
+            // After prefill the cache covers `all_tokens.len()` tokens;
+            // a hash at index i represents block i which holds
+            // tokens[i*bs .. (i+1)*bs]. That block is "fully written"
+            // iff (i+1)*bs <= cache.len (the actual fully-prefilled
+            // position). If only a partial block was written we don't
+            // register it (its content depends on the next prefill).
+            let block_end_token = (i + 1) * block_size;
+            if block_end_token > cache0.len {
+                break;
+            }
+            let block_id = cache0.paged_block_indices[i];
+            alloc.register_block_hash(block_id, hashes[i]);
+        }
+    }
+
     /// Prefill: process `tokens` prompt tokens, return last-token logits.
+    ///
+    /// When `FERRUM_PREFIX_CACHE=1` is set, blocks of `tokens` whose
+    /// content-addressed hash matches a previously-cached block are
+    /// spliced into this seq's KV cache via `try_acquire_prefix_cache`,
+    /// and only the unmatched suffix is actually prefilled.
     pub fn prefill_internal(&mut self, cache_id: &str, tokens: &[u32]) -> Vec<f32> {
-        let seq_len = tokens.len();
-        assert!(seq_len > 0);
-        self.ensure_scratch(seq_len);
+        assert!(!tokens.is_empty());
+        self.ensure_scratch(tokens.len());
         self.ensure_kv(cache_id);
+
+        // Block-level prefix cache. Env-gated for cautious rollout — the
+        // engine's older whole-prompt PrefixCache (continuous_engine.rs)
+        // still owns the default path; this knob opt-in switches the
+        // model layer to block-level matching too.
+        let cached_prefix_tokens = if std::env::var("FERRUM_PREFIX_CACHE").as_deref() == Ok("1") {
+            self.try_acquire_prefix_cache(cache_id, tokens)
+        } else {
+            0
+        };
+
+        // The suffix is what we actually push through the model. If the
+        // entire prompt hit the cache (suffix empty), we leave at least
+        // one block's worth to re-run so we still produce final logits.
+        // TODO: dedicated "full-hit" path that recomputes only the last
+        //   block's logits from cached KV — for now under-cache by 1 block.
+        let cached_prefix_tokens = if cached_prefix_tokens >= tokens.len() {
+            let block_size = self
+                .kv_caches
+                .get(cache_id)
+                .and_then(|c| c.first())
+                .map(|c| c.block_size)
+                .unwrap_or(16);
+            // Roll back one block so we still have a suffix to prefill.
+            cached_prefix_tokens.saturating_sub(block_size).min(tokens.len() - 1)
+        } else {
+            cached_prefix_tokens
+        };
+
+        // Sync cache.len down if we rolled back. Cheap: 1 u32 write per layer.
+        if cached_prefix_tokens > 0 {
+            let caches_mut = self.kv_caches.get_mut(cache_id).expect("cache present");
+            let mut ctx_tmp = B::new_context();
+            for c in caches_mut.iter_mut() {
+                if c.len != cached_prefix_tokens {
+                    c.len = cached_prefix_tokens;
+                    if let Some(cl) = c.context_lens.as_mut() {
+                        B::write_typed::<u32>(&mut ctx_tmp, cl, &[cached_prefix_tokens as u32]);
+                    }
+                }
+            }
+            B::sync(&mut ctx_tmp);
+        }
+
+        let suffix_tokens: &[u32] = &tokens[cached_prefix_tokens..];
+        let seq_len = suffix_tokens.len();
+        assert!(seq_len > 0, "prefix cache must leave ≥1 suffix token");
 
         let pos_offset = self
             .kv_caches
@@ -1719,7 +1930,7 @@ impl<B: MoeLlmBackend, K: KvDtypeKind> Qwen3MoeModel<B, K> {
             .residual
             .take()
             .expect("scratch residual missing (previous call didn't restore)");
-        B::embedding_lookup(&mut ctx, &self.embed, tokens, &mut residual, h);
+        B::embedding_lookup(&mut ctx, &self.embed, suffix_tokens, &mut residual, h);
 
         // For prefill (seq_len > 1) the cross-layer norm fusion does
         // not apply (it lives on the decode fast path). We still pass
@@ -1819,6 +2030,17 @@ impl<B: MoeLlmBackend, K: KvDtypeKind> Qwen3MoeModel<B, K> {
             bucket("  wsum", wsum_n, wsum_us);
         }
         self.scratch.residual = Some(residual);
+
+        // Register hashes for blocks newly written by this prefill so
+        // future requests with the same prompt prefix can reuse them.
+        // No-op when prefix cache is disabled (prior_cached_tokens always
+        // 0, register fires but `paged_block_alloc.is_none()` short-circuits)
+        // or when the cached prefix already covered all blocks (the rolled-
+        // back block gets re-registered with its newly-recomputed content).
+        if std::env::var("FERRUM_PREFIX_CACHE").as_deref() == Ok("1") {
+            self.register_prefix_cache(cache_id, tokens, cached_prefix_tokens);
+        }
+
         B::to_vec(&self.scratch.logits, vocab)
     }
 

--- a/crates/ferrum-models/src/models/qwen3_moe.rs
+++ b/crates/ferrum-models/src/models/qwen3_moe.rs
@@ -1684,11 +1684,7 @@ impl<B: MoeLlmBackend, K: KvDtypeKind> Qwen3MoeModel<B, K> {
     ///
     /// MUST be called after `ensure_kv(cache_id)`. Returns 0 if non-paged
     /// or paged_block_alloc is None.
-    pub(crate) fn try_acquire_prefix_cache(
-        &mut self,
-        cache_id: &str,
-        tokens: &[u32],
-    ) -> usize {
+    pub(crate) fn try_acquire_prefix_cache(&mut self, cache_id: &str, tokens: &[u32]) -> usize {
         let Some(alloc_arc) = self.paged_block_alloc.as_ref() else {
             return 0;
         };
@@ -1703,8 +1699,10 @@ impl<B: MoeLlmBackend, K: KvDtypeKind> Qwen3MoeModel<B, K> {
 
         // Hash chain on input tokens (only full blocks — trailing partial
         // block can't be cached as standalone).
-        let token_ids: Vec<ferrum_types::TokenId> =
-            tokens.iter().map(|&t| ferrum_types::TokenId::new(t)).collect();
+        let token_ids: Vec<ferrum_types::TokenId> = tokens
+            .iter()
+            .map(|&t| ferrum_types::TokenId::new(t))
+            .collect();
         let hashes: Vec<BlockHash> = block_hash_chain(&token_ids, block_size);
         if hashes.is_empty() {
             return 0;
@@ -1859,7 +1857,9 @@ impl<B: MoeLlmBackend, K: KvDtypeKind> Qwen3MoeModel<B, K> {
                 .map(|c| c.block_size)
                 .unwrap_or(16);
             // Roll back one block so we still have a suffix to prefill.
-            cached_prefix_tokens.saturating_sub(block_size).min(tokens.len() - 1)
+            cached_prefix_tokens
+                .saturating_sub(block_size)
+                .min(tokens.len() - 1)
         } else {
             cached_prefix_tokens
         };


### PR DESCRIPTION
## Summary

Wires phases 1 (#178) + 2 (#179) into \`Qwen3MoeModel::prefill_internal\`. With \`FERRUM_PREFIX_CACHE=1\` the model now does block-level prefix matching: same prompt prefix across requests → same physical KV blocks → only the unmatched suffix gets prefilled.

> Stack: based on \`feat/prefix-cache-phase2-hash-table\` (#179). Merge #178 → #179 → this in order.

## Apples-to-apples bench (Vast RTX 4090, Qwen3-30B-A3B-GPTQ-Int4)

**4-way fair comparison** — same \`vllm bench serve\` client, same shared-prefix dataset (128 prompts sharing a ~200-token system message + unique 5-token user question), c=32, max_tokens=256, NO application-level seed (cold start for both engines):

|  | out tok/s | TPOT p50 | TPOT p99 | TTFT |
|---|---:|---:|---:|---:|
| ferrum CACHE_OFF | 1333.2 | 18.7 ms | 26.5 ms | 536 ms |
| **ferrum CACHE_ON** | **1649.7** | 57.3 ms | 586 ms | **147 ms** |
| vLLM CACHE_OFF | 1871.9 | 16.1 ms | 17.6 ms | 243 ms |
| vLLM CACHE_ON | 1893.9 | 15.9 ms | 16.9 ms | 243 ms |

### Real numbers

- **ferrum cache delta**: **+23.7% throughput**, **-73% TTFT** (536 → 147 ms)
- vLLM cache delta: +1% (noise — vLLM's cache doesn't populate fast enough in 128-concurrent cold-start dispatch)
- ferrum ON closes apples gap: 71% of vLLM cold → 87% of vLLM ON
- ferrum p99 TPOT spike to 586 ms — first ~32 requests all miss cache → simultaneous prefill thundering herd. Followup work: stagger initial requests so cache populates before second batch.

Reproducer: \`bash bench/v0.2-cuda/test_prefix_apples_ferrum_noseed.sh\` (in this PR).

**Apples ShareGPT (diverse prompts, no shared prefix) c=32**: 1051 OFF / 1072 ON — no regression, no win (workload has no shared prefix to hit). Expected.

## Flow

\`\`\`
prefill_internal(cache_id, tokens):
  ensure_kv(cache_id)                         # fresh blocks allocated
  if FERRUM_PREFIX_CACHE=1:
    cached = try_acquire_prefix_cache(...)    # hash + lookup + splice
    if cached >= tokens.len():
      cached -= block_size                    # leave ≥1 suffix to prefill
    set cache.len = cached                    # pos_offset reads this
  suffix = tokens[cached..]
  embedding_lookup(suffix); forward_layers(suffix, pos_offset=cached)
  ... last-token logits ...
  if FERRUM_PREFIX_CACHE=1:
    register_prefix_cache(cache_id, tokens, cached)  # tag new blocks
\`\`\`

## New methods on Qwen3MoeModel

- \`try_acquire_prefix_cache(cache_id, tokens) -> usize\` — hashes tokens block-by-block, walks the longest prefix that hits in \`paged_block_alloc\`'s hash table. On hit: acquires the cached block (ref++), frees the displaced fresh block, splices into \`block_indices\`, rewrites \`block_table\` + \`context_lens\` to device. Returns matched token count.
- \`register_prefix_cache(cache_id, all_tokens, prior_cached_tokens)\` — after prefill, \`register_block_hash\` for blocks past \`prior_cached_tokens\` (the newly-written ones). Only registers blocks fully covered by \`cache.len\` — partial trailing block deferred.

## Test plan

- [x] cargo check --workspace --all-targets clean (Mac, no GPU)
- [x] cargo test -p ferrum-models — all passing
- [x] CUDA correctness: 128/128 requests succeed both ON/OFF
- [x] Fair apples bench: +23.7% throughput, -73% TTFT on shared-prefix workload
- [x] Apples ShareGPT (diverse): 1051 → 1072 tok/s — no regression

## Why not engine-side

The engine's pre-existing \`PrefixCache\` (continuous_engine.rs:1419) does whole-prompt matching with O(1) hit/miss — short-circuits exact repeats but useless for partial overlap. This PR adds the partial-overlap layer **inside the model**, behind \`FERRUM_PREFIX_CACHE=1\`. The two layers are complementary: engine cache catches exact repeats, model cache catches shared prefixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)