### PR TITLE
fix(server): strip trailing stop sentinel from chat completion (bug #3/5)

### DIFF
--- a/crates/ferrum-cli/tests/server_smoke.rs
+++ b/crates/ferrum-cli/tests/server_smoke.rs
@@ -312,31 +312,39 @@ async fn test_chat_max_tokens_truncation() {
 
 #[tokio::test(flavor = "current_thread")]
 #[ignore = "loads real model"]
-async fn test_chat_custom_stop_param_accepted() {
-    // OpenAI `stop` field must be accepted without 4xx/5xx and produce a
-    // valid completion. The strict assertion that the stop string is
-    // actually honored (period absent in output) is currently a known
-    // bug — kept loose here, will tighten when the sampler stop path is
-    // fixed. See project_http_server_gaps_2026_05_19.md.
+async fn test_chat_custom_stop_strips_sentinel() {
+    // OpenAI convention: a user-supplied `stop` sequence marks a boundary
+    // and is NOT included in the returned completion. The server strips
+    // a trailing stop sentinel on the way out (see `strip_trailing_stop`
+    // in `ferrum-server/src/axum_server.rs`).
     let fx = ServerFixture::spawn(SMOKE_MODEL).await;
-    let resp = Client::new()
+    let body: Value = Client::new()
         .post(fx.chat_url())
         .json(&json!({
             "model": SMOKE_MODEL,
-            "messages": [{"role": "user", "content": "Reply with one short sentence."}],
+            "messages": [{"role": "user", "content": "Reply with one sentence ending in a period."}],
             "max_tokens": 80,
             "temperature": 0.0,
-            "stop": ["XYZ_UNLIKELY_TOKEN"]
+            "stop": ["."]
         }))
         .send()
         .await
-        .expect("post");
-    assert_eq!(resp.status(), 200, "stop param request rejected");
-    let body: Value = resp.json().await.expect("json");
+        .expect("post")
+        .json()
+        .await
+        .expect("json");
     let content = body["choices"][0]["message"]["content"]
         .as_str()
         .unwrap_or("");
-    assert!(!content.trim().is_empty(), "content empty with stop param");
+    assert!(
+        !content.trim_end().ends_with('.'),
+        "stop sentinel '.' should have been stripped; got: {content:?}"
+    );
+    let fr = body["choices"][0]["finish_reason"].as_str();
+    assert!(
+        matches!(fr, Some("stop")),
+        "stop sequence should yield finish_reason=stop; got {fr:?}"
+    );
 }
 
 #[tokio::test(flavor = "current_thread")]

--- a/crates/ferrum-server/src/axum_server.rs
+++ b/crates/ferrum-server/src/axum_server.rs
@@ -450,6 +450,15 @@ async fn handle_chat_completions_sync(
     })?;
     match engine.infer(inference_request).await {
         Ok(output) => {
+            // OpenAI convention: user-supplied `stop` sequences are NOT
+            // included in the final completion text. The engine emits
+            // the stop token alongside everything else (the streaming
+            // chunks include it too, mirroring vLLM's behaviour); we
+            // strip a trailing match here on the way out so the
+            // assistant message a non-streaming client sees never
+            // contains the stop sentinel.
+            let stop_sequences = openai_request.stop.clone().unwrap_or_default();
+            let content = strip_trailing_stop(&output.text, &stop_sequences);
             let response = ChatCompletionsResponse {
                 id: Uuid::new_v4().to_string(),
                 object: "chat.completion".to_string(),
@@ -459,7 +468,7 @@ async fn handle_chat_completions_sync(
                     index: 0,
                     message: Some(ChatMessage {
                         role: MessageRole::Assistant,
-                        content: output.text,
+                        content,
                         name: None,
                     }),
                     delta: None,
@@ -887,6 +896,26 @@ impl std::fmt::Display for MessageRole {
             MessageRole::Function => write!(f, "function"),
         }
     }
+}
+
+/// Strip a single trailing occurrence of any user-supplied stop sequence
+/// from `text`. Mirrors OpenAI's convention that `stop` strings act as
+/// boundaries that are NOT included in the returned completion. We only
+/// strip from the suffix (not all occurrences) because a stop sequence
+/// the model produced legitimately mid-response shouldn't be redacted.
+fn strip_trailing_stop(text: &str, stops: &[String]) -> String {
+    let mut out = text.to_string();
+    let trimmed = out.trim_end();
+    for stop in stops {
+        if stop.is_empty() {
+            continue;
+        }
+        if let Some(prefix) = trimmed.strip_suffix(stop.as_str()) {
+            out = prefix.to_string();
+            break;
+        }
+    }
+    out
 }
 
 /// Render OpenAI-style chat messages into the prompt string the model was


### PR DESCRIPTION
## Summary

OpenAI convention: a user-supplied `stop` sequence marks a boundary and is **not** included in the returned completion. ferrum was emitting the stop sentinel — `stop=["."]` against *"Reply with one sentence ending in a period."* returned `"The sun set behind the hills, casting long shadows."` (period kept).

## Root cause

Two layers, but the fix lives at one of them:

- `should_stop()` in `continuous_engine.rs` checks `stop_token_ids.contains(last_token)` **after** the token is already pushed to `generated_tokens` and streamed to the channel.
- The engine treats single-token user stops the same as EOS — fine for "when do I stop" but wrong for "what's in the output". EOS being hidden is the user-facing behaviour OpenAI clients expect; the engine doesn't know whether a stop token came from EOS or a user `stop` string at output-assembly time.

Rather than threading a "user-stop vs EOS" distinction through the engine, fix at the HTTP boundary — that's the layer that knows the request's `stop` array.

## Fix

In `ferrum-server/src/axum_server.rs`:

```rust
fn strip_trailing_stop(text: &str, stops: &[String]) -> String {
    let mut out = text.to_string();
    let trimmed = out.trim_end();
    for stop in stops {
        if stop.is_empty() { continue; }
        if let Some(prefix) = trimmed.strip_suffix(stop.as_str()) {
            out = prefix.to_string();
            break;
        }
    }
    out
}
```

Called from `handle_chat_completions_sync` against the engine output before building the JSON response. Suffix-only on purpose — a stop string the model produced legitimately mid-response shouldn't be redacted.

**Streaming path unchanged** — clients see the stop char in the final delta, matching vLLM's behaviour. A future PR can mirror the strip on the final stream chunk if needed.

## Test tightened

| Before | After |
|---|---|
| `test_chat_custom_stop_param_accepted` — loose: 200 + non-empty content with stop param | `test_chat_custom_stop_strips_sentinel` — strict: trailing `.` absent + `finish_reason=stop` |

Local: 9/9 server_smoke tests pass.

## Refs

Bug #3 / 5 from `memory/project_http_server_gaps_2026_05_19.md`. Remaining:

- #4 — `temperature: 0.0` non-deterministic
- #5 — `response_format=json_object` markdown leak

🤖 Generated with [Claude Code](https://claude.com/claude-code)