### PR TITLE
docs(claude): add behavioral guidelines (read first)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,79 @@
 
 Guidance for Claude Code when working in this repository.
 
+## Behavioral guidelines (read first)
+
+Reduce common LLM coding mistakes. Merge with project-specific
+instructions below as needed.
+
+**Tradeoff:** these guidelines bias toward caution over speed. For
+trivial tasks, use judgment.
+
+### 1. Think before coding
+
+**Don't assume. Don't hide confusion. Surface tradeoffs.**
+
+Before implementing:
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them — don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
+
+### 2. Simplicity first
+
+**Minimum code that solves the problem. Nothing speculative.**
+
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- If you write 200 lines and it could be 50, rewrite it.
+
+Ask yourself: "Would a senior engineer say this is overcomplicated?"
+If yes, simplify.
+
+### 3. Surgical changes
+
+**Touch only what you must. Clean up only your own mess.**
+
+When editing existing code:
+- Don't "improve" adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated dead code, mention it — don't delete it.
+
+When your changes create orphans:
+- Remove imports/variables/functions that YOUR changes made unused.
+- Don't remove pre-existing dead code unless asked.
+
+The test: every changed line should trace directly to the user's
+request.
+
+### 4. Goal-driven execution
+
+**Define success criteria. Loop until verified.**
+
+Transform tasks into verifiable goals:
+- "Add validation" → "Write tests for invalid inputs, then make them pass"
+- "Fix the bug" → "Write a test that reproduces it, then make it pass"
+- "Refactor X" → "Ensure tests pass before and after"
+
+For multi-step tasks, state a brief plan:
+```
+1. [Step] → verify: [check]
+2. [Step] → verify: [check]
+3. [Step] → verify: [check]
+```
+
+Strong success criteria let you loop independently. Weak criteria
+("make it work") require constant clarification.
+
+**These guidelines are working if:** fewer unnecessary changes in
+diffs, fewer rewrites due to overcomplication, and clarifying questions
+come before implementation rather than after mistakes.
+
+---
+
 ## What is this
 
 Ferrum Infer is a Rust-native LLM inference engine. Single binary, no Python — supports Metal (macOS), CUDA (NVIDIA), CPU backends. Targets vLLM-level performance with PagedAttention, continuous batching, custom CUDA kernels.


### PR DESCRIPTION
## Summary

Adds a top-of-doc \"Behavioral guidelines (read first)\" section to `CLAUDE.md` with four rules:

1. **Think before coding** — surface assumptions, present alternatives, ask when unclear.
2. **Simplicity first** — minimum code, nothing speculative, no premature abstractions.
3. **Surgical changes** — touch only what's needed, match existing style, don't refactor adjacent code.
4. **Goal-driven execution** — verifiable success criteria, loop until passed.

## Why now

Distilled from misses in the 2026-05-25 M3 session:

- The vllm-marlin CUDA 13 dispatcher was disabled to unblock the link without first asking whether M2 owners cared about the IST-DASLab fallback (rule 1 + 3).
- Bench numbers were reported in the GOAL.md Update block without flagging `n_repeats=1`, apples-to-oranges vLLM baseline, no nsys on the ON path, or that `bottleneck-c*.md` still described the OFF state — caveats only surfaced after being asked about it (rule 4 — weak success criteria let preliminary numbers ship as if publication-grade; cleaned up in #213).

These guidelines bias toward caution over speed. Project-specific sections below them in CLAUDE.md (Build & dev commands, Done criteria, etc.) keep their precedence when they conflict.

## Test plan

- [x] Markdown renders cleanly
- [x] No code changes