### PR TITLE
feat(cli): --output-format jsonl + chat smoke tests (PR 1/6)

### DIFF
--- a/crates/ferrum-cli/src/commands/run.rs
+++ b/crates/ferrum-cli/src/commands/run.rs
@@ -2,10 +2,10 @@
 
 use crate::config::CliConfig;
 use chrono::Utc;
-use clap::Args;
+use clap::{Args, ValueEnum};
 use colored::*;
 use ferrum_models::source::{ModelFormat, ResolvedModelSource};
-use ferrum_types::{InferenceRequest, Priority, RequestId, Result, SamplingParams};
+use ferrum_types::{FinishReason, InferenceRequest, Priority, RequestId, Result, SamplingParams};
 use futures::StreamExt;
 use std::collections::HashMap;
 use std::io::{self, BufRead, IsTerminal, Write};
@@ -13,6 +13,75 @@ use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use uuid::Uuid;
+
+/// Output format for `ferrum run`. JSONL mode emits one record per event
+/// (assistant generation result, user input, exit) on stdout — used by
+/// integration tests and scripting. Text mode is the default interactive UX.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum, Default)]
+pub enum OutputFormat {
+    /// Streaming text on stdout, stats on stderr (default — interactive UX).
+    #[default]
+    Text,
+    /// One JSON record per event on stdout (machine-readable; tests).
+    Jsonl,
+}
+
+fn finish_reason_str(r: FinishReason) -> &'static str {
+    match r {
+        FinishReason::Length => "length",
+        FinishReason::Stop => "stop",
+        FinishReason::EOS => "eos",
+        FinishReason::Cancelled => "cancelled",
+        FinishReason::Error => "error",
+        FinishReason::ContentFilter => "content_filter",
+    }
+}
+
+fn emit_jsonl_ready(model: &str, backend: &str) {
+    let record = serde_json::json!({
+        "event": "ready",
+        "model": model,
+        "backend": backend,
+    });
+    println!("{record}");
+}
+
+fn emit_jsonl_user(turn: usize, content: &str) {
+    let record = serde_json::json!({
+        "event": "user",
+        "turn": turn,
+        "content": content,
+    });
+    println!("{record}");
+}
+
+fn emit_jsonl_assistant(
+    turn: usize,
+    content: &str,
+    finish_reason: Option<FinishReason>,
+    n_tokens: usize,
+    chunk_count: usize,
+    ms: f64,
+) {
+    let record = serde_json::json!({
+        "event": "assistant",
+        "turn": turn,
+        "content": content,
+        "finish_reason": finish_reason.map(finish_reason_str),
+        "n_tokens": n_tokens,
+        "chunk_count": chunk_count,
+        "ms": ms,
+    });
+    println!("{record}");
+}
+
+fn emit_jsonl_exit(reason: &str) {
+    let record = serde_json::json!({
+        "event": "exit",
+        "reason": reason,
+    });
+    println!("{record}");
+}
 
 #[derive(Args)]
 pub struct RunCommand {
@@ -98,6 +167,11 @@ pub struct RunCommand {
     /// Override via `FERRUM_KV_DTYPE` env var.
     #[arg(long, value_name = "DTYPE")]
     pub kv_dtype: Option<String>,
+
+    /// Output format. `text` (default) — streaming text + stats UX.
+    /// `jsonl` — one JSON record per event on stdout; used by tests and scripts.
+    #[arg(long, value_enum, default_value_t = OutputFormat::Text)]
+    pub output_format: OutputFormat,
 }
 
 pub async fn execute(cmd: RunCommand, config: CliConfig) -> Result<()> {
@@ -135,7 +209,8 @@ pub async fn execute(cmd: RunCommand, config: CliConfig) -> Result<()> {
 
     // Select device
     let device = select_device(&cmd.backend);
-    eprintln!("{}", format!("Using {:?} backend", device).dimmed());
+    let device_label = format!("{device:?}");
+    eprintln!("{}", format!("Using {device_label} backend").dimmed());
 
     // Create engine. Big-model loads (15-60 GB safetensors) are slow on
     // first run — print a hint so users don't think it's frozen. Per-
@@ -200,14 +275,26 @@ pub async fn execute(cmd: RunCommand, config: CliConfig) -> Result<()> {
         let mut stream = engine.infer_stream(request).await?;
         let start = std::time::Instant::now();
         let mut tokens = 0usize;
+        let mut content = String::new();
+        let mut chunk_count = 0usize;
+        let mut finish_reason: Option<FinishReason> = None;
+        let format = cmd.output_format;
+        let bench = cmd.bench_mode;
         while let Some(chunk) = stream.next().await {
             if let Ok(c) = chunk {
-                if !cmd.bench_mode {
-                    print!("{}", c.text);
-                    io::stdout().flush().ok();
+                if !c.text.is_empty() {
+                    chunk_count += 1;
+                    content.push_str(&c.text);
+                    if format == OutputFormat::Text && !bench {
+                        print!("{}", c.text);
+                        io::stdout().flush().ok();
+                    }
                 }
-                tokens += 1;
-                if c.finish_reason.is_some() {
+                if c.token.is_some() {
+                    tokens += 1;
+                }
+                if let Some(r) = c.finish_reason {
+                    finish_reason = Some(r);
                     break;
                 }
             }
@@ -218,25 +305,49 @@ pub async fn execute(cmd: RunCommand, config: CliConfig) -> Result<()> {
         } else {
             0.0
         };
-        if !cmd.bench_mode {
-            println!();
+        match format {
+            OutputFormat::Text => {
+                if !bench {
+                    println!();
+                }
+                eprintln!(
+                    "{}",
+                    format!("[{tokens} tokens, {tps:.1} tok/s, {elapsed:.1}s]").dimmed()
+                );
+            }
+            OutputFormat::Jsonl => {
+                emit_jsonl_assistant(
+                    0,
+                    &content,
+                    finish_reason,
+                    tokens,
+                    chunk_count,
+                    elapsed * 1000.0,
+                );
+            }
         }
-        eprintln!(
-            "{}",
-            format!("[{tokens} tokens, {tps:.1} tok/s, {elapsed:.1}s]").dimmed()
-        );
         return Ok(());
     }
 
     // Print ready message
-    eprintln!();
-    eprintln!("{}", "Ready. Type your message and press Enter.".green());
-    eprintln!("{}", "Use /bye or Ctrl+D to exit.".dimmed());
-    eprintln!();
+    let format = cmd.output_format;
+    match format {
+        OutputFormat::Text => {
+            eprintln!();
+            eprintln!("{}", "Ready. Type your message and press Enter.".green());
+            eprintln!("{}", "Use /bye or Ctrl+D to exit.".dimmed());
+            eprintln!();
+        }
+        OutputFormat::Jsonl => {
+            emit_jsonl_ready(&model_id, &device_label);
+        }
+    }
 
     // Interactive loop
     let mut history: Vec<(String, String)> = Vec::new(); // (role, content)
     let generating = Arc::new(AtomicBool::new(false));
+    let mut turn = 0usize;
+    let mut exit_reason: &str = "eof";
 
     // If stdin is not a TTY (piped input), don't print prompts and just consume lines.
     // This enables: `printf "hi\n/bye\n" | ferrum run ...` for automation/profiling.
@@ -260,7 +371,17 @@ pub async fn execute(cmd: RunCommand, config: CliConfig) -> Result<()> {
                     continue;
                 }
                 if input == "/bye" || input == "exit" || input == "quit" {
+                    exit_reason = match input {
+                        "/bye" => "bye",
+                        "exit" => "exit",
+                        "quit" => "quit",
+                        _ => "command",
+                    };
                     break;
+                }
+
+                if format == OutputFormat::Jsonl {
+                    emit_jsonl_user(turn, input);
                 }
 
                 // Build prompt with history
@@ -306,25 +427,40 @@ pub async fn execute(cmd: RunCommand, config: CliConfig) -> Result<()> {
                 let mut stream = engine.infer_stream(request).await?;
                 let mut response = String::new();
                 let start = std::time::Instant::now();
-                let mut token_count = 0;
+                let mut token_count = 0usize;
+                let mut chunk_count = 0usize;
+                let mut finish_reason: Option<FinishReason> = None;
 
                 while let Some(result) = stream.next().await {
                     match result {
                         Ok(chunk) => {
                             if !chunk.text.is_empty() {
-                                print!("{}", chunk.text);
-                                io::stdout().flush().unwrap();
+                                chunk_count += 1;
                                 response.push_str(&chunk.text);
+                                if format == OutputFormat::Text {
+                                    print!("{}", chunk.text);
+                                    io::stdout().flush().unwrap();
+                                }
                             }
                             if chunk.token.is_some() {
                                 token_count += 1;
                             }
-                            if chunk.finish_reason.is_some() {
+                            if let Some(r) = chunk.finish_reason {
+                                finish_reason = Some(r);
                                 break;
                             }
                         }
                         Err(e) => {
-                            eprintln!("\n{} {}", "Error:".red(), e);
+                            if format == OutputFormat::Text {
+                                eprintln!("\n{} {}", "Error:".red(), e);
+                            } else {
+                                let record = serde_json::json!({
+                                    "event": "error",
+                                    "turn": turn,
+                                    "message": e.to_string(),
+                                });
+                                println!("{record}");
+                            }
                             break;
                         }
                     }
@@ -332,25 +468,36 @@ pub async fn execute(cmd: RunCommand, config: CliConfig) -> Result<()> {
 
                 generating.store(false, Ordering::SeqCst);
 
-                // Print stats
                 let elapsed = start.elapsed();
-                let tps = if elapsed.as_secs_f64() > 0.0 {
-                    token_count as f64 / elapsed.as_secs_f64()
+                let elapsed_s = elapsed.as_secs_f64();
+                let tps = if elapsed_s > 0.0 {
+                    token_count as f64 / elapsed_s
                 } else {
                     0.0
                 };
-                println!();
-                eprintln!(
-                    "{}",
-                    format!(
-                        "[{} tokens, {:.1} tok/s, {:.1}s]",
-                        token_count,
-                        tps,
-                        elapsed.as_secs_f64()
-                    )
-                    .dimmed()
-                );
-                eprintln!();
+                let clean_response = response.trim().to_string();
+
+                match format {
+                    OutputFormat::Text => {
+                        println!();
+                        eprintln!(
+                            "{}",
+                            format!("[{token_count} tokens, {tps:.1} tok/s, {elapsed_s:.1}s]")
+                                .dimmed()
+                        );
+                        eprintln!();
+                    }
+                    OutputFormat::Jsonl => {
+                        emit_jsonl_assistant(
+                            turn,
+                            &clean_response,
+                            finish_reason,
+                            token_count,
+                            chunk_count,
+                            elapsed_s * 1000.0,
+                        );
+                    }
+                }
 
                 // In non-interactive mode, don't wait for terminal formatting/spacing.
                 if !stdin_is_tty {
@@ -360,7 +507,6 @@ pub async fn execute(cmd: RunCommand, config: CliConfig) -> Result<()> {
 
                 // Add to history
                 history.push(("user".to_string(), input.to_string()));
-                let clean_response = response.trim().to_string();
                 if !clean_response.is_empty() {
                     history.push(("assistant".to_string(), clean_response));
                 }
@@ -369,15 +515,24 @@ pub async fn execute(cmd: RunCommand, config: CliConfig) -> Result<()> {
                 while history.len() > 10 {
                     history.remove(0);
                 }
+                turn += 1;
             }
             Err(e) => {
                 eprintln!("{} {}", "Error reading input:".red(), e);
+                exit_reason = "read_error";
                 break;
             }
         }
     }
 
-    eprintln!("{}", "Goodbye!".bright_yellow());
+    match format {
+        OutputFormat::Text => {
+            eprintln!("{}", "Goodbye!".bright_yellow());
+        }
+        OutputFormat::Jsonl => {
+            emit_jsonl_exit(exit_reason);
+        }
+    }
     Ok(())
 }
 

--- a/crates/ferrum-cli/tests/chat_smoke.rs
+++ b/crates/ferrum-cli/tests/chat_smoke.rs
@@ -1,0 +1,236 @@
+//! Chat REPL smoke tests via `--output-format jsonl`.
+//!
+//! Drives `ferrum run` with stdin pipe + JSONL stdout, then asserts
+//! structural properties per turn. Catches the d67fbbb-class regressions:
+//! EOS / stop_sequences / stream / multi-turn KV / chat template.
+//!
+//! These tests load a real model and default to `#[ignore]` so a bare
+//! `cargo test` stays fast. Pre-pull the model once, then opt in:
+//!
+//!     ferrum pull qwen3:0.6b
+//!     cargo test -p ferrum-cli --features metal --test chat_smoke -- --ignored
+
+use serde_json::Value;
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+
+const SMOKE_MODEL: &str = "qwen3:0.6b";
+
+/// One JSONL record from `ferrum run --output-format jsonl`.
+#[derive(Debug)]
+struct ChatEvent {
+    raw: Value,
+}
+
+impl ChatEvent {
+    fn event(&self) -> &str {
+        self.raw["event"].as_str().unwrap_or("")
+    }
+    fn content(&self) -> Option<&str> {
+        self.raw["content"].as_str()
+    }
+    fn finish_reason(&self) -> Option<&str> {
+        self.raw["finish_reason"].as_str()
+    }
+}
+
+fn ferrum_bin() -> PathBuf {
+    if let Ok(bin) = std::env::var("CARGO_BIN_EXE_ferrum") {
+        return PathBuf::from(bin);
+    }
+    let current = std::env::current_exe().expect("test exe path");
+    let dir = current
+        .parent()
+        .and_then(|p| p.parent())
+        .expect("target dir");
+    let mut bin = dir.join("ferrum");
+    if cfg!(windows) {
+        bin.set_extension("exe");
+    }
+    assert!(bin.exists(), "ferrum binary not found at {}", bin.display());
+    bin
+}
+
+/// Spawn `ferrum run --output-format jsonl`, feed `stdin_lines` (one per line),
+/// then parse JSONL stdout into events. Panics on non-zero exit.
+fn run_chat(model: &str, system: Option<&str>, stdin_lines: &[&str]) -> Vec<ChatEvent> {
+    let mut cmd = Command::new(ferrum_bin());
+    cmd.args([
+        "run",
+        model,
+        "--output-format",
+        "jsonl",
+        "--temperature",
+        "0",
+        "--max-tokens",
+        "100",
+    ]);
+    if let Some(s) = system {
+        cmd.args(["--system", s]);
+    }
+    cmd.env("NO_COLOR", "1");
+    cmd.stdin(Stdio::piped());
+    cmd.stdout(Stdio::piped());
+    cmd.stderr(Stdio::piped());
+
+    let mut child = cmd.spawn().expect("spawn ferrum");
+    {
+        let stdin = child.stdin.as_mut().expect("child stdin");
+        for line in stdin_lines {
+            writeln!(stdin, "{line}").expect("write stdin");
+        }
+    }
+    let output = child.wait_with_output().expect("wait child");
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        panic!(
+            "ferrum run exited non-zero ({:?}); stderr:\n{stderr}",
+            output.status
+        );
+    }
+    parse_jsonl(&String::from_utf8_lossy(&output.stdout))
+}
+
+/// One-shot: `ferrum run <model> --prompt X --output-format jsonl`.
+fn run_chat_oneshot(model: &str, prompt: &str) -> Vec<ChatEvent> {
+    let mut cmd = Command::new(ferrum_bin());
+    cmd.args([
+        "run",
+        model,
+        "--output-format",
+        "jsonl",
+        "--temperature",
+        "0",
+        "--max-tokens",
+        "50",
+        "--prompt",
+        prompt,
+    ]);
+    cmd.env("NO_COLOR", "1");
+    cmd.stdout(Stdio::piped());
+    cmd.stderr(Stdio::piped());
+
+    let output = cmd.output().expect("run ferrum one-shot");
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        panic!("ferrum --prompt exited non-zero; stderr:\n{stderr}");
+    }
+    parse_jsonl(&String::from_utf8_lossy(&output.stdout))
+}
+
+fn parse_jsonl(stdout: &str) -> Vec<ChatEvent> {
+    stdout
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| {
+            let raw: Value = serde_json::from_str(line)
+                .unwrap_or_else(|e| panic!("bad JSONL line: {line:?}\nerror: {e}"));
+            ChatEvent { raw }
+        })
+        .collect()
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// PR 1 — 4 critical tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+#[ignore = "loads real model — run with `cargo test -- --ignored` after `ferrum pull qwen3:0.6b`"]
+fn test_oneshot_prompt() {
+    let events = run_chat_oneshot(SMOKE_MODEL, "Say hi in one short sentence.");
+    let assistant: Vec<_> = events.iter().filter(|e| e.event() == "assistant").collect();
+    assert_eq!(
+        assistant.len(),
+        1,
+        "expected exactly one assistant event, got {}",
+        assistant.len()
+    );
+    let a = &assistant[0];
+    assert!(
+        a.content().map(|c| !c.trim().is_empty()).unwrap_or(false),
+        "assistant content was empty"
+    );
+    assert!(
+        matches!(a.finish_reason(), Some("stop" | "eos" | "length")),
+        "unexpected finish_reason: {:?}",
+        a.finish_reason()
+    );
+}
+
+#[test]
+#[ignore = "loads real model"]
+fn test_repl_natural_eos() {
+    let events = run_chat(
+        SMOKE_MODEL,
+        None,
+        &["Say hi in one short sentence.", "/bye"],
+    );
+    let assistants: Vec<_> = events.iter().filter(|e| e.event() == "assistant").collect();
+    assert_eq!(
+        assistants.len(),
+        1,
+        "expected 1 assistant turn, got {}",
+        assistants.len()
+    );
+    let a = &assistants[0];
+    // Short prompt with max-tokens=100 → should hit natural stop, not length truncation.
+    // This catches the d67fbbb-class regression where EOS detection placeholder
+    // (vocab_size-10) never fires, so finish_reason was always 'length'.
+    assert!(
+        matches!(a.finish_reason(), Some("stop" | "eos")),
+        "expected natural stop / eos; got finish_reason={:?}, content={:?}",
+        a.finish_reason(),
+        a.content()
+    );
+}
+
+#[test]
+#[ignore = "loads real model"]
+fn test_repl_multi_turn_recall() {
+    let events = run_chat(
+        SMOKE_MODEL,
+        None,
+        &[
+            "Remember this fact: my name is XiaoMing.",
+            "What is my name? Reply with just the name.",
+            "/bye",
+        ],
+    );
+    let assistants: Vec<_> = events.iter().filter(|e| e.event() == "assistant").collect();
+    assert_eq!(
+        assistants.len(),
+        2,
+        "expected 2 assistant turns, got {}",
+        assistants.len()
+    );
+    let second = assistants[1].content().unwrap_or("");
+    // Catches d67fbbb-class regression where history wasn't carried into turn 2.
+    assert!(
+        second.to_lowercase().contains("xiaoming"),
+        "second turn should recall 'XiaoMing'; got: {second:?}"
+    );
+}
+
+#[test]
+#[ignore = "loads real model"]
+fn test_repl_no_template_leak() {
+    let events = run_chat(
+        SMOKE_MODEL,
+        None,
+        &["Hi there.", "Tell me a small number.", "/bye"],
+    );
+    // Sampler / stop-sequence path should swallow these, never expose them
+    // to user-visible content. If a regression lets them through, it's a
+    // chat-template double-application or sampler stop bug.
+    let leaky_markers = ["<|im_start|>", "<|im_end|>", "<|endoftext|>", "</s>", "<s>"];
+    for e in events.iter().filter(|e| e.event() == "assistant") {
+        let content = e.content().unwrap_or("");
+        for marker in &leaky_markers {
+            assert!(
+                !content.contains(marker),
+                "assistant leaked special token {marker:?} in content: {content:?}"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

First slice of a 6-PR effort to harden `cli run` against the d67fbbb regression class. Adds a machine-readable output mode and the four highest-ROI chat regression tests on top of it.

- New flag `--output-format <text|jsonl>` on `cli run`. JSONL emits one record per event (`ready` / `user` / `assistant` / `exit` / `error`) on stdout; `text` (default) preserves the existing interactive UX byte-for-byte.
- The same emitter wires both the REPL loop and the one-shot `--prompt` path, so tests of either exercise the same control flow users hit.
- New `crates/ferrum-cli/tests/chat_smoke.rs` drives the binary via stdin pipe and parses JSONL stdout. Uses Qwen3-0.6B over Metal locally; `#[ignore]` by default so a bare `cargo test` stays fast.

## Tests added

| Test | Catches |
|---|---|
| `test_oneshot_prompt` | `--prompt` path emits assistant event with non-empty content and a valid `finish_reason` |
| `test_repl_natural_eos` | Short prompt produces `finish_reason ∈ {stop, eos}` — **d67fbbb EOS regression** |
| `test_repl_multi_turn_recall` | Turn 2 recalls info from turn 1 — **history-loss regression** |
| `test_repl_no_template_leak` | Output never contains `<\|im_*\|>`, `</s>`, `<s>` — **sampler/template leak regression** |

Run with: `ferrum pull qwen3:0.6b && cargo test -p ferrum-cli --features metal --test chat_smoke -- --ignored --test-threads=1`

Full suite: ~110s on M1 Metal.

## Mutation verification

Each test was verified to fail when its target invariant is broken, and to pass once reverted:

| Mutation | Test | Actual failure message |
|---|---|---|
| 1. Skip the JSONL emit in one-shot path | `test_oneshot_prompt` | `expected exactly one assistant event, got 0` |
| 2. Drop the `finish_reason = Some(r)` assignment in REPL | `test_repl_natural_eos` | `expected natural stop / eos; got finish_reason=None` |
| 3. Skip `history.push` for user+assistant | `test_repl_multi_turn_recall` | Model replies *"Your name is not provided"*, assertion fails |
| 4. Append `<\|im_end\|>` to `response` after stream loop | `test_repl_no_template_leak` | `leaked special token "<\|im_end\|>"` |

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p ferrum-cli --features metal --tests`
- [x] `cargo test -p ferrum-cli --features metal --test cli_e2e` (8 existing tests still pass)
- [x] `cargo test -p ferrum-cli --features metal --test chat_smoke -- --ignored --test-threads=1` (4 passed, ~110s)
- [x] All 4 mutations verified to break the right test

## Follow-up PRs in this series

- PR 2: remaining 7 Tier 1 tests
- PR 3: rstest parameterization across Qwen3 / TinyLlama / Llama-3.2
- PR 4: pty + SIGINT (3 tests)
- PR 5: stress (RSS / concurrency)
- PR 6: CI workflows + CLAUDE.md Done criteria

🤖 Generated with [Claude Code](https://claude.com/claude-code)