### PR TITLE
fix(server): strip markdown fence around JSON mode output (bug #5/5)

### DIFF
--- a/crates/ferrum-cli/tests/server_openai_compat.rs
+++ b/crates/ferrum-cli/tests/server_openai_compat.rs
@@ -221,20 +221,14 @@ async fn test_openai_client_response_format_json_object() {
     let response = client.chat().create(request).await.expect("chat request");
     let content = response.choices[0].message.content.as_deref().unwrap_or("");
     assert!(!content.trim().is_empty(), "json_object response empty");
-    // Loose floor: extract the first `{...}` substring and parse it.
-    // The strict assertion (entire content is valid JSON) currently
-    // fails because `JsonModeProcessor` doesn't hard-mask markdown
-    // fences — see `project_http_server_gaps_2026_05_19.md`. Tighten
-    // when the processor lands a fix.
-    let start = content.find('{');
-    let end = content.rfind('}');
-    let parsed = match (start, end) {
-        (Some(s), Some(e)) if e > s => serde_json::from_str::<serde_json::Value>(&content[s..=e]),
-        _ => Err(serde_json::from_str::<serde_json::Value>("").unwrap_err()),
-    };
+    // Strict: the whole content must be valid JSON. The server strips
+    // markdown fences in `strip_markdown_json_fence` before returning;
+    // models that don't emit a fence at all pass through unchanged.
+    let parsed: Result<serde_json::Value, _> = serde_json::from_str(content.trim());
     assert!(
         parsed.is_ok(),
-        "response_format=json_object should contain parseable JSON; got: {content:?}"
+        "response_format=json_object should produce parseable JSON \
+         (server strips markdown fences); got: {content:?}"
     );
 }
 

--- a/crates/ferrum-server/src/axum_server.rs
+++ b/crates/ferrum-server/src/axum_server.rs
@@ -450,15 +450,23 @@ async fn handle_chat_completions_sync(
     })?;
     match engine.infer(inference_request).await {
         Ok(output) => {
-            // OpenAI convention: user-supplied `stop` sequences are NOT
-            // included in the final completion text. The engine emits
-            // the stop token alongside everything else (the streaming
-            // chunks include it too, mirroring vLLM's behaviour); we
-            // strip a trailing match here on the way out so the
-            // assistant message a non-streaming client sees never
-            // contains the stop sentinel.
+            // Post-process the completion text in two passes:
+            //   1. Strip a markdown fence when `response_format = json_object`
+            //      or `json_schema` — JsonModeProcessor's soft biases don't
+            //      hard-mask the fence the model wants to emit.
+            //   2. Strip a trailing user-supplied `stop` sentinel — OpenAI
+            //      convention is that stop strings mark a boundary and are
+            //      NOT included in the returned completion.
+            // Order matters: fence-strip first reveals the actual JSON,
+            // then any stop sentinel inside that JSON gets trimmed.
+            let after_fence = match &openai_request.response_format {
+                Some(rf) if rf.format_type == "json_object" || rf.format_type == "json_schema" => {
+                    strip_markdown_json_fence(&output.text)
+                }
+                _ => output.text,
+            };
             let stop_sequences = openai_request.stop.clone().unwrap_or_default();
-            let content = strip_trailing_stop(&output.text, &stop_sequences);
+            let content = strip_trailing_stop(&after_fence, &stop_sequences);
             let response = ChatCompletionsResponse {
                 id: Uuid::new_v4().to_string(),
                 object: "chat.completion".to_string(),
@@ -916,6 +924,27 @@ fn strip_trailing_stop(text: &str, stops: &[String]) -> String {
         }
     }
     out
+}
+
+/// When `response_format = json_object` is set, the model is meant to
+/// emit valid JSON only. Qwen / Llama instruct models frequently wrap
+/// the JSON in markdown fences anyway (```` ```json ... ``` ````)
+/// because that's how they were trained. `JsonModeProcessor` only
+/// applies soft logit biases, not a hard mask, so the fence slips
+/// through. Strip a single outermost ` ```json ... ``` ` /
+/// ` ``` ... ``` ` wrapper. Preserves inner JSON exactly. Returns the
+/// input unchanged if no fence is present.
+fn strip_markdown_json_fence(text: &str) -> String {
+    let trimmed = text.trim();
+    // Try the most specific marker first.
+    for prefix in ["```json\n", "```json", "```\n", "```"] {
+        if let Some(rest) = trimmed.strip_prefix(prefix) {
+            if let Some(inner) = rest.strip_suffix("```") {
+                return inner.trim().to_string();
+            }
+        }
+    }
+    text.to_string()
 }
 
 /// Render OpenAI-style chat messages into the prompt string the model was


### PR DESCRIPTION
## Summary

`response_format = json_object` was returning markdown-fenced JSON:

```
"```json\n{\"name\":\"John Doe\",\"age\":30}\n```"
```

`JsonModeProcessor` (in `crates/ferrum-sampler/src/json_mode.rs`) is wired through `continuous_engine.rs:148` and applies **soft logit biases** (`structural_bias: 5.0`, `invalid_penalty: -10.0`) to nudge the model toward JSON. But Qwen / Llama instruct models' trained reflex of wrapping JSON in markdown fences is stronger than the bias.

A real fix is a sampler-architecture rewrite (hard grammar masking, like `RegexGuidedProcessor` in `guided.rs`). That's a separate, larger PR.

## Pragmatic fix

Same boundary approach as PR #203 (stop sentinel): strip the fence on the way out of the HTTP handler.

New helper in `ferrum-server/src/axum_server.rs`:

```rust
fn strip_markdown_json_fence(text: &str) -> String {
    let trimmed = text.trim();
    for prefix in ["```json\n", "```json", "```\n", "```"] {
        if let Some(rest) = trimmed.strip_prefix(prefix) {
            if let Some(inner) = rest.strip_suffix("```") {
                return inner.trim().to_string();
            }
        }
    }
    text.to_string()
}
```

Wired into `handle_chat_completions_sync` against the engine output **only when** `response_format.type` is `json_object` or `json_schema`. Models that don't emit a fence pass through unchanged.

Streaming path unchanged for now — clients see the fence in deltas, matching vLLM's pre-grammar behaviour.

## Test tightened

| Before | After |
|---|---|
| `parsed = content[first '{' .. last '}']` — loose: "contains parseable JSON somewhere" | `parsed = serde_json::from_str(content.trim())` — strict: "whole content is valid JSON" |

Local: 4/4 `server_openai_compat` tests pass.

## Refs

Bug #5 / 5 from `memory/project_http_server_gaps_2026_05_19.md`. **Closes the last user-visible gap from the 2026-05-19 bug inventory.**

Hardening `JsonModeProcessor` into a real hard-mask grammar (analogous to `RegexGuidedProcessor`) remains open as a separate item — when that lands, the boundary strip becomes redundant and can be removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)