### PR TITLE
ci(chat-smoke): nightly workflow + CLAUDE.md Done criteria (PR 6/6)

### DIFF
--- a/.github/workflows/chat-smoke.yml
+++ b/.github/workflows/chat-smoke.yml
@@ -1,0 +1,76 @@
+name: Chat Smoke (nightly)
+
+# Runs the chat / pty / stress smoke suites against real models.
+# These are #[ignore]'d in cargo test by default — opt in here.
+#
+# Trigger:
+#   - Daily at 03:00 UTC
+#   - Manual via workflow_dispatch (use when iterating on cli run / REPL)
+#
+# Not on every PR — model pulls + cold-loads cost ~5–10 min per lane.
+# PR-time CI (.github/workflows/ci.yml) already catches compile errors
+# via `cargo check --all-targets`.
+
+on:
+  schedule:
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: chat-smoke-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+  RUSTFLAGS: "-D warnings"
+
+jobs:
+  metal:
+    name: Chat smoke (macOS Metal)
+    runs-on: macos-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-chat-smoke-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-chat-smoke-
+
+      # Cache HF models so cold-load is fast across runs.
+      - uses: actions/cache@v3
+        with:
+          path: ~/.cache/huggingface
+          key: hf-cache-chat-smoke-v1
+          restore-keys: hf-cache-chat-smoke-
+
+      - name: Build release binary + tests
+        run: cargo build --release -p ferrum-cli --features metal --tests
+
+      - name: Pre-pull required models
+        run: |
+          ./target/release/ferrum pull qwen3:0.6b
+          ./target/release/ferrum pull tinyllama
+          ./target/release/ferrum pull qwen2.5:0.5b
+
+      - name: Chat smoke (JSONL stdin pipe — 13 instances)
+        run: |
+          cargo test --release -p ferrum-cli --features metal \
+            --test chat_smoke -- --ignored --test-threads=1
+
+      - name: Chat pty smoke (3 tests — bye / Ctrl+D / SIGINT)
+        run: |
+          cargo test --release -p ferrum-cli --features metal \
+            --test chat_pty -- --ignored --test-threads=1
+
+      - name: Chat stress (30-turn no-OOM + 3-way concurrency)
+        run: |
+          cargo test --release -p ferrum-cli --features metal \
+            --test chat_stress -- --ignored --test-threads=1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,27 @@ The unified path lives in `crates/ferrum-engine/src/continuous_engine.rs::proces
 - CUDA code behind `#[cfg(feature = "cuda")]`, Metal behind target OS gates, Triton kernels behind `#[cfg(feature = "triton-kernels")]` (implies cuda)
 - Shared types/traits go in `ferrum-types`/`ferrum-interfaces`, never duplicated
 
+## Done criteria — engine / scheduler / sampler / CLI run changes
+
+Any PR that touches `ferrum-engine/src/continuous_engine.rs`,
+`ferrum-engine/src/sampler/`, `ferrum-scheduler/`, or
+`ferrum-cli/src/commands/run.rs` is in the d67fbbb blast radius
+(EOS / stop_sequences / stream / multi-turn KV / chat template). It is
+NOT done until the chat smoke suites pass locally:
+
+```bash
+ferrum pull qwen3:0.6b           # + tinyllama, qwen2.5:0.5b for full matrix
+cargo test --release -p ferrum-cli --features metal --test chat_smoke -- --ignored --test-threads=1
+cargo test --release -p ferrum-cli --features metal --test chat_pty   -- --ignored --test-threads=1
+cargo test --release -p ferrum-cli --features metal --test chat_stress -- --ignored --test-threads=1
+```
+
+Total ~70 s on M1 Metal (`--release` is required — debug is ~5× slower).
+Nightly CI (`.github/workflows/chat-smoke.yml`) runs the same suites on
+macos-latest. PR-time CI (`.github/workflows/ci.yml`) only compiles them
+via `cargo check --all-targets` — actual runs are nightly because each
+test cold-loads a real model.
+
 ## CUDA backend layout
 
 `crates/ferrum-kernels/src/backend/cuda/` split by supertrait:


### PR DESCRIPTION
## Summary

Final PR of the chat smoke series. Closes the loop with CI integration + project-level enforcement.

Depends on PRs #192 + #193 + #194 (the three test files this workflow runs). Once they merge, this auto-rebases onto main.

## Changes

### `.github/workflows/chat-smoke.yml` (new)

Nightly + `workflow_dispatch` workflow that runs the three chat suites against real models on `macos-latest`:

- `chat_smoke` (13 instances, ~42s)
- `chat_pty` (3 tests, ~8s)
- `chat_stress` (2 tests, ~19s)

Total ~70s + cold-load + model-pull. HF cache is cached between runs via `actions/cache`.

**Why nightly, not PR-time?** Each chat test cold-loads a ~1.2 GB real model and uses Metal hardware. Stock `macos-latest` runners need to download the model and warm up — too expensive for every PR. PR-time CI (`.github/workflows/ci.yml`) already compiles these tests via `cargo check --all-targets`, catching compile errors immediately; actual runtime regressions are caught within 24 h by the nightly run.

### `CLAUDE.md` — new "Done criteria" section

Spells out which paths are in the d67fbbb regression blast radius and what commands must pass locally before a PR touching them is "done":

```bash
cargo test --release -p ferrum-cli --features metal --test chat_smoke -- --ignored --test-threads=1
cargo test --release -p ferrum-cli --features metal --test chat_pty   -- --ignored --test-threads=1
cargo test --release -p ferrum-cli --features metal --test chat_stress -- --ignored --test-threads=1
```

The `--release` requirement is called out explicitly (debug-mode runs are ~5× slower).

## Series recap

| PR | Scope | Tests |
|---|---|---:|
| #189 | `--output-format jsonl` foundation + 4 critical tests | 4 |
| #191 | Tier 1 remaining 7 tests | 7 |
| #192 | rstest parameterization + matrix narrowing | 13 (incl. 3-way leak test) |
| #193 | PTY + signal smoke | 3 |
| #194 | Stress + concurrency | 2 |
| #195 (this) | CI workflow + Done criteria | — |
| **Total** | | **18 test instances** |

Local full-suite runtime: **~70 s on M1 Metal with `--release`**.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] Workflow YAML lint (yamllint-compatible)
- [x] CLAUDE.md renders correctly in GitHub markdown preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)