### PR TITLE
docs(m3-goal): flag preliminary session-2026-05-25 numbers

### DIFF
--- a/docs/bench/m3-80pct-goal-2026-05-25/GOAL.md
+++ b/docs/bench/m3-80pct-goal-2026-05-25/GOAL.md
@@ -171,12 +171,50 @@ Lever #1 (vllm-moe-marlin) unblocked. See
 [`session-2026-05-25/RESULTS.md`](session-2026-05-25/RESULTS.md) +
 [`session-2026-05-25/PROGRESS.md`](session-2026-05-25/PROGRESS.md).
 
-| c  | OFF tput | ON tput | Δ%   | ratio_OFF → ratio_ON | gap to 0.80 |
+> ⚠️ **Data-quality caveats — read before quoting any number below**
+>
+> Per the same caveats applied to the original baseline table earlier
+> in this doc, the session-2026-05-25 numbers are **preliminary, not
+> publication-grade**:
+>
+> 1. **vLLM ratios are apples-to-oranges**. The ratio column compares
+>    this session's ferrum runs (`--dataset random --random-input-len
+>    256 --random-output-len 128`) against the historical vLLM column
+>    (2026-05-13 ShareGPT, average input ≤ 200 tokens). random-256 is
+>    roughly 2× heavier on prefill — it suppresses ferrum's throughput
+>    denominator and depresses the ratio (especially at small c where
+>    prefill dominates). The Δ% column (OFF→ON) is sound; the
+>    ratio_OFF / ratio_ON columns are **indicative only**.
+> 2. **n_repeats=1**. Single-shot per cell, no Student-t CI. PLAYBOOK
+>    § 0.4 needs n ≥ 3 before quoting outside the team.
+> 3. **c=4 marked anomaly** is inherited from the previous session's
+>    `num_prompts=30` caveat — **not re-verified** this session. Treat
+>    the +7% Δ as a lower bound; re-run with `num_prompts ≥ 128`
+>    before reading anything into it.
+> 4. **c=32 + FERRUM_GRAPH=0 = "−1.5% vs GRAPH=1"** (in `RESULTS.md`)
+>    sits inside single-shot noise. Don't read it as "graph-off doesn't
+>    help with vllm-moe-marlin" until repeated n ≥ 3.
+> 5. **No nsys / chrome-trace captured for the ON path this session**.
+>    `bottleneck-c1/c4/c16/c32.md` in this directory still describe
+>    the OFF (pre-vllm-moe-marlin) state. We don't yet know which
+>    kernel owns the remaining 23 pp gap at c=32 ON — `moe` may no
+>    longer be 73% of GPU time once vllm-moe-marlin is active.
+>
+> Re-baseline against apples-to-apples vLLM (random 256/128, vLLM
+> 0.20.2 on driver ≥ 575) **and** re-run `sweep_bottleneck.sh
+> qwen3-moe-30b-int4` with `FERRUM_VLLM_MOE=1` before any external
+> communication of this lever's outcome.
+
+| c  | OFF tput | ON tput | Δ%   | ratio_OFF → ratio_ON ⚠️ | gap to 0.80 ⚠️ |
 |---:|---------:|--------:|-----:|---:|---:|
 | 1  | 128.0    | 146.5   | +14% | 0.62 → **0.71** | 9 pp |
-| 4  | 130.1    | 138.8   | +7%  | 0.26 → 0.27 | re-test (anomaly) |
+| 4  | 130.1    | 138.8   | +7%  | 0.26 → 0.27 ⚠️ | re-test (anomaly inherited, not re-verified) |
 | 16 | 673.6    | 818.3   | +22% | 0.54 → **0.65** | 15 pp |
 | 32 | 871.1    | 1079.4  | +24% | 0.46 → **0.57** | 23 pp |
+
+⚠️ markers on a column mean "see caveat #1 — apples-to-oranges with
+the vLLM denominator". The OFF→ON Δ% column itself is internally
+consistent (same hardware, same dataset).
 
 Phase B is partially done — vllm-moe-marlin shipped, but the c=32
 graph-off A/B and Phase 3 chunked-prefill 8192 verify are still
@@ -185,3 +223,17 @@ gap on c=16/c=32. The encoding bug GOAL.md hinted at went deeper
 than visibility flags — see
 [`session-2026-05-25/PROGRESS.md#findings`](session-2026-05-25/PROGRESS.md#findings)
 for the symbol-level diagnosis.
+
+### Next-session must-do (to retire the caveats above)
+
+1. Rent pod with driver ≥ 575, install vLLM 0.20.2, run `vllm bench
+   serve --dataset random --random-input-len 256 --random-output-len
+   128 --num-prompts 256 --n-repeats 5` for c=1/4/16/32 to land the
+   apples-to-apples denominator.
+2. `FERRUM_VLLM_MOE=1 bash scripts/sweep_bottleneck.sh
+   qwen3-moe-30b-int4 1,4,16,32` (this captures chrome trace + nsys)
+   and replace `bottleneck-c*.md` with ON-state data.
+3. Re-run ferrum bench with `num_prompts=128, n_repeats=5` so the
+   throughput column lands with CI95.
+4. Replace this Update block with the publication-grade table once
+   (1)+(3) are in hand.

--- a/docs/bench/m3-80pct-goal-2026-05-25/session-2026-05-25/RESULTS.md
+++ b/docs/bench/m3-80pct-goal-2026-05-25/session-2026-05-25/RESULTS.md
@@ -1,9 +1,16 @@
 # Session bench results — 2026-05-25 vllm-moe-marlin unblock
 
+> ⚠️ **PRELIMINARY** — `n_repeats=1`, `num_prompts=30`, no nsys / chrome-trace
+> captured for the ON path, vLLM ratio column uses a different dataset than
+> ferrum's runs (see `../GOAL.md` Update caveats). The OFF→ON Δ% is
+> internally consistent; the ratio_OFF / ratio_ON columns are indicative
+> only. Don't quote these numbers externally before the next-session
+> re-baseline (re-baseline checklist at the bottom of `../GOAL.md`).
+
 GPU: Vast contract 37796550, RTX 4090 (sm_89), CUDA 13.0.48, driver 580.82.09,
 locked 2520 MHz / 350 W. ferrum commit `47e8dec`. Dataset: random in=256
-out=128, num_prompts=30, warmup=5, n_repeats=1. Same iter-3 env knob set
-as GOAL.md cell-2026-05-25.
+out=128, `num_prompts=30`, warmup=5, **`n_repeats=1` (single-shot, no CI95)**.
+Same iter-3 env knob set as GOAL.md cell-2026-05-25.
 
 ## Numbers
 
@@ -62,12 +69,14 @@ heuristic) + Phase E (chunked-prefill 8192 tokens) still needed.
 Per GOAL.md lever #5 prediction of "+3pp at c=32". With vllm-moe-marlin
 on:
 
-| config | c=32 tput tok/s |
+| config | c=32 tput tok/s (n=1) |
 |---|---:|
 | GRAPH=1 (current default, ON path) | 1079.4 |
 | GRAPH=0 (this test) | 1063.2 |
 
-**GRAPH=0 is -1.5% worse**, not +3pp. The original prediction was vs
-the iter-3 (no vllm-moe-marlin) baseline; the new MoE kernel restructures
-work so graph capture overhead is amortized differently. Ship default
-remains `FERRUM_GRAPH=1` across all c.
+⚠️ **Inconclusive at n=1.** −1.5% is inside single-shot noise (we've
+seen day-to-day c=32 numbers wobble ~3-5% even with locked clocks). Do
+**not** read this as "graph-off doesn't help once vllm-moe-marlin is
+on" — that needs ≥3 repeats per cell. The most we can say from this
+data is "graph-off is not an obvious win at c=32; merits a proper A/B
+in the next session" — not a refutation of GOAL.md lever #5.


### PR DESCRIPTION
## Summary

Self-correction on PR #211's docs. The 2026-05-25 session shipped the vllm-moe-marlin CUDA 13 unblock cleanly, but the bench data attached to that lever has limitations I didn't call out in the original Update block. Flagging them in place so the numbers aren't quoted externally without seeing the caveats.

## Issues being flagged

1. **vLLM ratio column is apples-to-oranges.** Ferrum bench ran `--dataset random --random-input-len 256 --random-output-len 128`; the vLLM column it's compared against is from the 2026-05-13 ShareGPT row (avg ≤200 tok input). Random-256 is ~2× heavier on prefill — depresses the ratio. The caveat is on the original baseline table earlier in the doc, just wasn't propagated to the Update.
2. **`n_repeats=1`** — single-shot, no Student-t CI95. PLAYBOOK § 0.4 wants ≥3 before external quoting.
3. **c=4 'anomaly' was inherited**, not re-verified at `num_prompts=128`.
4. **`c=32 + FERRUM_GRAPH=0 == −1.5% worse`** sits inside single-shot noise — RESULTS.md previously over-claimed this as a refutation of GOAL.md lever #5.
5. **No nsys / chrome trace** captured for the ON path. `bottleneck-c*.md` in the m3-goal dir still describe the OFF (pre-vllm-moe-marlin) state — we don't know which kernel owns the remaining 23 pp gap at c=32 ON.

## Changes

- `docs/bench/m3-80pct-goal-2026-05-25/GOAL.md` — adds a Caveats block above the Update table, adds ⚠️ markers on the ratio columns, adds a "next-session must-do" checklist (vLLM apples-to-apples baseline + sweep_bottleneck.sh with `FERRUM_VLLM_MOE=1` + `n_repeats=5`).
- `docs/bench/m3-80pct-goal-2026-05-25/session-2026-05-25/RESULTS.md` — header warning, weakened graph-off conclusion to "inconclusive at n=1".

The OFF→ON Δ% column itself stays unmarked — it's internally consistent (same hardware, same dataset, same single-shot run for both sides).

## Test plan

- [x] Markdown renders correctly
- [x] No code changes — docs only