### PR TITLE
test(bench): apples-all driver + 2026-05-13 report

### DIFF
--- a/bench/v0.2-cuda/REPORT_2026-05-13.md
+++ b/bench/v0.2-cuda/REPORT_2026-05-13.md
@@ -1,0 +1,96 @@
+# Apples-to-apples Bench Report — 2026-05-13
+
+**Build**: main @ `ac4b32d` (after merging PRs #176, #178, #181, #182, #177)
+**Hardware**: Vast.ai RTX 4090 (sm_89, 24GB)
+**Methodology**: `vllm bench serve --backend openai-chat`, ShareGPT V3 subset, c=1/4/16/32, 1 repeat
+**Driver**: `bench/v0.2-cuda/apples_all_drive.sh`
+
+vLLM 0.20.2 server args (apples baseline):
+```
+vllm serve <model> --port 8800 --max-num-seqs 64 --max-model-len 4096 \
+  --no-enable-prefix-caching --no-enable-log-requests [--quantization gptq_marlin if INT4]
+```
+
+ferrum server env (matches `apples_m3_drive.sh` ferrum_start block).
+
+---
+
+## M2 — Llama-3.1-8B-GPTQ-INT4 (dense INT4)
+
+| c | vllm tok/s | ferrum tok/s | ratio | TPOT_p50 (ms) ferrum/vllm |
+|---|---:|---:|---:|---:|
+| 1  | 147.7  | 116.4  | 79% | 8.10 / 6.61 |
+| 4  | 475.5  | 354.2  | 74% | 9.76 / 7.04 |
+| 16 | 1433.4 | 704.6  | **49%** | 18.2 / 11.2 |
+| 32 | 2179.2 | 825.2  | **38%** | 32.5 / 13.8 |
+
+**Baseline (2026-05-07 @ c6a81d9, CLAUDE.md):**
+- c=1: 111 / c=4: 369 / c=16: 964 / c=32: 1215
+
+**M2 regression analysis**:
+- c=1 / c=4: within noise (+5% / -4%)
+- **c=16: 964 → 704 = -27%** ★
+- **c=32: 1215 → 825 = -32%** ★★
+
+vLLM stable (2204 → 2179). ferrum dense path regressed substantially since c6a81d9. Likely culprits: Architecture v2 Backend-trait refactor, Dim 5 KV dtype refactor, or one of the many cross-crate splits. **Action: bisect and fix.**
+
+## M3 — Qwen3-30B-A3B-GPTQ-Int4 (MoE INT4)
+
+| c | vllm tok/s | ferrum tok/s | ratio | TPOT_p50 (ms) ferrum/vllm |
+|---|---:|---:|---:|---:|
+| 1  | 205.4  | 108.8  | 53% | 56.3 / 4.7 |
+| 4  | 505.8  | 317.7  | 63% | 11.1 / 7.6 |
+| 16 | 1253.2 | 805.2  | 64% | 15.0 / 12.1 |
+| 32 | 1883.2 | 1044.2 | 55% | 29.3 / 16.0 |
+
+**Baseline (2026-05-12 @ 4a17a17, memory `project_cuda_perf_2026_05_12_session.md`):**
+- c=1: 143 / c=4: 329 / c=16: 788 / c=32: 1038
+
+**M3 delta**:
+- c=1: 143 → 109 = **-24%** ★
+- c=4: 329 → 318 = -3% (noise)
+- c=16: 788 → 805 = +2% (dynamic moe_block_size landed)
+- c=32: 1038 → 1044 = +1% (no regression — dynamic block_size picks 16 for diverse routing)
+
+c=1 regression on M3 needs investigation. TPOT_p50 56ms / p99 199ms at c=1 suggests an outlier in one of the 4 prompts (likely the longest prompt's prefill latency). Not a sustained per-iter slowdown.
+
+## Prefix cache (shared-prefix workload)
+
+Separate apples bench, same client, custom shared-prefix dataset (128 prompts × 200-tok shared system msg + unique 5-tok user q):
+
+|  | out tok/s | TPOT p99 | TTFT |
+|---|---:|---:|---:|
+| ferrum CACHE_OFF | 1333.2 | 26.5 ms | 536 ms |
+| **ferrum CACHE_ON** | **1649.7** | 586 ms | **147 ms** |
+| vLLM CACHE_OFF | 1871.9 | 17.6 ms | 243 ms |
+| vLLM CACHE_ON | 1893.9 | 16.9 ms | 243 ms |
+
+ferrum prefix cache: **+23.7% throughput, -73% TTFT**. vLLM's prefix cache in this regime: +1% (doesn't populate fast enough in 128-concurrent cold-start dispatch). All NO seeding / cold-start. PR #182 (#180 ex).
+
+## Closing-gap matrix
+
+|   | c=1 | c=4 | c=16 | c=32 |
+|---|---|---|---|---|
+| M2 (dense) | 79% | 74% | 49% ↓ | 38% ↓↓ |
+| M3 (MoE) | 53% | 63% | 64% | 55% |
+
+ferrum closer to vLLM on M3 than on M2 — opposite of intuition (MoE is harder). Suggests the dense Marlin path on M2 has regressed somewhere recently. M3 numbers stable around their tracked target.
+
+## Notable kernel-time anomalies
+
+- **M2 c=32 TPOT 32.5 ms vs vLLM 13.8 ms (2.4×)** — too high to explain by any single kernel; likely batching density or schedule.
+- **M3 c=1 TPOT_p50 56 ms** — 1 token bench, probably one slow prompt dominating; reruns advisable.
+- **ferrum p99 / p50 ratios**: M3 c=1 = 199/56 = 3.5× spread. ShareGPT prompts vary in length (128 tokens to 580 tokens), and cold-start prefills the first prompts get full prefill while later may benefit from JIT warmup.
+
+## Action items
+
+1. **M2 c=16/c=32 perf regression** — Block-bisect main back to c6a81d9 (2026-05-07) to identify the regression commit. Likely dense Marlin / qkv dispatch path.
+2. **M3 c=1 outlier** — Re-run with 3 repeats to confirm if 109 tok/s is sticky or noise; the published c=1=143 baseline.
+3. **Prefix-cache p99 spike on cold start** — initial 32 concurrent requests all miss cache → simultaneous prefill thundering herd. Stagger admission to amortize the first prefill before the rest fire.
+
+## Where to find data
+
+- Raw JSON: `bench/v0.2-cuda/results/{vllm,ferrum}__{M2,M3}__c{1,4,16,32}__r1.json`
+- Server logs: `bench/v0.2-cuda/results/{vllm,ferrum}__{M2,M3}__r1.server.log`
+- Driver: `bench/v0.2-cuda/apples_all_drive.sh`
+- Summary tool: `python3 bench/v0.2-cuda/summary.py`

--- a/bench/v0.2-cuda/apples_all_drive.sh
+++ b/bench/v0.2-cuda/apples_all_drive.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# Apples-to-apples sweep across M1 (FP16) / M2 (INT4 dense) / M3 (INT4 MoE).
+# Uses the same env-rich ferrum config as apples_m3_drive.sh, but parameterized
+# per model (MoE-specific knobs only when arch=MoE).
+#
+# Models selected via MODELS env: "M1 M2 M3" by default.
+# Concurrencies fixed at 1/4/16/32, 1 repeat per cell.
+
+set -uo pipefail
+export PATH=/root/.cargo/bin:/usr/local/cuda/bin:$PATH
+export CUDA_HOME=/usr/local/cuda
+cd /workspace/ferrum-infer-rs
+
+MODELS="${MODELS:-M2 M1 M3}"  # M2 first (smallest), M3 last (largest)
+CONCURRENCIES="${CONCURRENCIES:-1 4 16 32}"
+
+pkill -9 -f "vllm.entrypoints" 2>/dev/null || true
+pkill -9 -f "ferrum.*serve"    2>/dev/null || true
+pkill -9 -f "vllm serve"       2>/dev/null || true
+pkill -9 -f "VLLM"             2>/dev/null || true
+sleep 5
+
+vllm_args_for_model() {
+    local tag="$1"
+    # M1 = FP16 (no quantization flag), M2/M3 = GPTQ marlin
+    case "$tag" in
+        M1) echo "--max-num-seqs 64 --max-model-len 4096 --no-enable-prefix-caching --no-enable-log-requests" ;;
+        M2|M3) echo "--max-num-seqs 64 --max-model-len 4096 --no-enable-prefix-caching --no-enable-log-requests --quantization gptq_marlin" ;;
+        *) echo ""; return 1 ;;
+    esac
+}
+
+ferrum_env_for_model() {
+    local tag="$1"
+    # Common env. MoE-specific knobs only matter for M3 but are harmless on dense.
+    cat <<EOF
+CUDA_VISIBLE_DEVICES=0
+FERRUM_KV_CAPACITY=2048
+FERRUM_KV_MAX_BLOCKS=4096
+FERRUM_PAGED_MAX_SEQS=32
+FERRUM_METAL_PAGED_KV=1
+FERRUM_GREEDY_ARGMAX=1
+FERRUM_MARLIN_SKIP_WS_ZERO=1
+EOF
+    if [ "$tag" = "M3" ]; then
+        cat <<EOF
+FERRUM_VLLM_MOE=1
+FERRUM_MOE_BUCKETED=1
+FERRUM_MOE_STREAMS=4
+FERRUM_MOE_BATCH_THRESHOLD=4
+FERRUM_MOE_GRAPH=1
+FERRUM_GRAPH_SKIP_UPLOAD=1
+EOF
+    fi
+}
+
+run_model() {
+    local TAG="$1"
+    local MODEL_DIR="/workspace/models/$TAG"
+    if [ ! -e "$MODEL_DIR" ]; then
+        echo "[!! ] $TAG not found at $MODEL_DIR — skipping"
+        return 0
+    fi
+
+    # ── vLLM half ───────────────────────────────────────────
+    echo
+    echo "============================================="
+    echo "[$TAG] vllm"
+    echo "============================================="
+    pkill -9 -f "vllm" 2>/dev/null || true
+    pkill -9 -f "VLLM" 2>/dev/null || true
+    sleep 5
+    source /workspace/vllm-venv/bin/activate
+    PORT=8800
+    SERVER_LOG="bench/v0.2-cuda/results/vllm__${TAG}__r1.server.log"
+    local vargs="$(vllm_args_for_model "$TAG")"
+    CUDA_VISIBLE_DEVICES=0 \
+      vllm serve "$MODEL_DIR" --port "$PORT" $vargs \
+      > "$SERVER_LOG" 2>&1 &
+    VPID=$!
+    for i in $(seq 1 600); do
+        curl -sf "http://127.0.0.1:$PORT/v1/models" >/dev/null 2>&1 && { echo "[vllm] ready in ${i}s"; break; }
+        ! kill -0 "$VPID" 2>/dev/null && { echo "[vllm] died"; tail -50 "$SERVER_LOG"; return 1; }
+        sleep 1
+    done
+    curl -sf -m 60 -X POST "http://127.0.0.1:$PORT/v1/chat/completions" \
+        -H "Content-Type: application/json" \
+        -d "{\"model\":\"$MODEL_DIR\",\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}],\"max_tokens\":4,\"temperature\":0}" > /dev/null || true
+    for c in $CONCURRENCIES; do
+        echo "--- [vllm/$TAG] cell c=$c ---"
+        rm -f bench/v0.2-cuda/results/vllm__${TAG}__c${c}__r1.*
+        bash bench/v0.2-cuda/run_cell.sh vllm "$TAG" "$c" 1 "$PORT" 2>&1 | tail -3 || echo "  (cell failed)"
+    done
+    kill -INT "$VPID" 2>/dev/null; wait "$VPID" 2>/dev/null || true
+    pkill -9 -f "vllm" 2>/dev/null || true
+    pkill -9 -f "VLLM" 2>/dev/null || true
+    deactivate 2>/dev/null || true
+    sleep 5
+
+    # ── ferrum half ───────────────────────────────────────────
+    echo
+    echo "============================================="
+    echo "[$TAG] ferrum"
+    echo "============================================="
+    PORT=8801
+    SERVER_LOG="bench/v0.2-cuda/results/ferrum__${TAG}__r1.server.log"
+    local env_vars=""
+    while IFS= read -r line; do
+        [ -n "$line" ] && env_vars="$env_vars $line"
+    done < <(ferrum_env_for_model "$TAG")
+    eval "$env_vars /workspace/ferrum-infer-rs/target/release/ferrum serve \
+        --model \"$MODEL_DIR\" --port \"$PORT\" \
+        --gpu-memory-utilization 0.95" > "$SERVER_LOG" 2>&1 &
+    FPID=$!
+    for i in $(seq 1 240); do
+        curl -sf "http://127.0.0.1:$PORT/v1/models" >/dev/null 2>&1 && { echo "[ferrum] ready in ${i}s"; break; }
+        ! kill -0 "$FPID" 2>/dev/null && { echo "[ferrum] died"; tail -50 "$SERVER_LOG"; return 1; }
+        sleep 1
+    done
+    curl -sf -m 60 -X POST "http://127.0.0.1:$PORT/v1/chat/completions" \
+        -H "Content-Type: application/json" \
+        -d '{"model":"x","messages":[{"role":"user","content":"hi"}],"max_tokens":4,"temperature":0}' > /dev/null
+    source /workspace/vllm-venv/bin/activate
+    for c in $CONCURRENCIES; do
+        echo "--- [ferrum/$TAG] cell c=$c ---"
+        rm -f bench/v0.2-cuda/results/ferrum__${TAG}__c${c}__r1.*
+        bash bench/v0.2-cuda/run_cell.sh ferrum "$TAG" "$c" 1 "$PORT" 2>&1 | tail -3 || echo "  (cell failed)"
+    done
+    kill -INT "$FPID" 2>/dev/null; wait "$FPID" 2>/dev/null || true
+    pkill -9 -f "ferrum.*serve" 2>/dev/null || true
+    sleep 3
+}
+
+for TAG in $MODELS; do
+    run_model "$TAG"
+done
+
+echo
+echo "============================================="
+echo "Summary"
+echo "============================================="
+printf '%-8s %-3s %12s %12s\n' engine c "out_tps" "TPOT_p50_ms"
+for engine in vllm ferrum; do
+    for TAG in $MODELS; do
+        for c in $CONCURRENCIES; do
+            F="bench/v0.2-cuda/results/${engine}__${TAG}__c${c}__r1.json"
+            if [ -f "$F" ]; then
+                python3 -c "
+import json
+d = json.load(open('$F'))
+print(f\"{'${engine}':8s} ${TAG} c=${c:>2} out={d.get('output_throughput',0):8.1f} tok/s  p50={d.get('mean_tpot_ms',0):6.2f}ms\")
+"
+            fi
+        done
+    done
+done

--- a/bench/v0.2-cuda/bisect_m2.sh
+++ b/bench/v0.2-cuda/bisect_m2.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# Bisect helper: build ferrum at given commit, run M2 c=32 bench, output tok/s.
+# Usage: bisect_m2.sh <commit-sha>
+set -e
+cd /workspace/ferrum-infer-rs
+SHA="$1"
+[ -z "$SHA" ] && { echo "usage: $0 <sha>"; exit 1; }
+
+echo "[bisect] checkout $SHA"
+git stash 2>&1 | tail -1 || true
+git checkout "$SHA" 2>&1 | tail -1
+
+echo "[bisect] cargo build (incremental)..."
+source /root/.cargo/env
+cargo build --release --features cuda,vllm-moe-marlin -p ferrum-cli --bin ferrum 2>&1 | tail -2
+
+# kill any stragglers
+pkill -9 -f "ferrum.*serve" 2>/dev/null || true
+pkill -9 -f "vllm" 2>/dev/null || true
+pkill -9 -f "VLLM" 2>/dev/null || true
+sleep 3
+
+echo "[bisect] starting ferrum on M2..."
+PORT=8801
+LOG=/tmp/bisect_m2.log
+CUDA_VISIBLE_DEVICES=0 \
+FERRUM_KV_CAPACITY=2048 FERRUM_KV_MAX_BLOCKS=4096 \
+FERRUM_PAGED_MAX_SEQS=32 FERRUM_METAL_PAGED_KV=1 FERRUM_GREEDY_ARGMAX=1 \
+FERRUM_MARLIN_SKIP_WS_ZERO=1 \
+  /workspace/ferrum-infer-rs/target/release/ferrum serve \
+    --model /workspace/models/M2 --port "$PORT" \
+    --gpu-memory-utilization 0.95 \
+  > "$LOG" 2>&1 &
+FPID=$!
+for i in $(seq 1 180); do
+    curl -sf "http://127.0.0.1:$PORT/v1/models" >/dev/null 2>&1 && { echo "[bisect] ready in ${i}s"; break; }
+    ! kill -0 $FPID 2>/dev/null && { echo "[bisect] FERRUM DIED"; tail -50 "$LOG"; exit 2; }
+    sleep 1
+done
+curl -sf -m 60 -X POST "http://127.0.0.1:$PORT/v1/chat/completions" \
+    -H "Content-Type: application/json" \
+    -d '{"model":"x","messages":[{"role":"user","content":"hi"}],"max_tokens":4,"temperature":0}' > /dev/null
+
+source /workspace/vllm-venv/bin/activate
+RES=bench/v0.2-cuda/results/bisect__M2__c32__${SHA}.json
+rm -f bench/v0.2-cuda/results/bisect__M2__c32__${SHA}.*
+
+bash bench/v0.2-cuda/run_cell.sh ferrum M2 32 "bisect_${SHA}" "$PORT" 2>&1 | tail -3
+
+kill -INT $FPID 2>/dev/null; sleep 3
+pkill -9 -f "ferrum.*serve" 2>/dev/null || true
+
+# Print result
+F="bench/v0.2-cuda/results/ferrum__M2__c32__rbisect_${SHA}.json"
+if [ -f "$F" ]; then
+    python3 -c "
+import json
+d = json.load(open('$F'))
+print(f\"[bisect] $SHA: out={d.get('output_throughput',0):.1f} tok/s TPOT_p50={d.get('mean_tpot_ms',0):.2f}ms\")
+"
+else
+    echo "[bisect] NO RESULT FILE"
+fi

--- a/bench/v0.2-cuda/summary.py
+++ b/bench/v0.2-cuda/summary.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+"""Pretty-print bench results from JSON files in this directory."""
+import json
+import glob
+import os
+import sys
+
+results_dir = sys.argv[1] if len(sys.argv) > 1 else os.path.dirname(os.path.abspath(__file__)) + "/results"
+patterns = sys.argv[2:] if len(sys.argv) > 2 else ["*__r1.json"]
+for pat in patterns:
+    for f in sorted(glob.glob(os.path.join(results_dir, pat))):
+        try:
+            d = json.load(open(f))
+        except Exception:
+            continue
+        name = os.path.basename(f).replace(".json", "")
+        tps = d.get("output_throughput", 0)
+        p50 = d.get("mean_tpot_ms", 0)
+        p99 = d.get("p99_tpot_ms", 0)
+        ttft = d.get("mean_ttft_ms", 0)
+        ok = d.get("completed", 0)
+        fail = d.get("failed", 0)
+        print(f"{name:32s} out={tps:8.1f} tok/s  TPOT={p50:6.2f}/{p99:7.2f} ms  TTFT={ttft:6.0f} ms  ok={ok}/{ok+fail}")


### PR DESCRIPTION
## Summary

Lands the bench tooling and report from the 2026-05-13 apples-to-apples session:

- `bench/v0.2-cuda/apples_all_drive.sh` — unified M1/M2/M3 sweep with one env block
- `bench/v0.2-cuda/summary.py` — JSON results → markdown table
- `bench/v0.2-cuda/bisect_m2.sh` — single-commit M2 c=32 driver for hunting the dense regression
- `bench/v0.2-cuda/REPORT_2026-05-13.md` — headline: M2 c=32 ferrum 825 vs vLLM 2179 = 38% (regressed from 2026-05-07's 1215); M3 c=32 = 55% (stable); prefix cache +24% / -73% TTFT

Pure bench/docs — no Rust code touched.

## Test plan

- [x] `cargo check --workspace` clean (no source changes)
- [x] `apples_all_drive.sh` exercised on Vast 4090 (results in `bench/v0.2-cuda/results/*r1*`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)