### PR TITLE
fix(engine): prefix cache default OFF — restores greedy determinism (bug #4/5)

### DIFF
--- a/crates/ferrum-cli/tests/server_smoke.rs
+++ b/crates/ferrum-cli/tests/server_smoke.rs
@@ -445,3 +445,44 @@ async fn test_chat_concurrent_2_requests() {
     assert!(!content_a.trim().is_empty(), "request A content empty");
     assert!(!content_b.trim().is_empty(), "request B content empty");
 }
+
+#[tokio::test(flavor = "current_thread")]
+#[ignore = "loads real model"]
+async fn test_chat_greedy_is_deterministic() {
+    // Two identical greedy requests must produce byte-identical
+    // completion content. Originally dropped from PR 8 because prefix
+    // cache (on by default at the time) had a CoW gap that let
+    // request 1's decode mutate the cached KV, so request 2/3 diverged
+    // deterministically into a different stable state. Now the prefix
+    // cache defaults OFF — the cache-induced non-determinism is gone.
+    let fx = ServerFixture::spawn(SMOKE_MODEL).await;
+    let req = json!({
+        "model": SMOKE_MODEL,
+        "messages": [{"role": "user", "content": "Reply with the digits 1 2 3 in order."}],
+        "max_tokens": 20,
+        "temperature": 0.0
+    });
+    let mut contents = Vec::new();
+    for _ in 0..2 {
+        let body: Value = Client::new()
+            .post(fx.chat_url())
+            .json(&req)
+            .send()
+            .await
+            .expect("post")
+            .json()
+            .await
+            .expect("json");
+        contents.push(
+            body["choices"][0]["message"]["content"]
+                .as_str()
+                .unwrap_or("")
+                .to_string(),
+        );
+    }
+    assert_eq!(
+        contents[0], contents[1],
+        "greedy decoding must be deterministic across requests"
+    );
+    assert!(!contents[0].trim().is_empty(), "greedy content empty");
+}

--- a/crates/ferrum-cli/tests/server_stress.rs
+++ b/crates/ferrum-cli/tests/server_stress.rs
@@ -46,15 +46,23 @@ struct ServerFixture {
 
 impl ServerFixture {
     async fn spawn(model: &str) -> Self {
+        Self::spawn_with_env(model, &[]).await
+    }
+
+    /// Spawn the server with extra env vars. Used by tests that need to
+    /// opt in to non-default engine knobs (e.g. `FERRUM_PREFIX_CACHE=1`).
+    async fn spawn_with_env(model: &str, extra_env: &[(&str, &str)]) -> Self {
         let port = free_port();
         let base_url = format!("http://127.0.0.1:{port}");
-        let child = Command::new(ferrum_bin())
-            .args(["serve", model, "--port", &port.to_string()])
+        let mut cmd = Command::new(ferrum_bin());
+        cmd.args(["serve", model, "--port", &port.to_string()])
             .env("NO_COLOR", "1")
             .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn()
-            .expect("spawn ferrum serve");
+            .stderr(Stdio::piped());
+        for (k, v) in extra_env {
+            cmd.env(k, v);
+        }
+        let child = cmd.spawn().expect("spawn ferrum serve");
 
         let client = Client::new();
         let healthz = format!("{base_url}/health");
@@ -151,14 +159,18 @@ async fn test_concurrent_8_requests() {
 #[tokio::test(flavor = "current_thread")]
 #[ignore = "loads real model"]
 async fn test_prefix_cache_speedup() {
-    // Fire two requests sharing a long system prompt. If prefix caching
-    // is active (vLLM-style APC / RadixAttention equivalent), the second
-    // request should hit the cache and complete noticeably faster.
+    // Fire two requests sharing a long system prompt. With the prefix
+    // cache enabled the second request should hit the cache and complete
+    // noticeably faster than the first.
     //
-    // Threshold is generous (second ≤ 90% of first) to avoid CI flake on
-    // slow first-iteration scheduler warmup. If even this loose floor
-    // fails, prefix caching is either disabled or broken.
-    let fx = ServerFixture::spawn(SMOKE_MODEL).await;
+    // Prefix cache now defaults OFF (see continuous_engine.rs for the
+    // CoW gap that motivated the flip). This test opts in explicitly
+    // via `FERRUM_PREFIX_CACHE=1`. Once the CoW write-fork lands, the
+    // default can flip back to ON and this opt-in becomes redundant.
+    //
+    // Threshold is generous (second ≤ 110 % of first) to avoid CI flake
+    // on slow first-iteration scheduler warmup.
+    let fx = ServerFixture::spawn_with_env(SMOKE_MODEL, &[("FERRUM_PREFIX_CACHE", "1")]).await;
     let client = Client::new();
     let url = fx.chat_url();
 

--- a/crates/ferrum-engine/src/continuous_engine.rs
+++ b/crates/ferrum-engine/src/continuous_engine.rs
@@ -589,11 +589,15 @@ impl EngineInner {
         // path (they don't enter the unified batch — they have no model
         // call to make). The remainder are added to `unified_prefills`.
         let model_info = self.model_executor.info();
-        let skip_prefix_cache = if cfg!(feature = "cuda") {
-            std::env::var("FERRUM_PREFIX_CACHE").map_or(true, |v| v != "1")
-        } else {
-            std::env::var("FERRUM_PREFIX_CACHE").is_ok_and(|v| v == "0")
-        };
+        // Prefix cache defaults OFF on every backend. The `clone_handle`
+        // path in `crates/ferrum-kv/src/managers/paged.rs` is COW-by-flag
+        // but the engine write path doesn't fork blocks on first write,
+        // so a second request that hits the cache shares mutated KV from
+        // the first request's decode and diverges deterministically
+        // (request 1 ≠ request 2 == request 3). Reproduced 2026-05-19;
+        // see `~/.claude/projects/*/memory/project_http_server_gaps_2026_05_19.md`.
+        // Opt in via `FERRUM_PREFIX_CACHE=1` once the CoW fix lands.
+        let skip_prefix_cache = std::env::var("FERRUM_PREFIX_CACHE").map_or(true, |v| v != "1");
         let mut unified_prefills: Vec<(RequestId, Vec<TokenId>, Arc<dyn KvCacheHandle>)> =
             Vec::new();
         for rid in &prefill_ids {
@@ -997,17 +1001,21 @@ impl EngineInner {
         // through to full prefill — supporting them needs incremental prefill
         // on top of a cloned KV, not yet exposed by the executor contract.
         //
-        // CUDA default: OFF. Historical candle CUDA decode runner released
-        // the KV on completion, invalidating clones ("No candle KV cache to
-        // export"). The Phase E Model-as-Code CUDA path may be safe, but
-        // end-to-end engine + prefix-cache is not yet validated on GPU.
-        // Toggle via env `FERRUM_PREFIX_CACHE=1` to opt in on CUDA; CPU/Metal
-        // defaults ON (validated).
-        let skip_prefix_cache = if cfg!(feature = "cuda") {
-            std::env::var("FERRUM_PREFIX_CACHE").map_or(true, |v| v != "1")
-        } else {
-            std::env::var("FERRUM_PREFIX_CACHE").is_ok_and(|v| v == "0")
-        };
+        // CUDA + CPU + Metal: prefix cache defaults OFF. The `clone_handle`
+        // path in ferrum-kv flags blocks as COW but the write path doesn't
+        // fork before mutating, so cache hits share decode-time mutations
+        // back into the cached prefix — first request differs from
+        // subsequent ones (reproduced 2026-05-19, see gaps memo). Opt in
+        // via env `FERRUM_PREFIX_CACHE=1` once the CoW fix lands.
+        // Prefix cache defaults OFF on every backend. The `clone_handle`
+        // path in `crates/ferrum-kv/src/managers/paged.rs` is COW-by-flag
+        // but the engine write path doesn't fork blocks on first write,
+        // so a second request that hits the cache shares mutated KV from
+        // the first request's decode and diverges deterministically
+        // (request 1 ≠ request 2 == request 3). Reproduced 2026-05-19;
+        // see `~/.claude/projects/*/memory/project_http_server_gaps_2026_05_19.md`.
+        // Opt in via `FERRUM_PREFIX_CACHE=1` once the CoW fix lands.
+        let skip_prefix_cache = std::env::var("FERRUM_PREFIX_CACHE").map_or(true, |v| v != "1");
         if !skip_prefix_cache {
             let hit = self
                 .prefix_cache
@@ -1236,11 +1244,15 @@ impl EngineInner {
         )> = Vec::new();
 
         let model_info = self.model_executor.info();
-        let skip_prefix_cache = if cfg!(feature = "cuda") {
-            std::env::var("FERRUM_PREFIX_CACHE").map_or(true, |v| v != "1")
-        } else {
-            std::env::var("FERRUM_PREFIX_CACHE").is_ok_and(|v| v == "0")
-        };
+        // Prefix cache defaults OFF on every backend. The `clone_handle`
+        // path in `crates/ferrum-kv/src/managers/paged.rs` is COW-by-flag
+        // but the engine write path doesn't fork blocks on first write,
+        // so a second request that hits the cache shares mutated KV from
+        // the first request's decode and diverges deterministically
+        // (request 1 ≠ request 2 == request 3). Reproduced 2026-05-19;
+        // see `~/.claude/projects/*/memory/project_http_server_gaps_2026_05_19.md`.
+        // Opt in via `FERRUM_PREFIX_CACHE=1` once the CoW fix lands.
+        let skip_prefix_cache = std::env::var("FERRUM_PREFIX_CACHE").map_or(true, |v| v != "1");
 
         for rid in request_ids {
             let (input_tokens, num_tokens) = {

--- a/crates/ferrum-engine/tests/continuous_batch_test.rs
+++ b/crates/ferrum-engine/tests/continuous_batch_test.rs
@@ -306,8 +306,20 @@ async fn concurrent_streams_all_complete() {
 // Prefix cache tests
 // ────────────────────────────────────────────────────────────────────────────
 
-/// CPU/Metal-only — engine defaults `skip_prefix_cache = true` on cuda builds.
-#[cfg(not(feature = "cuda"))]
+/// Prefix cache hit path — engine defaults `skip_prefix_cache = true`
+/// on every backend (the CoW write-fork path in ferrum-kv isn't fully
+/// wired, see `~/.claude/projects/*/memory/project_http_server_gaps_2026_05_19.md`
+/// bug #4). Opt in by running with `FERRUM_PREFIX_CACHE=1`:
+///
+///     FERRUM_PREFIX_CACHE=1 cargo test -p ferrum-engine \
+///         --test continuous_batch_test prefix_cache_avoids_second_prefill \
+///         -- --ignored
+///
+/// Marked `#[ignore]` so default `cargo test` stays green. Equivalent
+/// user-observable coverage lives in
+/// `ferrum-cli/tests/server_stress.rs::test_prefix_cache_speedup`,
+/// which uses subprocess env isolation (safe under parallel tests).
+#[ignore = "prefix cache defaults OFF; opt in with FERRUM_PREFIX_CACHE=1 + --ignored"]
 #[tokio::test]
 async fn prefix_cache_avoids_second_prefill() {
     let executor = Arc::new(MockModelExecutor::instant(VOCAB_SIZE));

--- a/crates/ferrum-engine/tests/prefix_cache_test.rs
+++ b/crates/ferrum-engine/tests/prefix_cache_test.rs
@@ -43,14 +43,12 @@ fn make_request(prompt: &str, max_tokens: usize) -> InferenceRequest {
 }
 
 /// Two identical prompts in a row should hit the prefix cache on the
-/// second call (tokenization produces the same TokenId vec → exact match).
-///
-/// CPU/Metal-only: when compiled with `--features cuda`, the engine
-/// defaults `skip_prefix_cache = true` (continuous_engine.rs comment:
-/// "end-to-end engine + prefix-cache not yet validated on GPU").
-/// These tests use Mock backends but the engine's gate is a compile-
-/// time `cfg!(feature = "cuda")`, so they have to mirror it.
-#[cfg(not(feature = "cuda"))]
+/// second call. Engine defaults `skip_prefix_cache = true` (CoW
+/// write-fork gap, see gaps memo bug #4) — opt in via
+/// `FERRUM_PREFIX_CACHE=1 cargo test ... -- --ignored`. Equivalent
+/// user-visible coverage in
+/// `ferrum-cli/tests/server_stress.rs::test_prefix_cache_speedup`.
+#[ignore = "prefix cache defaults OFF; opt in with FERRUM_PREFIX_CACHE=1 + --ignored"]
 #[tokio::test]
 async fn prefix_cache_hit_on_repeat_prompt() {
     let engine = make_engine();
@@ -106,8 +104,8 @@ async fn prefix_cache_cold_start_miss() {
 
 /// Stats accessor returns sensible counters after mixed traffic.
 ///
-/// CPU/Metal-only (see `prefix_cache_hit_on_repeat_prompt`).
-#[cfg(not(feature = "cuda"))]
+/// Cache off by default — opt in (see `prefix_cache_hit_on_repeat_prompt`).
+#[ignore = "prefix cache defaults OFF; opt in with FERRUM_PREFIX_CACHE=1 + --ignored"]
 #[tokio::test]
 async fn prefix_cache_stats_accounting() {
     let engine = make_engine();


### PR DESCRIPTION
## Summary

Two identical greedy (`temperature: 0.0`) requests to a fresh server produced different outputs.

Reproduced 2026-05-19 via curl against `cli serve qwen3:0.6b`:

```
Request 1: "1 2 3"
Request 2: "1 Answer: 1000000000000000"
Request 3: "1 Answer: 1000000000000000"
```

Identical request payload, identical prompt, identical sampling params. First token matches; second diverges; requests 2+ converge to a different stable state.

## Root cause — prefix cache CoW gap

Isolated by re-running the same curl with `FERRUM_PREFIX_CACHE=0`:

```
Request 1: "1 2 3"
Request 2: "1 2 3"
Request 3: "1 2 3"  ✅
```

`PagedKvCacheHandle::clone_handle` in `crates/ferrum-kv/src/managers/paged.rs` is **COW-by-flag** — it sets `has_cow_refs = true` and bumps the ref count but **does not fork the underlying blocks** before the new handle is used for writes. The engine's decode write path doesn't check `is_cow()` either. So:

1. Request 1 stores its prefix KV in the cache.
2. Decoder writes `"1 2 3"` into the same physical blocks (mutating the cached state).
3. Request 2's prefix-cache hit clones the *contaminated* KV.
4. Decode picks up extra residue → diverges deterministically.

## Pragmatic fix

Flip the prefix cache default to OFF on every backend. CUDA was already OFF (different historical reason — candle CUDA decode runner used to release KV on completion). Metal/CPU flipped from ON to match.

The three identical toggle blocks in `continuous_engine.rs` collapse to one line:

```rust
let skip_prefix_cache = std::env::var("FERRUM_PREFIX_CACHE")
    .map_or(true, |v| v != "1");
```

Opt in via `FERRUM_PREFIX_CACHE=1` once the underlying CoW write-fork lands in `ferrum-kv`.

## Test changes

- **Re-add `test_chat_greedy_is_deterministic`** to `server_smoke.rs` (was dropped from PR #197 because of this bug). Asserts two identical greedy requests produce byte-identical content. Now passes.
- **Update `test_prefix_cache_speedup`** in `server_stress.rs` to opt in via `FERRUM_PREFIX_CACHE=1`. Speedup still measurable: `first=437ms / second=103ms` — **76 % faster** with cache on.
- **New `ServerFixture::spawn_with_env` helper** for tests that need non-default engine env knobs.

Local: 10/10 `server_smoke` + 2/2 `server_stress` pass.

## Refs

Bug #4 / 5 from `memory/project_http_server_gaps_2026_05_19.md`. Closes the user-visible non-determinism. The underlying CoW write-fork bug in `ferrum-kv` stays open as a separate item — should be fixed when prefix cache is re-enabled by default.

Remaining: bug #5 (response_format markdown leak).

🤖 Generated with [Claude Code](https://claude.com/claude-code)