### PR TITLE
feat(kv): block hash chain + lookup table (prefix-cache phase 2/4)

### DIFF
--- a/crates/ferrum-models/src/common/paged_pool.rs
+++ b/crates/ferrum-models/src/common/paged_pool.rs
@@ -20,30 +20,82 @@
 //!
 //! Each physical block has a `u16` ref count. `allocate` / `allocate_n`
 //! create a block with `ref_count = 1`. `free` decrements; when the count
-//! reaches zero the block returns to the free list (physical reuse).
-//! New API `acquire(block)` increments — used by the upcoming prefix cache
-//! when another sequence wants to share an already-resident block.
+//! reaches zero the block returns to the free list. `acquire(block)`
+//! increments — used by the prefix cache when another sequence wants to
+//! share an already-resident block.
 //!
 //! Backwards compatible: pre-prefix-cache callers don't touch `acquire`,
 //! so every block stays at ref=1 and `free` behaves identically to the
 //! old single-ref free.
 //!
-//! ## What's *not* here yet (deferred to Phase 2-4 of prefix cache):
-//! - **Block hash chain** + global hash → block_id table.
+//! ## Hash table (Phase 2 of block-level prefix cache)
+//!
+//! Each block can be tagged with a content-addressed `BlockHash` via
+//! [`BlockAllocator::register_block_hash`]. The hash is computed by
+//! chaining `parent_hash` with the block's tokens (see
+//! [`block_hash_chain`]) so identical prefixes across requests produce
+//! identical hash sequences.
+//!
+//! [`BlockAllocator::try_acquire_by_hash`] looks up a hash and bumps the
+//! ref count on hit. **Soft-free blocks** (ref=0 still in `free_list`
+//! with content intact) can be resurrected — this is what makes the cache
+//! actually useful across requests. `allocate` evicts a stale hash when
+//! a soft-free block is recycled with new content.
+//!
+//! ## What's *not* here yet (deferred to Phase 3-4 of prefix cache):
 //! - **Engine integration**: hashing incoming prompt blocks, looking up
 //!   matching prefix, splicing the existing blocks into the new seq's
-//!   block_table.
-//! - **Eviction policy**: when ref hits 0 the block becomes immediately
-//!   reusable; an LRU "soft-free" tier would let us keep recently-evicted
-//!   blocks hot for opportunistic prefix-cache hits before they're
-//!   overwritten by a new allocate.
+//!   block_table, running prefill only on the unmatched suffix.
+//! - **LRU eviction**: `free_list` is LIFO. Better policy would be
+//!   LRU-soft-free so the oldest (least likely to hit) blocks are
+//!   reused first. Today the most-recently-freed gets reused first
+//!   (pessimistic for cross-request reuse).
 //! - **Preemption**: when blocks run out we still just `Err`; real
 //!   scheduler would refuse-and-queue or evict.
 //! - Cross-process or cross-model pooling.
 
 use ferrum_kernels::backend::Backend;
-use ferrum_types::{FerrumError, Result};
+use ferrum_types::{FerrumError, Result, TokenId};
+use std::collections::HashMap;
+use std::hash::{Hash, Hasher};
 use std::sync::atomic::{AtomicUsize, Ordering};
+
+/// Hash identifying a content-addressable KV block. Computed from a chain
+/// of (parent_hash, block_tokens) — see [`block_hash_chain`].
+pub type BlockHash = u64;
+
+/// Compute the hash for one block, chained from its parent.
+///
+/// `parent` is the hash of the preceding block (0 for the first block).
+/// `tokens` are the `block_size` token ids in this block.
+///
+/// Uses Rust's default `SipHasher` for collision resistance with no extra
+/// deps. SipHash at ~1 GB/s processes a 16-token block (64 bytes) in tens
+/// of ns; per-request hashing of <200 blocks is well under a microsecond
+/// — invisible next to a prefill kernel.
+pub fn block_hash(parent: BlockHash, tokens: &[TokenId]) -> BlockHash {
+    let mut h = std::collections::hash_map::DefaultHasher::new();
+    parent.hash(&mut h);
+    for t in tokens {
+        t.get().hash(&mut h);
+    }
+    h.finish()
+}
+
+/// Compute the chained hash sequence for a token list, broken into
+/// `block_size`-token blocks. Trailing partial block (length <
+/// `block_size`) is dropped — partial blocks can't be looked up
+/// independently since their content depends on what gets appended next.
+pub fn block_hash_chain(tokens: &[TokenId], block_size: usize) -> Vec<BlockHash> {
+    let n = tokens.len() / block_size;
+    let mut out = Vec::with_capacity(n);
+    let mut parent: BlockHash = 0;
+    for chunk in tokens.chunks_exact(block_size) {
+        parent = block_hash(parent, chunk);
+        out.push(parent);
+    }
+    out
+}
 
 /// LIFO free-list block allocator. `O(1)` allocate / free, no fragmentation
 /// (all blocks are uniform size).
@@ -58,12 +110,25 @@ pub struct BlockAllocator {
     /// pool-sizing diagnostics in the bench harness.
     peak_in_use: AtomicUsize,
     /// Per-block reference count. `ref_counts[i] == 0` ⟺ block i is on
-    /// the free list. `allocate` sets to 1; `acquire` increments;
+    /// the free list (either freshly-uninitialized or soft-free with a
+    /// hash still registered). `allocate` sets to 1; `acquire` increments;
     /// `free` decrements and (only when reaching 0) returns the block
     /// to the free list. Width 16 bits — supports up to 65535 concurrent
     /// sharers of the same physical KV block, far past any realistic
     /// continuous batching cap.
     ref_counts: Vec<u16>,
+    /// Block-hash lookup. Contains entries for every block whose content
+    /// has been hash-registered via [`Self::register_block_hash`] — both
+    /// live (ref ≥ 1) and soft-free (ref = 0 but content not yet
+    /// overwritten). [`Self::try_acquire_by_hash`] hits this map; on hit
+    /// the entry is resurrected with ref = 1 if it was soft-free.
+    /// Survives across requests — this is what makes the prefix cache
+    /// actually useful.
+    hash_table: HashMap<BlockHash, u32>,
+    /// Reverse map block_id → hash, for cleanup. When a block's content
+    /// gets overwritten by `allocate` returning it on a fresh request,
+    /// we use this to erase its stale hash from `hash_table`.
+    block_to_hash: Vec<Option<BlockHash>>,
 }
 
 impl BlockAllocator {
@@ -79,6 +144,8 @@ impl BlockAllocator {
             capacity: num_blocks,
             peak_in_use: AtomicUsize::new(0),
             ref_counts: vec![0u16; num_blocks as usize],
+            hash_table: HashMap::new(),
+            block_to_hash: vec![None; num_blocks as usize],
         }
     }
 
@@ -97,6 +164,9 @@ impl BlockAllocator {
                     "allocate yielded block {b} with non-zero ref_count {}",
                     self.ref_counts[b as usize]
                 );
+                // Soft-free block with a stale hash → content will be
+                // overwritten, so erase the hash mapping.
+                self.evict_hash_if_any(b);
                 self.ref_counts[b as usize] = 1;
                 let in_use = self.capacity as usize - self.free_list.len();
                 self.peak_in_use.fetch_max(in_use, Ordering::Relaxed);
@@ -106,6 +176,22 @@ impl BlockAllocator {
                 "paged KV pool exhausted (capacity={} blocks, all in use)",
                 self.capacity
             ))),
+        }
+    }
+
+    /// Internal: erase any hash mapping for a block whose content is
+    /// about to be overwritten. No-op if the block had no hash registered.
+    fn evict_hash_if_any(&mut self, block: u32) {
+        if let Some(h) = self.block_to_hash[block as usize].take() {
+            // Only erase from hash_table if it still points at THIS block.
+            // (Defensive — a hash collision later registering the same h
+            // to a different block could mean the entry now points
+            // elsewhere; we shouldn't yank the live one.)
+            if let Some(&mapped) = self.hash_table.get(&h) {
+                if mapped == block {
+                    self.hash_table.remove(&h);
+                }
+            }
         }
     }
 
@@ -125,12 +211,75 @@ impl BlockAllocator {
                 self.ref_counts[b as usize] == 0,
                 "allocate_n yielded block {b} with non-zero ref_count"
             );
+            self.evict_hash_if_any(b);
             self.ref_counts[b as usize] = 1;
             out.push(b);
         }
         let in_use = self.capacity as usize - self.free_list.len();
         self.peak_in_use.fetch_max(in_use, Ordering::Relaxed);
         Ok(out)
+    }
+
+    /// Look up a hash in the prefix-cache table. If the hash maps to a
+    /// physical block (live or soft-free), bump its ref count and return
+    /// the block id. A soft-free block (ref=0 in free_list) is
+    /// resurrected — pulled out of the free list and ref set to 1.
+    /// Returns `None` on cache miss.
+    pub fn try_acquire_by_hash(&mut self, hash: BlockHash) -> Option<u32> {
+        let &block = self.hash_table.get(&hash)?;
+        let bi = block as usize;
+        if self.ref_counts[bi] == 0 {
+            // Soft-free: pull out of free_list (O(n) on free_list length;
+            // typically small — few hundred at peak utilisation).
+            if let Some(pos) = self.free_list.iter().rposition(|&b| b == block) {
+                self.free_list.swap_remove(pos);
+            } else {
+                // Inconsistency: ref=0 but not in free_list. Shouldn't
+                // happen unless someone bypassed the API. Treat as miss
+                // to avoid corruption.
+                debug_assert!(false, "block {block} has ref=0 but not in free_list");
+                return None;
+            }
+            self.ref_counts[bi] = 1;
+            let in_use = self.capacity as usize - self.free_list.len();
+            self.peak_in_use.fetch_max(in_use, Ordering::Relaxed);
+        } else {
+            self.acquire(block);
+        }
+        Some(block)
+    }
+
+    /// Associate a hash with a block (after its content is written).
+    /// If the block already had a hash, the old mapping is replaced.
+    /// Block must currently be live (ref ≥ 1).
+    pub fn register_block_hash(&mut self, block: u32, hash: BlockHash) {
+        let bi = block as usize;
+        debug_assert!(
+            self.ref_counts[bi] > 0,
+            "register_block_hash on block {block} with ref_count=0 (not allocated)"
+        );
+        // Replace prior hash if any.
+        if let Some(old_h) = self.block_to_hash[bi].replace(hash) {
+            if old_h != hash {
+                if let Some(&mapped) = self.hash_table.get(&old_h) {
+                    if mapped == block {
+                        self.hash_table.remove(&old_h);
+                    }
+                }
+            } else {
+                // Same hash being re-registered; nothing to clean up.
+                return;
+            }
+        }
+        // Last-writer-wins on collision (same hash different content —
+        // SipHash collisions on 64-token inputs are astronomically rare).
+        self.hash_table.insert(hash, block);
+    }
+
+    /// Read accessor for tests / debugging.
+    #[inline]
+    pub fn hash_table_size(&self) -> usize {
+        self.hash_table.len()
     }
 
     /// Increment the ref count for an already-allocated block. Used by
@@ -402,5 +551,109 @@ mod tests {
         assert_eq!(a.free_count(), 5);
         a.free(&blocks); // each ref=0, all released
         assert_eq!(a.free_count(), 8);
+    }
+
+    // ── Phase 2: hash table tests ────────────────────────────────────────
+
+    fn toks(ids: &[u32]) -> Vec<TokenId> {
+        ids.iter().map(|&i| TokenId::new(i)).collect()
+    }
+
+    #[test]
+    fn block_hash_chain_basic() {
+        let tokens = toks(&[1, 2, 3, 4, 5, 6, 7, 8]);
+        let chain = block_hash_chain(&tokens, 4);
+        assert_eq!(chain.len(), 2);
+        // Identical second block must produce a DIFFERENT chained hash
+        // because its parent (first block) is the same here but the
+        // chain order forces hash[1] = h(hash[0], tokens[4..8]).
+        assert_ne!(chain[0], chain[1]);
+    }
+
+    #[test]
+    fn block_hash_chain_identical_prefix_same_hashes() {
+        let a = toks(&[10, 20, 30, 40, 50, 60, 70, 80]);
+        let b = toks(&[10, 20, 30, 40, 99, 99, 99, 99]);
+        let ca = block_hash_chain(&a, 4);
+        let cb = block_hash_chain(&b, 4);
+        assert_eq!(ca[0], cb[0], "first block matches → same hash[0]");
+        assert_ne!(ca[1], cb[1], "second block differs → different hash[1]");
+    }
+
+    #[test]
+    fn block_hash_chain_drops_partial_trailing() {
+        let tokens = toks(&[1, 2, 3, 4, 5, 6, 7]); // 7 tokens, block_size=4 → 1 full
+        let chain = block_hash_chain(&tokens, 4);
+        assert_eq!(chain.len(), 1);
+    }
+
+    #[test]
+    fn hash_table_register_and_acquire_live() {
+        let mut a = BlockAllocator::new(4);
+        let b = a.allocate().unwrap();
+        let h = 0xDEAD_BEEFu64;
+        a.register_block_hash(b, h);
+        assert_eq!(a.hash_table_size(), 1);
+        // Re-acquire by hash: must bump ref (block is live)
+        let got = a.try_acquire_by_hash(h);
+        assert_eq!(got, Some(b));
+        assert_eq!(a.ref_count(b), 2);
+    }
+
+    #[test]
+    fn hash_table_soft_free_resurrection() {
+        let mut a = BlockAllocator::new(4);
+        let b = a.allocate().unwrap();
+        let h = 0xABCD_1234u64;
+        a.register_block_hash(b, h);
+        a.free(&[b]); // ref=0, block in free_list, hash STILL registered
+        assert_eq!(a.free_count(), 4);
+        assert_eq!(a.ref_count(b), 0);
+        // Cache hit on the soft-free block: must resurrect with ref=1
+        let got = a.try_acquire_by_hash(h);
+        assert_eq!(got, Some(b));
+        assert_eq!(a.ref_count(b), 1);
+        // The block is OFF the free_list now.
+        assert_eq!(a.free_count(), 3);
+    }
+
+    #[test]
+    fn hash_table_miss_returns_none() {
+        let mut a = BlockAllocator::new(4);
+        let b = a.allocate().unwrap();
+        a.register_block_hash(b, 1);
+        assert_eq!(a.try_acquire_by_hash(99), None);
+        // No side effects on miss
+        assert_eq!(a.ref_count(b), 1);
+    }
+
+    #[test]
+    fn hash_table_evicts_on_realloc() {
+        // Allocate, register hash, free → soft-free with hash. Then
+        // allocate a new block — the recycled one's hash must be erased
+        // because its content is about to be overwritten.
+        let mut a = BlockAllocator::new(2);
+        let b1 = a.allocate().unwrap();
+        let h = 0x1234u64;
+        a.register_block_hash(b1, h);
+        a.free(&[b1]); // soft-free
+        assert_eq!(a.hash_table_size(), 1);
+        // Allocate to consume the only free block — should recycle b1
+        // and evict its hash.
+        let b2 = a.allocate().unwrap();
+        assert_eq!(b2, b1, "LIFO should reuse b1");
+        assert_eq!(a.hash_table_size(), 0, "stale hash erased on realloc");
+        assert_eq!(a.try_acquire_by_hash(h), None);
+    }
+
+    #[test]
+    fn hash_table_replace_block_hash() {
+        let mut a = BlockAllocator::new(4);
+        let b = a.allocate().unwrap();
+        a.register_block_hash(b, 1);
+        a.register_block_hash(b, 2); // overwrite
+        assert_eq!(a.hash_table_size(), 1);
+        assert_eq!(a.try_acquire_by_hash(1), None);
+        assert_eq!(a.try_acquire_by_hash(2), Some(b));
     }
 }


### PR DESCRIPTION
Stacked on merged #178. See #179 for full context (closed because base branch was deleted on merge). Block hash chain + global hash→block_id table for prefix cache phase 2. 17/17 tests pass.