### PR TITLE
test(cli): pty + signal chat smoke (PR 4/6)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -686,6 +686,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "comma"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55b672471b4e9f9e95499ea597ff64941a309b2cdbffcc46f2cc5e2d971fd335"
+
+[[package]]
 name = "compact_str"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1267,6 +1273,7 @@ dependencies = [
  "num_cpus",
  "rand 0.9.2",
  "reqwest",
+ "rexpect",
  "rstest",
  "serde",
  "serde_json",
@@ -2657,9 +2664,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.177"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libloading"
@@ -3025,6 +3032,18 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "rawpointer",
+]
+
+[[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags 2.10.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
 ]
 
 [[package]]
@@ -3965,6 +3984,19 @@ dependencies = [
  "wasm-streams",
  "web-sys",
  "webpki-roots 1.0.3",
+]
+
+[[package]]
+name = "rexpect"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a0ac16ec311879f32b8b1963eb6b81792f30c6bede86d8ce83ad5adfca4698d"
+dependencies = [
+ "comma",
+ "nix",
+ "regex",
+ "tempfile",
+ "thiserror 2.0.17",
 ]
 
 [[package]]

--- a/crates/ferrum-cli/Cargo.toml
+++ b/crates/ferrum-cli/Cargo.toml
@@ -79,6 +79,7 @@ shellexpand = "3.1"
 
 [dev-dependencies]
 rstest = "0.23"
+rexpect = "0.6"
 
 [features]
 default = []

--- a/crates/ferrum-cli/tests/chat_pty.rs
+++ b/crates/ferrum-cli/tests/chat_pty.rs
@@ -1,0 +1,83 @@
+//! PTY-driven smoke tests for `ferrum run` — covers exit paths and
+//! signal handling that stdin-pipe tests can't exercise:
+//!
+//! - `/bye` slash command exits cleanly
+//! - Ctrl+D (EOF on TTY) exits cleanly
+//! - Ctrl+C (SIGINT) terminates the process
+//!
+//! Loads a real model, `#[ignore]` by default. Opt in:
+//!
+//!     ferrum pull qwen3:0.6b
+//!     cargo test --release -p ferrum-cli --features metal --test chat_pty \
+//!       -- --ignored --test-threads=1
+
+use rexpect::session::spawn_command;
+use std::path::PathBuf;
+use std::process::Command;
+
+const SMOKE_MODEL: &str = "qwen3:0.6b";
+const SPAWN_TIMEOUT_MS: u64 = 90_000;
+
+fn ferrum_bin() -> PathBuf {
+    if let Ok(bin) = std::env::var("CARGO_BIN_EXE_ferrum") {
+        return PathBuf::from(bin);
+    }
+    let current = std::env::current_exe().expect("test exe path");
+    let dir = current
+        .parent()
+        .and_then(|p| p.parent())
+        .expect("target dir");
+    let mut bin = dir.join("ferrum");
+    if cfg!(windows) {
+        bin.set_extension("exe");
+    }
+    assert!(bin.exists(), "ferrum binary not found at {}", bin.display());
+    bin
+}
+
+fn spawn_ferrum_run() -> rexpect::session::PtySession {
+    let mut cmd = Command::new(ferrum_bin());
+    cmd.args(["run", SMOKE_MODEL]);
+    cmd.env("NO_COLOR", "1");
+    spawn_command(cmd, Some(SPAWN_TIMEOUT_MS)).expect("spawn ferrum on pty")
+}
+
+#[test]
+#[ignore = "loads real model — run with `cargo test -- --ignored`"]
+fn test_pty_bye_command_exits() {
+    // /bye should drop us out of the REPL with the "Goodbye!" banner and
+    // a clean exit. Catches regressions where the slash-command match
+    // gets dropped or the cleanup path hangs.
+    let mut p = spawn_ferrum_run();
+    p.exp_string("Ready.").expect("ready banner");
+    p.send_line("/bye").expect("send /bye");
+    p.exp_string("Goodbye").expect("goodbye banner");
+    p.exp_eof().expect("clean EOF after /bye");
+}
+
+#[test]
+#[ignore = "loads real model"]
+fn test_pty_ctrl_d_clean_exit() {
+    // Ctrl+D (EOF on TTY) hits the `read_line -> Ok(0)` branch, which
+    // must `break` out of the loop. If a regression turns it into
+    // `continue`, the process hangs on the next read forever.
+    let mut p = spawn_ferrum_run();
+    p.exp_string("Ready.").expect("ready banner");
+    p.send_control('d').expect("send Ctrl+D");
+    p.exp_string("Goodbye").expect("goodbye banner after EOF");
+    p.exp_eof().expect("clean EOF after Ctrl+D");
+}
+
+#[test]
+#[ignore = "loads real model"]
+fn test_pty_sigint_terminates() {
+    // Ctrl+C (SIGINT) must terminate the process; default tokio behavior
+    // is fine here, but the test guards against a future regression that
+    // installs a signal handler swallowing SIGINT into an infinite loop.
+    let mut p = spawn_ferrum_run();
+    p.exp_string("Ready.").expect("ready banner");
+    p.send_control('c').expect("send Ctrl+C");
+    // Process should terminate (any exit status acceptable for SIGINT).
+    p.exp_eof()
+        .expect("process should die on SIGINT within timeout");
+}


### PR DESCRIPTION
## Summary

Adds 3 PTY-driven tests that exercise paths stdin-pipe tests can't reach: TTY-mode REPL prompts, slash-command exits, and signal handling.

Depends on PR #192 (rstest dev-dep is already added there). Once #192 merges, this PR auto-rebases onto main.

| Test | Catches |
|---|---|
| `test_pty_bye_command_exits` | `/bye` slash-command branch missing or re-routed; cleanup path hung |
| `test_pty_ctrl_d_clean_exit` | `Ok(0) => break` regression on EOF — would otherwise hang forever |
| `test_pty_sigint_terminates` | Smoke against default Tokio SIGINT — guards against future handler that swallows SIGINT into an infinite loop |

## Implementation

- Adds `rexpect = "0.6"` dev-dep (cross-platform PTY driver — macOS + Linux).
- New file: `crates/ferrum-cli/tests/chat_pty.rs`.
- Uses Qwen3-0.6B for fast cold-load. Suite runtime: **~8s on M1 Metal** with `--release`.

## Mutation verification

| Mutation | Test | Actual failure |
|---|---|---|
| 12. Drop `"/bye"` from input match | `test_pty_bye_command_exits` | Timeout after 90s waiting for "Goodbye"; the literal `/bye` got piped to the model as a prompt (`"You're welcome! 😊 Have a great day!"`) |
| 13. Change `Ok(0) => break` to `continue` | `test_pty_ctrl_d_clean_exit` | Timeout after 90s; EOF loops forever instead of exiting cleanly |

Both reverted before commit.

The SIGINT test is a smoke against OS-level default behavior — there's no natural ferrum-side mutation target (would require introducing a signal handler that swallows SIGINT, which is a feature change not a regression). Worth keeping as a guard so a future commit can't silently break Ctrl+C handling.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo test --release -p ferrum-cli --features metal --test chat_pty -- --ignored --test-threads=1` — 3 passed in 8s
- [x] Both mutations verified to break the right test
- [x] Existing `cli_e2e` + `chat_smoke` still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)