### PR TITLE
fix(engine): populate loaded_models in ContinuousBatchEngine::status (bug #1/5)

### DIFF
--- a/crates/ferrum-cli/tests/server_smoke.rs
+++ b/crates/ferrum-cli/tests/server_smoke.rs
@@ -363,12 +363,10 @@ async fn test_chat_empty_messages_400() {
 
 #[tokio::test(flavor = "current_thread")]
 #[ignore = "loads real model"]
-async fn test_models_endpoint_structure() {
-    // GET /v1/models must return the OpenAI list envelope. The `data`
-    // array currently comes back empty because
-    // `state.status().loaded_models` isn't populated (see gaps memo);
-    // we only check structure here, not that the loaded model is
-    // listed. Tighten when that gap is fixed.
+async fn test_models_endpoint_lists_loaded() {
+    // GET /v1/models must return the OpenAI list envelope and include
+    // the currently loaded model. Catches regressions where the engine
+    // forgets to plumb its `EngineConfig.model.model_id` into `status()`.
     let fx = ServerFixture::spawn(SMOKE_MODEL).await;
     let resp = Client::new()
         .get(format!("{}/v1/models", fx.url))
@@ -378,7 +376,19 @@ async fn test_models_endpoint_structure() {
     assert_eq!(resp.status(), 200);
     let body: Value = resp.json().await.expect("json");
     assert_eq!(body["object"].as_str(), Some("list"));
-    assert!(body["data"].is_array(), "data must be an array");
+    let data = body["data"].as_array().expect("data must be an array");
+    assert!(!data.is_empty(), "/v1/models data array must not be empty");
+    // The loaded model's id is `Qwen/Qwen3-0.6B` after alias resolution;
+    // the request alias was `qwen3:0.6b`. Match on the canonical id.
+    let ids: Vec<_> = data.iter().filter_map(|m| m["id"].as_str()).collect();
+    assert!(
+        ids.iter()
+            .any(|id| id.to_lowercase().contains("qwen3-0.6b")),
+        "expected loaded model in /v1/models data; got ids: {ids:?}"
+    );
+    for entry in data {
+        assert_eq!(entry["object"].as_str(), Some("model"));
+    }
 }
 
 #[tokio::test(flavor = "current_thread")]

--- a/crates/ferrum-engine/src/continuous_engine.rs
+++ b/crates/ferrum-engine/src/continuous_engine.rs
@@ -2289,7 +2289,7 @@ impl InferenceEngine for ContinuousBatchEngine {
         let metrics = self.inner.scheduler.metrics();
         EngineStatus {
             is_ready: self.inner.is_running.load(Ordering::SeqCst),
-            loaded_models: vec![],
+            loaded_models: vec![self.inner.config.model.model_id.clone()],
             active_requests: metrics.running_requests,
             queued_requests: metrics.waiting_requests,
             memory_usage: ferrum_types::MemoryUsage {


### PR DESCRIPTION
## Summary

`GET /v1/models` was returning `data: []` because `ContinuousBatchEngine::status` had `loaded_models: vec![]` hard-coded — ignoring the model_id the engine already had stored in `self.inner.config.model.model_id`.

OpenAI clients that auto-discover the served model (e.g. default `openai-python`) saw zero models and either errored or fell back to a literal `gpt-4` name that ferrum then had to synthesise an answer for.

## Fix

One-line change in `crates/ferrum-engine/src/continuous_engine.rs::status`:

```rust
-loaded_models: vec![],
+loaded_models: vec![self.inner.config.model.model_id.clone()],
```

## Test tightened

| Before | After |
|---|---|
| `test_models_endpoint_structure` — asserts `body.object == "list"` and `data` is an array (allows empty) | `test_models_endpoint_lists_loaded` — asserts the data array is non-empty AND contains `Qwen3-0.6B` (case-insensitive, matches the resolved alias) |

Local: 9/9 server_smoke tests pass.

## Refs

- Bug #1 / 5 from `memory/project_http_server_gaps_2026_05_19.md`
- PR #201 (fix bug #2) is open in parallel; both are independent

🤖 Generated with [Claude Code](https://claude.com/claude-code)