### PR TITLE
test(cli): 7 more chat smoke tests — Tier 1 complete (PR 2/6)

### DIFF
--- a/crates/ferrum-cli/tests/chat_smoke.rs
+++ b/crates/ferrum-cli/tests/chat_smoke.rs
@@ -33,6 +33,12 @@ impl ChatEvent {
     fn finish_reason(&self) -> Option<&str> {
         self.raw["finish_reason"].as_str()
     }
+    fn chunk_count(&self) -> Option<u64> {
+        self.raw["chunk_count"].as_u64()
+    }
+    fn exit_reason(&self) -> Option<&str> {
+        self.raw["reason"].as_str()
+    }
 }
 
 fn ferrum_bin() -> PathBuf {
@@ -53,8 +59,19 @@ fn ferrum_bin() -> PathBuf {
 }
 
 /// Spawn `ferrum run --output-format jsonl`, feed `stdin_lines` (one per line),
-/// then parse JSONL stdout into events. Panics on non-zero exit.
+/// then parse JSONL stdout into events. Panics on non-zero exit. Defaults to
+/// `--max-tokens 100`. Use `run_chat_full` to override.
 fn run_chat(model: &str, system: Option<&str>, stdin_lines: &[&str]) -> Vec<ChatEvent> {
+    run_chat_full(model, system, 100, stdin_lines)
+}
+
+fn run_chat_full(
+    model: &str,
+    system: Option<&str>,
+    max_tokens: u32,
+    stdin_lines: &[&str],
+) -> Vec<ChatEvent> {
+    let max_tokens_s = max_tokens.to_string();
     let mut cmd = Command::new(ferrum_bin());
     cmd.args([
         "run",
@@ -64,7 +81,7 @@ fn run_chat(model: &str, system: Option<&str>, stdin_lines: &[&str]) -> Vec<Chat
         "--temperature",
         "0",
         "--max-tokens",
-        "100",
+        &max_tokens_s,
     ]);
     if let Some(s) = system {
         cmd.args(["--system", s]);
@@ -233,4 +250,189 @@ fn test_repl_no_template_leak() {
             );
         }
     }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// PR 2 — remaining 7 Tier 1 tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+#[ignore = "loads real model"]
+fn test_repl_max_tokens_truncation() {
+    // --max-tokens=5 forces length truncation (model won't naturally finish
+    // a "long story" prompt in 5 tokens). Catches regressions where
+    // max-tokens isn't propagated to SamplingParams.
+    let events = run_chat_full(
+        SMOKE_MODEL,
+        None,
+        5,
+        &["Tell me a long story about dragons.", "/bye"],
+    );
+    let assistants: Vec<_> = events.iter().filter(|e| e.event() == "assistant").collect();
+    assert_eq!(assistants.len(), 1, "expected 1 assistant turn");
+    assert_eq!(
+        assistants[0].finish_reason(),
+        Some("length"),
+        "max-tokens=5 should hit length truncation; got {:?}; content={:?}",
+        assistants[0].finish_reason(),
+        assistants[0].content()
+    );
+}
+
+#[test]
+#[ignore = "loads real model"]
+fn test_repl_stop_seq_each_turn() {
+    // 3 short turns, every one must hit a natural stop. This is the
+    // d67fbbb regression-net for stop-detection across multiple turns —
+    // a stop-state-leak between turns would manifest as missing/wrong
+    // finish_reason on later turns.
+    let events = run_chat(
+        SMOKE_MODEL,
+        None,
+        &[
+            "Hi.",
+            "What's 2 plus 2?",
+            "What's the capital of France?",
+            "/bye",
+        ],
+    );
+    let assistants: Vec<_> = events.iter().filter(|e| e.event() == "assistant").collect();
+    assert_eq!(assistants.len(), 3, "expected 3 assistant turns");
+    for (i, a) in assistants.iter().enumerate() {
+        assert!(
+            matches!(a.finish_reason(), Some("stop" | "eos")),
+            "turn {} unexpected finish_reason: {:?}",
+            i,
+            a.finish_reason()
+        );
+    }
+}
+
+#[test]
+#[ignore = "loads real model"]
+fn test_repl_chunk_count_matches() {
+    // chunk_count must be > 0 when content is non-empty, and content must
+    // be at least chunk_count bytes (each emitted chunk has ≥1 byte).
+    // Catches stream-counter regressions and "last chunk swallowed" bugs.
+    let events = run_chat(
+        SMOKE_MODEL,
+        None,
+        &["Write one short sentence about cats.", "/bye"],
+    );
+    let assistants: Vec<_> = events.iter().filter(|e| e.event() == "assistant").collect();
+    assert_eq!(assistants.len(), 1);
+    let a = &assistants[0];
+    let chunk_count = a.chunk_count().expect("chunk_count field present");
+    let content = a.content().unwrap_or("");
+    assert!(
+        chunk_count > 0,
+        "chunk_count should be > 0 with non-empty content; got 0, content={content:?}"
+    );
+    assert!(
+        content.len() >= chunk_count as usize,
+        "content.len()={} should be >= chunk_count={chunk_count} (each chunk ≥ 1 byte); content={content:?}",
+        content.len()
+    );
+}
+
+#[test]
+#[ignore = "loads real model"]
+fn test_repl_history_truncation_at_10() {
+    // CLI caps history at 10 entries. Drive 12 short turns and verify
+    // each turn still produces a non-empty response with a valid
+    // finish_reason — proves the truncation logic doesn't crash mid-flight
+    // and doesn't corrupt the prompt structure for later turns.
+    let mut lines: Vec<String> = (1..=12)
+        .map(|i| format!("Reply with just the number {i}."))
+        .collect();
+    lines.push("/bye".to_string());
+    let line_refs: Vec<&str> = lines.iter().map(String::as_str).collect();
+
+    let events = run_chat_full(SMOKE_MODEL, None, 30, &line_refs);
+    let assistants: Vec<_> = events.iter().filter(|e| e.event() == "assistant").collect();
+    assert_eq!(
+        assistants.len(),
+        12,
+        "expected 12 assistant turns, got {}",
+        assistants.len()
+    );
+    for (i, a) in assistants.iter().enumerate() {
+        assert!(
+            a.content().map(|c| !c.trim().is_empty()).unwrap_or(false),
+            "turn {i} content empty: {:?}",
+            a.content()
+        );
+        assert!(
+            matches!(a.finish_reason(), Some("stop" | "eos" | "length")),
+            "turn {i} finish_reason: {:?}",
+            a.finish_reason()
+        );
+    }
+}
+
+#[test]
+#[ignore = "loads real model"]
+fn test_repl_system_prompt() {
+    // System prompt should constrain generation. Catches regression where
+    // --system flag is parsed but not actually plumbed through to
+    // build_chat_prompt.
+    let events = run_chat(
+        SMOKE_MODEL,
+        Some("You must always reply with exactly the word YES, nothing else."),
+        &["What is the weather like?", "/bye"],
+    );
+    let assistants: Vec<_> = events.iter().filter(|e| e.event() == "assistant").collect();
+    assert_eq!(assistants.len(), 1);
+    let content = assistants[0].content().unwrap_or("");
+    // Loose check: response must contain "yes" (case-insensitive). Small
+    // models won't be perfectly obedient but should at least mention it.
+    assert!(
+        content.to_lowercase().contains("yes"),
+        "system prompt asked for 'YES'; assistant said: {content:?}"
+    );
+}
+
+#[test]
+#[ignore = "loads real model"]
+fn test_repl_utf8_chinese() {
+    // Pure-Chinese round-trip. Verifies UTF-8 byte boundaries don't crack
+    // in tokenizer / decoder / JSONL serialization paths.
+    let events = run_chat(
+        SMOKE_MODEL,
+        Some("请用中文回答。"),
+        &["你好，请用一句话问候我。", "/bye"],
+    );
+    let assistants: Vec<_> = events.iter().filter(|e| e.event() == "assistant").collect();
+    assert_eq!(assistants.len(), 1);
+    let content = assistants[0].content().unwrap_or("");
+    // Expect at least one CJK Unified Ideograph character in response.
+    let has_cjk = content
+        .chars()
+        .any(|c| (0x4E00..=0x9FFF).contains(&(c as u32)));
+    assert!(
+        has_cjk,
+        "expected Chinese characters in response; got: {content:?}"
+    );
+}
+
+#[test]
+#[ignore = "loads real model"]
+fn test_repl_clean_exit_bye() {
+    // The final JSONL record must be an `exit` event with reason="bye"
+    // when the user typed /bye. Catches regressions in exit-path bookkeeping
+    // (e.g., always emitting "eof" regardless of how loop terminated).
+    let events = run_chat(SMOKE_MODEL, None, &["Hi.", "/bye"]);
+    let last = events.last().expect("at least one event");
+    assert_eq!(
+        last.event(),
+        "exit",
+        "last event should be 'exit'; got: {:?}",
+        last.event()
+    );
+    assert_eq!(
+        last.exit_reason(),
+        Some("bye"),
+        "exit reason should be 'bye'; got: {:?}",
+        last.exit_reason()
+    );
 }


### PR DESCRIPTION
## Summary

Builds on PR #189 (depends on its `--output-format jsonl` flag — review/merge that first; GitHub will rebase this onto main automatically). Completes Tier 1 with the remaining 7 tests, each scoped to a distinct REPL bug class.

| New test | Catches |
|---|---|
| `test_repl_max_tokens_truncation` | `--max-tokens` not propagated into `SamplingParams` |
| `test_repl_stop_seq_each_turn` | Stop detection leaks state across turns — later turns miss `finish_reason` |
| `test_repl_chunk_count_matches` | Stream chunk counting off / last chunk swallowed |
| `test_repl_history_truncation_at_10` | 12-turn run survives without crashing the REPL |
| `test_repl_system_prompt` | `--system` flag parsed but not threaded into `build_chat_prompt` |
| `test_repl_utf8_chinese` | UTF-8 byte boundary corruption in tokenizer / decoder / JSONL serializer |
| `test_repl_clean_exit_bye` | `/bye` exit reason not recorded in the trailing `exit` event |

## API improvements

- Added `ChatEvent::chunk_count()` and `ChatEvent::exit_reason()` accessors.
- New helper `run_chat_full(model, system, max_tokens, lines)` for tests that need a per-test `--max-tokens` override. The existing `run_chat` keeps its signature and delegates with `max_tokens = 100`.

## Mutation verification (7/7 caught)

| Mutation | Test | Actual failure |
|---|---|---|
| 5. Hardcode `max_tokens: 1000` in `SamplingParams` | `max_tokens_truncation` | `right: Some(\"length\")` mismatch |
| 6. Skip `chunk_count += 1` | `chunk_count_matches` | `chunk_count=0` while content is non-empty |
| 7. Pass `None` instead of `cmd.system.as_deref()` to `build_chat_prompt` | `system_prompt` | Model goes into weather lecture, never says \"YES\" |
| 8. Filter non-ASCII chars from `response` before push | `utf8_chinese` | No CJK characters in response |
| 9. Drop `exit_reason = match input { ... }` assignment | `clean_exit_bye` | `Some(\"eof\")` ≠ `Some(\"bye\")` |
| 10. Emit `finish_reason` only on turn 0 (None afterwards) | `stop_seq_each_turn` | `turn 1 unexpected finish_reason: None` |
| 11. `panic!()` when `history.len() > 11` after push | `history_truncation_at_10` | Process panics, exits non-zero, helper surfaces error |

## Full test matrix after this PR

| Test | Time (M1 Metal) | Mutation caught |
|---|---:|:---:|
| `test_oneshot_prompt` (PR 1) | ~13s | ✅ |
| `test_repl_natural_eos` (PR 1) | ~15s | ✅ |
| `test_repl_multi_turn_recall` (PR 1) | ~30s | ✅ |
| `test_repl_no_template_leak` (PR 1) | ~35s | ✅ |
| `test_repl_max_tokens_truncation` | ~13s | ✅ |
| `test_repl_stop_seq_each_turn` | ~30s | ✅ |
| `test_repl_chunk_count_matches` | ~13s | ✅ |
| `test_repl_history_truncation_at_10` | ~120s | ✅ |
| `test_repl_system_prompt` | ~13s | ✅ |
| `test_repl_utf8_chinese` | ~13s | ✅ |
| `test_repl_clean_exit_bye` | ~13s | ✅ |
| **Total** | **~295s** | **11/11** |

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p ferrum-cli --features metal --test chat_smoke -- --ignored --test-threads=1` (11 passed in 295s)
- [x] `cargo test -p ferrum-cli --features metal --test cli_e2e` (8 existing pass)
- [x] All 7 mutations verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)