### PR TITLE
ci(chat-smoke): add HTTP server suites + extend Done criteria (PR 11/11)

### DIFF
--- a/.github/workflows/chat-smoke.yml
+++ b/.github/workflows/chat-smoke.yml
@@ -1,11 +1,12 @@
 name: Chat Smoke (nightly)
 
-# Runs the chat / pty / stress smoke suites against real models.
-# These are #[ignore]'d in cargo test by default — opt in here.
+# Runs every chat / pty / stress / server smoke suite against real models.
+# All are #[ignore]'d in `cargo test` by default — opt in here.
 #
 # Trigger:
 #   - Daily at 03:00 UTC
-#   - Manual via workflow_dispatch (use when iterating on cli run / REPL)
+#   - Manual via workflow_dispatch (use when iterating on cli run /
+#     cli serve / REPL / ferrum-server)
 #
 # Not on every PR — model pulls + cold-loads cost ~5–10 min per lane.
 # PR-time CI (.github/workflows/ci.yml) already catches compile errors
@@ -74,3 +75,18 @@ jobs:
         run: |
           cargo test --release -p ferrum-cli --features metal \
             --test chat_stress -- --ignored --test-threads=1
+
+      - name: HTTP server smoke (9 tests — OpenAI /v1/chat/completions)
+        run: |
+          cargo test --release -p ferrum-cli --features metal \
+            --test server_smoke -- --ignored --test-threads=1
+
+      - name: HTTP server OpenAI client contract (4 tests — async-openai)
+        run: |
+          cargo test --release -p ferrum-cli --features metal \
+            --test server_openai_compat -- --ignored --test-threads=1
+
+      - name: HTTP server stress (8 concurrent + prefix cache speedup)
+        run: |
+          cargo test --release -p ferrum-cli --features metal \
+            --test server_stress -- --ignored --test-threads=1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,26 +84,38 @@ The unified path lives in `crates/ferrum-engine/src/continuous_engine.rs::proces
 - CUDA code behind `#[cfg(feature = "cuda")]`, Metal behind target OS gates, Triton kernels behind `#[cfg(feature = "triton-kernels")]` (implies cuda)
 - Shared types/traits go in `ferrum-types`/`ferrum-interfaces`, never duplicated
 
-## Done criteria — engine / scheduler / sampler / CLI run changes
+## Done criteria — engine / scheduler / sampler / CLI run / HTTP server
 
 Any PR that touches `ferrum-engine/src/continuous_engine.rs`,
-`ferrum-engine/src/sampler/`, `ferrum-scheduler/`, or
-`ferrum-cli/src/commands/run.rs` is in the d67fbbb blast radius
-(EOS / stop_sequences / stream / multi-turn KV / chat template). It is
-NOT done until the chat smoke suites pass locally:
+`ferrum-engine/src/sampler/`, `ferrum-scheduler/`,
+`ferrum-cli/src/commands/run.rs`, `ferrum-cli/src/commands/serve.rs`,
+or `ferrum-server/` is in the d67fbbb blast radius (EOS /
+stop_sequences / stream / multi-turn KV / chat template / OpenAI wire
+format). It is NOT done until both blast-radius suites pass locally:
 
 ```bash
-ferrum pull qwen3:0.6b           # + tinyllama, qwen2.5:0.5b for full matrix
-cargo test --release -p ferrum-cli --features metal --test chat_smoke -- --ignored --test-threads=1
-cargo test --release -p ferrum-cli --features metal --test chat_pty   -- --ignored --test-threads=1
-cargo test --release -p ferrum-cli --features metal --test chat_stress -- --ignored --test-threads=1
+# Pre-pull models once
+ferrum pull qwen3:0.6b           # + tinyllama, qwen2.5:0.5b for full chat matrix
+
+# CLI lane (REPL / PTY / stress)
+cargo test --release -p ferrum-cli --features metal --test chat_smoke   -- --ignored --test-threads=1
+cargo test --release -p ferrum-cli --features metal --test chat_pty     -- --ignored --test-threads=1
+cargo test --release -p ferrum-cli --features metal --test chat_stress  -- --ignored --test-threads=1
+
+# HTTP server lane (OpenAI /v1/chat/completions)
+cargo test --release -p ferrum-cli --features metal --test server_smoke         -- --ignored --test-threads=1
+cargo test --release -p ferrum-cli --features metal --test server_openai_compat -- --ignored --test-threads=1
+cargo test --release -p ferrum-cli --features metal --test server_stress        -- --ignored --test-threads=1
 ```
 
-Total ~70 s on M1 Metal (`--release` is required — debug is ~5× slower).
-Nightly CI (`.github/workflows/chat-smoke.yml`) runs the same suites on
+Total ~115 s on M1 Metal (`--release` is required — debug is ~5× slower).
+Nightly CI (`.github/workflows/chat-smoke.yml`) runs every suite above on
 macos-latest. PR-time CI (`.github/workflows/ci.yml`) only compiles them
 via `cargo check --all-targets` — actual runs are nightly because each
 test cold-loads a real model.
+
+Known server-side gaps (loose-assertion floor in current tests, tighten
+when each lands a fix): see `~/.claude/projects/*/memory/project_http_server_gaps_2026_05_19.md`.
 
 ## CUDA backend layout
 


### PR DESCRIPTION
## Summary

Closing PR of the HTTP server test series. Two changes:

### 1. `.github/workflows/chat-smoke.yml`

Adds three new steps to the existing macOS Metal nightly job:

- HTTP server smoke (9 tests — OpenAI `/v1/chat/completions`)
- HTTP server OpenAI client contract (4 tests — `async-openai`)
- HTTP server stress (8 concurrent + prefix cache speedup)

The macOS HF model cache is already shared with the existing chat / pty / stress steps, so no extra `ferrum pull` is needed.

### 2. `CLAUDE.md` — Done criteria

Broadens the d67fbbb blast-radius section:

- Adds `ferrum-cli/src/commands/serve.rs` and `ferrum-server/` to the trigger paths.
- Lists the three new HTTP test commands alongside the existing CLI ones.
- Points at `memory/project_http_server_gaps_2026_05_19.md` for tests currently shipping with loose floors (so a future fix PR knows where to tighten).

## Series total — 33 test instances covering d67fbbb on both lanes

| Suite | Tests | Runtime (M1 Metal --release) |
|---|---:|---:|
| `chat_smoke` (CLI REPL via JSONL stdin pipe) | 13 | ~42 s |
| `chat_pty` (CLI PTY + Ctrl+D / Ctrl+C) | 3 | ~8 s |
| `chat_stress` (CLI 30-turn + 3-way concurrency) | 2 | ~19 s |
| `server_smoke` (HTTP OpenAI `/v1/chat/completions`) | 9 | ~25 s |
| `server_openai_compat` (HTTP via `async-openai`) | 4 | ~12 s |
| `server_stress` (HTTP 8 concurrent + prefix cache) | 2 | ~8 s |
| **Total** | **33** | **~115 s** |

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] Workflow YAML validates locally
- [x] CLAUDE.md renders correctly
- [x] All 6 test files exist on disk and were verified to pass in their respective PRs (#196, #197, #199, #198, this PR plus #195 for the CLI ones)

🤖 Generated with [Claude Code](https://claude.com/claude-code)