### PR TITLE
test(server): HTTP server smoke + 4 critical tests (PR 7/11)

### DIFF
--- a/crates/ferrum-cli/tests/server_smoke.rs
+++ b/crates/ferrum-cli/tests/server_smoke.rs
@@ -1,0 +1,261 @@
+//! HTTP server smoke tests — drive a real `cli serve` subprocess via
+//! reqwest and assert OpenAI `/v1/chat/completions` contract.
+//!
+//! These tests mirror the d67fbbb regression surface (EOS / stop_sequences /
+//! stream / multi-turn) on the HTTP path, which goes through a different
+//! code lane than the CLI REPL: stateless per request, SSE for streaming,
+//! axum router + handler, full `messages` array per call.
+//!
+//! Loads a real model and is `#[ignore]`'d by default. Each test spawns
+//! its own server (4 cold-loads ~ 60 s). Opt in:
+//!
+//!     ferrum pull qwen3:0.6b
+//!     cargo test --release -p ferrum-cli --features metal --test server_smoke \
+//!       -- --ignored --test-threads=1
+
+use reqwest::Client;
+use serde_json::{json, Value};
+use std::net::TcpListener;
+use std::path::PathBuf;
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+const SMOKE_MODEL: &str = "qwen3:0.6b";
+const STARTUP_TIMEOUT: Duration = Duration::from_secs(120);
+
+fn ferrum_bin() -> PathBuf {
+    if let Ok(bin) = std::env::var("CARGO_BIN_EXE_ferrum") {
+        return PathBuf::from(bin);
+    }
+    let current = std::env::current_exe().expect("test exe path");
+    let dir = current
+        .parent()
+        .and_then(|p| p.parent())
+        .expect("target dir");
+    let mut bin = dir.join("ferrum");
+    if cfg!(windows) {
+        bin.set_extension("exe");
+    }
+    assert!(bin.exists(), "ferrum binary not found at {}", bin.display());
+    bin
+}
+
+/// Ask the OS for an unused TCP port. Small race window between the bind
+/// release here and the server's bind — acceptable for CI.
+fn free_port() -> u16 {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
+    listener.local_addr().expect("local_addr").port()
+}
+
+/// Spawns `cli serve <model> --port N` and polls `/health` until ready.
+/// Drop kills the child so each test self-cleans even on panic.
+struct ServerFixture {
+    url: String,
+    child: Child,
+}
+
+impl ServerFixture {
+    async fn spawn(model: &str) -> Self {
+        let port = free_port();
+        let url = format!("http://127.0.0.1:{port}");
+        let child = Command::new(ferrum_bin())
+            .args(["serve", model, "--port", &port.to_string()])
+            .env("NO_COLOR", "1")
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("spawn ferrum serve");
+
+        // Poll /health.
+        let client = Client::new();
+        let healthz = format!("{url}/health");
+        let start = Instant::now();
+        loop {
+            if start.elapsed() > STARTUP_TIMEOUT {
+                panic!("server did not become healthy within {STARTUP_TIMEOUT:?}");
+            }
+            let ok = client
+                .get(&healthz)
+                .timeout(Duration::from_secs(2))
+                .send()
+                .await
+                .map(|r| r.status().is_success())
+                .unwrap_or(false);
+            if ok {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(500)).await;
+        }
+
+        Self { url, child }
+    }
+
+    fn chat_url(&self) -> String {
+        format!("{}/v1/chat/completions", self.url)
+    }
+}
+
+impl Drop for ServerFixture {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+/// Parse an SSE response body into `(chunks, saw_done)`. Each chunk is the
+/// parsed JSON inside a `data: { ... }` line. `[DONE]` is the OpenAI
+/// stream terminator.
+fn parse_sse(body: &str) -> (Vec<Value>, bool) {
+    let mut chunks = Vec::new();
+    let mut saw_done = false;
+    for block in body.split("\n\n") {
+        for line in block.lines() {
+            if let Some(data) = line.strip_prefix("data: ") {
+                let data = data.trim();
+                if data == "[DONE]" {
+                    saw_done = true;
+                } else if !data.is_empty() {
+                    let v: Value = serde_json::from_str(data)
+                        .unwrap_or_else(|e| panic!("bad SSE JSON: {data:?} ({e})"));
+                    chunks.push(v);
+                }
+            }
+        }
+    }
+    (chunks, saw_done)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// PR 7 — 4 critical HTTP server tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[tokio::test(flavor = "current_thread")]
+#[ignore = "loads real model — run with `cargo test -- --ignored`"]
+async fn test_chat_completion_basic() {
+    let fx = ServerFixture::spawn(SMOKE_MODEL).await;
+    let resp = Client::new()
+        .post(fx.chat_url())
+        .json(&json!({
+            "model": SMOKE_MODEL,
+            "messages": [{"role": "user", "content": "Say hi in one short sentence."}],
+            "max_tokens": 100,
+            "temperature": 0.0
+        }))
+        .send()
+        .await
+        .expect("post");
+    assert_eq!(resp.status(), 200, "non-200: {:?}", resp.status());
+    let body: Value = resp.json().await.expect("json");
+    let content = body["choices"][0]["message"]["content"]
+        .as_str()
+        .expect("missing choices[0].message.content");
+    assert!(!content.trim().is_empty(), "content empty: {body:?}");
+    let fr = body["choices"][0]["finish_reason"].as_str();
+    assert!(
+        matches!(fr, Some("stop" | "length")),
+        "unexpected finish_reason: {fr:?}"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+#[ignore = "loads real model"]
+async fn test_chat_streaming_sse() {
+    let fx = ServerFixture::spawn(SMOKE_MODEL).await;
+    let resp = Client::new()
+        .post(fx.chat_url())
+        .json(&json!({
+            "model": SMOKE_MODEL,
+            "messages": [{"role": "user", "content": "Say hi in one short sentence."}],
+            "max_tokens": 100,
+            "temperature": 0.0,
+            "stream": true
+        }))
+        .send()
+        .await
+        .expect("post");
+    assert_eq!(resp.status(), 200);
+    let body = resp.text().await.expect("body");
+    let (chunks, saw_done) = parse_sse(&body);
+    assert!(!chunks.is_empty(), "expected SSE chunks, got 0");
+    assert!(saw_done, "missing `data: [DONE]` terminator");
+
+    let mut content = String::new();
+    for c in &chunks {
+        if let Some(delta) = c["choices"][0]["delta"]["content"].as_str() {
+            content.push_str(delta);
+        }
+    }
+    assert!(!content.trim().is_empty(), "concatenated content empty");
+
+    // The final non-empty chunk should carry a terminal finish_reason.
+    let terminal = chunks
+        .iter()
+        .rev()
+        .find(|c| !c["choices"][0]["finish_reason"].is_null());
+    let fr = terminal.and_then(|c| c["choices"][0]["finish_reason"].as_str());
+    assert!(
+        matches!(fr, Some("stop" | "length")),
+        "terminal finish_reason: {fr:?}"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+#[ignore = "loads real model"]
+async fn test_chat_multi_turn_messages() {
+    let fx = ServerFixture::spawn(SMOKE_MODEL).await;
+    let resp = Client::new()
+        .post(fx.chat_url())
+        .json(&json!({
+            "model": SMOKE_MODEL,
+            "messages": [
+                {"role": "user", "content": "Remember this fact: my name is XiaoMing."},
+                {"role": "assistant", "content": "Got it. Your name is XiaoMing."},
+                {"role": "user", "content": "What is my name? Reply with just the name."}
+            ],
+            "max_tokens": 50,
+            "temperature": 0.0
+        }))
+        .send()
+        .await
+        .expect("post");
+    let body: Value = resp.json().await.expect("json");
+    let content = body["choices"][0]["message"]["content"]
+        .as_str()
+        .unwrap_or("");
+    // Server-side tokenization must respect the full messages array so
+    // the third turn references the first turn's information.
+    assert!(
+        content.to_lowercase().contains("xiaoming"),
+        "expected recall of 'XiaoMing'; got: {content:?}"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+#[ignore = "loads real model"]
+async fn test_chat_no_template_leak() {
+    let fx = ServerFixture::spawn(SMOKE_MODEL).await;
+    let resp = Client::new()
+        .post(fx.chat_url())
+        .json(&json!({
+            "model": SMOKE_MODEL,
+            "messages": [{"role": "user", "content": "Tell me a small number."}],
+            "max_tokens": 50,
+            "temperature": 0.0
+        }))
+        .send()
+        .await
+        .expect("post");
+    let body: Value = resp.json().await.expect("json");
+    let content = body["choices"][0]["message"]["content"]
+        .as_str()
+        .unwrap_or("");
+    // Sampler / template path should strip these before they reach the
+    // wire; a leak would indicate double-template-application or a
+    // sampler stop bug analogous to d67fbbb.
+    for marker in &["<|im_start|>", "<|im_end|>", "<|endoftext|>"] {
+        assert!(
+            !content.contains(marker),
+            "assistant leaked template token {marker:?} in: {content:?}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

First slice of the HTTP server test series. Mirrors the CLI chat smoke suite (PRs #189–#195) on the `/v1/chat/completions` lane.

The HTTP path traverses a **different code lane** than the CLI REPL: stateless per request, axum handler + SSE for streaming, full `messages` array tokenized per call. d67fbbb-class regressions (EOS / stop_sequences / stream / multi-turn KV) exist independently on this lane and need their own coverage.

## What this PR adds

`crates/ferrum-cli/tests/server_smoke.rs`:

- `ServerFixture` — spawns `cli serve <model> --port N` on a free TCP port, polls `/health` until ready, kills the child on Drop.
- `parse_sse(body)` — minimal SSE parser: splits on `\n\n`, extracts `data: { ... }` JSON chunks + the `[DONE]` terminator.

Four critical tests:

| Test | Catches |
|---|---|
| `test_chat_completion_basic` | Non-streaming `POST /v1/chat/completions` produces 200 with non-empty `choices[0].message.content` and valid `finish_reason` |
| `test_chat_streaming_sse` | `stream=true` emits ≥1 chunks, a `data: [DONE]` terminator, non-empty concatenated content, terminal `finish_reason` on the final chunk |
| `test_chat_multi_turn_messages` | `messages=[user1, assistant1, user2]` — assistant reply must reference user1's info; catches `apply_chat_template` regressions that drop history |
| `test_chat_no_template_leak` | Assistant content never contains `<\|im_start\|>` / `<\|im_end\|>` / `<\|endoftext\|>` — catches sampler/template strip regressions |

Each test spawns its own server (`Drop` kills on test end). Total runtime: **~13 s on M1 Metal with `--release`** (4 cold-loads).

## Mutation verification (4/4 caught)

| # | Mutation | Test | Failure |
|---|---|---|---|
| 14 | `content: output.text` → `String::new()` in `handle_chat_completions_sync` | `basic` | `content empty` |
| 15 | Drop the `Event::default().data(\"[DONE]\")` send in SSE writer | `streaming` | `missing [DONE] terminator` |
| 16 | `for msg in messages` → `for msg in messages.iter().rev().take(1)` in `apply_chat_template` | `multi_turn` | Model replies *\"Your name is not provided\"* |
| 17 | `format!(\"{}<\|im_end\|>\", output.text)` on sync response content | `template_leak` | `leaked template token <\|im_end\|>` |

All mutations are surgical patches to existing handler code — no anti-pattern model-id branching, per the rule in `feedback_mutation_anti_patterns.md`. All reverted before commit.

## Series ahead (10 PRs total for HTTP)

- PR 8 — Tier 1 remaining 6 tests (max_tokens, stop, errors, /v1/models, determinism, prefix-cache smoke)
- PR 9 — `async-openai` client contract test
- PR 10 — concurrent / stress (16 parallel requests, prefix cache speedup)
- PR 11 — CI workflow extension + CLAUDE.md Done criteria update

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo test --release -p ferrum-cli --features metal --test server_smoke -- --ignored --test-threads=1` — 4 passed in ~13 s
- [x] Existing `cli_e2e` + `chat_smoke` + `chat_pty` + `chat_stress` still pass
- [x] All 4 mutations verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)