### PR TITLE
test(phase-3.1): qk_norm_rope op-diff + varlen/marlin stubs

### DIFF
--- a/crates/ferrum-testkit/src/op_diff/marlin_matmul.rs
+++ b/crates/ferrum-testkit/src/op_diff/marlin_matmul.rs
@@ -1,0 +1,33 @@
+//! `marlin_matmul` (GPTQ INT4) op-diff harness — **PARTIAL: planning stub**.
+//!
+//! The full op needs:
+//!   - A: fp16 input `[m, k]`
+//!   - B: packed INT4 weight in Marlin tile layout `[k / pack_factor, n]`
+//!   - scales: fp16 `[k / group_size, n]`
+//!   - zeros: int32 optional, `[k / group_size, n / pack_factor]`
+//!   - g_idx: int32 optional, `[k]` for desc_act
+//!
+//! Setup needs a Marlin packer that converts a reference fp32 weight
+//! matrix into the specific tile layout (`pack_factor=8`, `tile_size=16`,
+//! interleaved nibbles). The packer lives in `ferrum-quantization` /
+//! `ferrum-kernels/quantization/gptq_marlin/` but isn't exposed as a
+//! testkit-callable helper.
+//!
+//! Reference impl: CPU backend's `gemm_quant` for `QuantKind::Gptq`
+//! dequantizes the packed B back to fp32 then runs a regular sgemm.
+//! That's what we'd compare CUDA's hand-tuned Marlin kernel against.
+//!
+//! Punted to follow-up: needs `marlin_pack_fixture(fp32 weight) ->
+//! QuantWeights<B>` helper that all backends agree on. Without it
+//! the test would be testing the PACKER not the matmul.
+
+#![allow(dead_code)]
+
+pub struct MarlinMatmulOp {
+    pub m: usize,
+    pub n: usize,
+    pub k: usize,
+    pub group_size: usize,
+}
+
+// impl OpUnderTest for MarlinMatmulOp — pending marlin_pack_fixture helper.

--- a/crates/ferrum-testkit/src/op_diff/mod.rs
+++ b/crates/ferrum-testkit/src/op_diff/mod.rs
@@ -28,6 +28,9 @@
 //! once empirical baselines are stable.
 
 pub mod gemm;
+pub mod marlin_matmul; // stub — see file docs
+pub mod paged_varlen_attn; // stub — see file docs
+pub mod qk_norm_rope;
 pub mod rms_norm;
 pub mod silu_mul;
 

--- a/crates/ferrum-testkit/src/op_diff/paged_varlen_attn.rs
+++ b/crates/ferrum-testkit/src/op_diff/paged_varlen_attn.rs
@@ -1,0 +1,30 @@
+//! `paged_varlen_attention` op-diff harness — **PARTIAL: planning stub**.
+//!
+//! The full op needs:
+//!   - cu_seqlens (cumulative seq lengths, `[batch+1]` u32)
+//!   - paged K/V cache (`[num_blocks, num_heads, block_size, head_dim]`)
+//!   - block tables (`[batch, max_blocks_per_seq]` i32)
+//!   - Q tensor (`[total_tokens, num_heads, head_dim]`)
+//!   - softmax_scale, num_kv_heads (for GQA)
+//!
+//! The CPU reference impl exists in `crates/ferrum-kernels/src/backend/cpu.rs`
+//! but reconstructing valid paged tables from scratch is ~200 lines of
+//! setup. Punting for a follow-up: needs a shared `paged_kv_fixture()`
+//! helper in `ferrum-testkit::fixtures` to produce a valid block_table
+//! + cu_seqlens pair from a sequence length list, which can be reused
+//! by `paged_decode_attention` op-diff too.
+//!
+//! See PR #206's "Known gaps" section.
+
+#![allow(dead_code)]
+
+pub struct PagedVarlenAttnOp {
+    pub batch: usize,
+    pub seq_lens: Vec<usize>,
+    pub num_heads: usize,
+    pub num_kv_heads: usize,
+    pub head_dim: usize,
+    pub block_size: usize,
+}
+
+// impl OpUnderTest for PagedVarlenAttnOp — pending paged_kv_fixture helper.

--- a/crates/ferrum-testkit/src/op_diff/qk_norm_rope.rs
+++ b/crates/ferrum-testkit/src/op_diff/qk_norm_rope.rs
@@ -1,0 +1,150 @@
+//! `qk_norm_rope` op-diff harness — covers the fused
+//! rms_norm + rotary-position-embedding + head-major transpose used in
+//! all transformer attention layers (`split_qkv_norm_rope_into_paged_cache_f16`
+//! in nsys traces — top-10 kernel on M3).
+//!
+//! Layout:
+//!   input  `[tokens, heads, head_dim]` — token-major
+//!   norm_w `[head_dim]`
+//!   cos    `[max_pos, head_dim/2]`
+//!   sin    `[max_pos, head_dim/2]`
+//!   output `[heads, tokens, head_dim]` — head-major after the fused
+//!          transpose
+//!
+//! `mode = 1` exercises the actual RoPE pairs path; `mode = 0` is the
+//! transpose-only fallback (which the harness can also test for fast
+//! sanity).
+
+use super::{random_vec, OpUnderTest, Output};
+
+pub struct QkNormRopeOp {
+    pub tokens: usize,
+    pub heads: usize,
+    pub head_dim: usize,
+    pub pos_offset: usize,
+    pub eps: f32,
+    pub mode: i32,
+}
+
+impl QkNormRopeOp {
+    fn max_pos(&self) -> usize {
+        self.pos_offset + self.tokens + 16 // small safety margin
+    }
+    fn output_len(&self) -> usize {
+        self.tokens * self.heads * self.head_dim
+    }
+
+    /// Inputs derived from seed:
+    ///   x:     [-2, 2)
+    ///   norm:  [0.5, 1.5)
+    ///   cos/sin: precomputed RoPE rotation tables (theta_i = 10000^{-2i/d})
+    fn build_input(&self, seed: u64) -> (Vec<f32>, Vec<f32>, Vec<f32>, Vec<f32>) {
+        let half = self.head_dim / 2;
+        let x = random_vec(self.tokens * self.heads * self.head_dim, -2.0, 2.0, seed);
+        let norm = random_vec(self.head_dim, 0.5, 1.5, seed.wrapping_add(1));
+
+        let mut cos = Vec::with_capacity(self.max_pos() * half);
+        let mut sin = Vec::with_capacity(self.max_pos() * half);
+        for pos in 0..self.max_pos() {
+            for i in 0..half {
+                let theta = 10000f32.powf(-(i as f32) * 2.0 / self.head_dim as f32);
+                let angle = pos as f32 * theta;
+                cos.push(angle.cos());
+                sin.push(angle.sin());
+            }
+        }
+        (x, norm, cos, sin)
+    }
+}
+
+impl OpUnderTest for QkNormRopeOp {
+    fn name(&self) -> &str {
+        "qk_norm_rope"
+    }
+
+    fn run_cpu(&self, seed: u64) -> Output {
+        use ferrum_kernels::backend::cpu::CpuBackend;
+        use ferrum_kernels::backend::Backend;
+        let (x, w, cos, sin) = self.build_input(seed);
+        let mut ctx = CpuBackend::new_context();
+        let x_buf = CpuBackend::from_slice(&x);
+        let w_buf = CpuBackend::from_slice(&w);
+        let cos_buf = CpuBackend::from_slice(&cos);
+        let sin_buf = CpuBackend::from_slice(&sin);
+        let mut out = CpuBackend::alloc(self.output_len());
+        CpuBackend::qk_norm_rope(
+            &mut ctx,
+            &x_buf,
+            &w_buf,
+            &cos_buf,
+            &sin_buf,
+            &mut out,
+            self.tokens,
+            self.heads,
+            self.head_dim,
+            self.pos_offset,
+            self.eps,
+            self.mode,
+        );
+        CpuBackend::sync(&mut ctx);
+        CpuBackend::to_vec(&out, self.output_len())
+    }
+
+    #[cfg(all(target_os = "macos", feature = "metal"))]
+    fn run_metal(&self, seed: u64) -> Output {
+        use ferrum_kernels::backend::metal::MetalBackend;
+        use ferrum_kernels::backend::Backend;
+        let (x, w, cos, sin) = self.build_input(seed);
+        let mut ctx = MetalBackend::new_context();
+        let x_buf = MetalBackend::from_slice(&x);
+        let w_buf = MetalBackend::from_slice(&w);
+        let cos_buf = MetalBackend::from_slice(&cos);
+        let sin_buf = MetalBackend::from_slice(&sin);
+        let mut out = MetalBackend::alloc(self.output_len());
+        MetalBackend::qk_norm_rope(
+            &mut ctx,
+            &x_buf,
+            &w_buf,
+            &cos_buf,
+            &sin_buf,
+            &mut out,
+            self.tokens,
+            self.heads,
+            self.head_dim,
+            self.pos_offset,
+            self.eps,
+            self.mode,
+        );
+        MetalBackend::sync(&mut ctx);
+        MetalBackend::to_vec(&out, self.output_len())
+    }
+
+    #[cfg(feature = "cuda")]
+    fn run_cuda(&self, seed: u64) -> Output {
+        use ferrum_kernels::backend::cuda::CudaBackend;
+        use ferrum_kernels::backend::Backend;
+        let (x, w, cos, sin) = self.build_input(seed);
+        let mut ctx = CudaBackend::new_context();
+        let x_buf = CudaBackend::from_slice(&x);
+        let w_buf = CudaBackend::from_slice(&w);
+        let cos_buf = CudaBackend::from_slice(&cos);
+        let sin_buf = CudaBackend::from_slice(&sin);
+        let mut out = CudaBackend::alloc(self.output_len());
+        CudaBackend::qk_norm_rope(
+            &mut ctx,
+            &x_buf,
+            &w_buf,
+            &cos_buf,
+            &sin_buf,
+            &mut out,
+            self.tokens,
+            self.heads,
+            self.head_dim,
+            self.pos_offset,
+            self.eps,
+            self.mode,
+        );
+        CudaBackend::sync(&mut ctx);
+        CudaBackend::to_vec(&out, self.output_len())
+    }
+}

--- a/crates/ferrum-testkit/tests/op_diff.rs
+++ b/crates/ferrum-testkit/tests/op_diff.rs
@@ -13,7 +13,8 @@
 //! harness still runs and produces a sensible reference output.
 
 use ferrum_testkit::op_diff::{
-    compare_backends, gemm::GemmOp, rms_norm::RmsNormOp, silu_mul::SiluMulOp, NMSE_FP16_TOL,
+    compare_backends, gemm::GemmOp, qk_norm_rope::QkNormRopeOp, rms_norm::RmsNormOp,
+    silu_mul::SiluMulOp, NMSE_FP16_TOL,
 };
 
 #[test]
@@ -82,6 +83,53 @@ fn gemm_qkv_shape() {
     // since CPU O(m*n*k) loop is cubic.
     let op = GemmOp { m: 2, n: 4096, k: 4096 };
     let report = compare_backends(&op, 31);
+    check_accelerator_tolerance(&report, NMSE_FP16_TOL);
+}
+
+#[test]
+fn qk_norm_rope_small_mode_0() {
+    // Mode 0 = plain transpose; tests that the head-major output
+    // matches across backends.
+    let op = QkNormRopeOp {
+        tokens: 4,
+        heads: 8,
+        head_dim: 64,
+        pos_offset: 0,
+        eps: 1e-5,
+        mode: 0,
+    };
+    let report = compare_backends(&op, 51);
+    check_accelerator_tolerance(&report, NMSE_FP16_TOL);
+}
+
+#[test]
+fn qk_norm_rope_small_mode_1() {
+    // Mode 1 = fused rms_norm + RoPE pairs + transpose.
+    let op = QkNormRopeOp {
+        tokens: 4,
+        heads: 8,
+        head_dim: 64,
+        pos_offset: 0,
+        eps: 1e-5,
+        mode: 1,
+    };
+    let report = compare_backends(&op, 53);
+    check_accelerator_tolerance(&report, NMSE_FP16_TOL);
+}
+
+#[test]
+fn qk_norm_rope_llama_shape_with_offset() {
+    // Llama-3 8B head_dim=128. Position offset matters for decode at
+    // non-zero generation index.
+    let op = QkNormRopeOp {
+        tokens: 2,
+        heads: 32,
+        head_dim: 128,
+        pos_offset: 64,
+        eps: 1e-5,
+        mode: 1,
+    };
+    let report = compare_backends(&op, 71);
     check_accelerator_tolerance(&report, NMSE_FP16_TOL);
 }
 


### PR DESCRIPTION
## Summary

Closes PR #206's known gap on L1 op-diff coverage.

### Fully implemented
- **`qk_norm_rope`** — fused rms_norm + RoPE + head-major transpose. 3 test variants (transpose-only, full RoPE, Llama 128-head with pos_offset). Metal NMSE 0 / 1.5e-14 / 9.1e-15.

### Stubbed with implementation notes
- **`paged_varlen_attn`** — needs shared `paged_kv_fixture` helper (~200 lines of setup)
- **`marlin_matmul`** — needs `marlin_pack_fixture` exposing the GPTQ INT4 packer for cross-backend identity

Both stub files document exactly what's needed so the next person doesn't re-discover.

## Why qk_norm_rope matters

Rotary positional embedding has been a recurring source of subtle bugs across models. The 3 test variants exercise:
1. Pure transpose (mode=0) — catches layout regressions
2. RoPE pairs at pos=0 (mode=1) — catches angle convention bugs
3. RoPE at pos_offset=64 (mode=1) — catches mid-decode position arithmetic bugs

The cos/sin tables are computed in-test from standard `10000^(-2i/d)` theta, so the test catches any rotation-order tweak (rotate-pairs vs rotate-halves, or +π/2 phase convention) — NMSE jumps from 1e-15 to ~1 instantly.

## Test plan

- [x] `cargo test -p ferrum-testkit --test op_diff` — 9 / 9 pass (CPU only, Mac)
- [x] `cargo test -p ferrum-testkit --test op_diff --features metal` — 9 / 9 pass (Mac Metal)
- [ ] CUDA run skipped (Vast pod destroyed); pattern verified by prior gemm/rms_norm/silu_mul CUDA NMSE ~1e-7

🤖 Generated with [Claude Code](https://claude.com/claude-code)