### PR TITLE
fix(server): reject empty messages array with 400 BadRequest (bug #2/5)

### DIFF
--- a/crates/ferrum-cli/tests/server_smoke.rs
+++ b/crates/ferrum-cli/tests/server_smoke.rs
@@ -341,11 +341,9 @@ async fn test_chat_custom_stop_param_accepted() {
 
 #[tokio::test(flavor = "current_thread")]
 #[ignore = "loads real model"]
-async fn test_chat_empty_messages_no_5xx() {
-    // Empty messages array must not crash the server. OpenAI spec
-    // expects 400, but ferrum currently returns 200 with synthetic
-    // content (see project_http_server_gaps_2026_05_19.md). The only
-    // floor we guard here is "no 5xx / no panic".
+async fn test_chat_empty_messages_400() {
+    // OpenAI spec rejects empty messages with 400 BadRequest. We enforce
+    // this in `chat_completions_handler` before tokenization.
     let fx = ServerFixture::spawn(SMOKE_MODEL).await;
     let resp = Client::new()
         .post(fx.chat_url())
@@ -356,10 +354,10 @@ async fn test_chat_empty_messages_no_5xx() {
         .send()
         .await
         .expect("post");
-    let status = resp.status().as_u16();
-    assert!(
-        status < 500,
-        "empty messages produced 5xx (server crash/panic); got {status}"
+    assert_eq!(
+        resp.status().as_u16(),
+        400,
+        "empty messages should be 400 BadRequest"
     );
 }
 

--- a/crates/ferrum-server/src/axum_server.rs
+++ b/crates/ferrum-server/src/axum_server.rs
@@ -293,6 +293,14 @@ async fn chat_completions_handler(
     );
     debug!("Request: {:?}", request);
 
+    // OpenAI spec requires at least one message. Reject empty arrays at
+    // the boundary rather than synthesising a fake prompt downstream.
+    if request.messages.is_empty() {
+        return Err(ServerError::BadRequest(
+            "messages array must not be empty".to_string(),
+        ));
+    }
+
     // Convert OpenAI request to internal format
     let inference_request =
         convert_chat_request(&request).map_err(|e| ServerError::BadRequest(e.to_string()))?;


### PR DESCRIPTION
## Summary

OpenAI's `/v1/chat/completions` spec requires a non-empty `messages` array. ferrum was accepting `messages: []`, synthesising a fake prompt, and returning 200 with generated text.

Surfaced by PR #197's `test_chat_empty_messages_no_5xx`, which had to ship with the loose "no 5xx" floor while this bug was open.

## Fix

One-line validation at the top of `chat_completions_handler` (before tokenization):

```rust
if request.messages.is_empty() {
    return Err(ServerError::BadRequest("messages array must not be empty".into()));
}
```

`ServerError::BadRequest` already maps to HTTP 400 in `IntoResponse` for `ServerError`.

## Test tightened

| Before | After |
|---|---|
| `test_chat_empty_messages_no_5xx` — asserts `status < 500` (loose floor) | `test_chat_empty_messages_400` — asserts `status == 400` (strict) |

Local: 9/9 tests in `server_smoke` pass.

## Series progress

Bug 2 / 5 from `memory/project_http_server_gaps_2026_05_19.md`. Remaining:

| # | Bug | PR |
|---|---|---|
| 1 | `GET /v1/models` returns `data: []` | next |
| 3 | Custom `stop` sequences leak the stop char | after |
| 4 | `temperature: 0.0` non-deterministic | after |
| 5 | `response_format = json_object` markdown leak | after |

🤖 Generated with [Claude Code](https://claude.com/claude-code)