### PR TITLE
perf(bench): make FERRUM_DECODE_OP_PROFILE opt-in via FERRUM_PROFILE_STAGES

### DIFF
--- a/scripts/sweep_bottleneck.sh
+++ b/scripts/sweep_bottleneck.sh
@@ -73,7 +73,11 @@ export FERRUM_MOE_STREAMS=4
 export FERRUM_GREEDY_ARGMAX=1
 export FERRUM_KV_MAX_BLOCKS=2048
 export FERRUM_PAGED_MAX_SEQS=32
-export FERRUM_DECODE_OP_PROFILE=1
+# DECODE_OP_PROFILE inflates cuStreamSynchronize count (~4 stage_end ×
+# 48 layers × per-iter eager work) — cost ~10% c=32 in graph-on
+# regime, ~16% in eager regime. Off by default; opt in for per-stage
+# host timer breakdown. Verified 2026-05-27 (iter-1 A/B on RTX 4090).
+[ "${FERRUM_PROFILE_STAGES:-0}" = "1" ] && export FERRUM_DECODE_OP_PROFILE=1
 
 # Per-cell sweep
 IFS=',' read -ra CELLS <<< "$SWEEP_CSV"


### PR DESCRIPTION
## Summary
- `sweep_bottleneck.sh:76` set `FERRUM_DECODE_OP_PROFILE=1` unconditionally, which inserts `B::sync(ctx)` after every stage_end in `forward_layer_batched_decode` (4 stage_ends × 48 layers × per-iter eager work)
- Cost verified on RTX 4090 c=32 / Qwen3-30B-A3B-GPTQ-Int4:
  - baseline regime (no VLLM_MOE / no MOE_GRAPH): 723.4 → **837.6 tok/s (+15.8%)** when flag removed
  - production regime (VLLM_MOE=1, MOE_GRAPH=1): 894.3 → **979.3 tok/s (+9.5%)** when flag removed
- paris bisect on the flag-off path: outputs \"The capital of France is **Paris**.\" — correctness preserved
- Flag now opt-in via `FERRUM_PROFILE_STAGES=1` for the per-stage host timer use case

## Why this matters

Reframes iter-2 SESSION-REPORT's \"5000 cuStreamSync / 38 per iter\" lever claim — that count was instrumentation overhead from this exact flag, not a real production sync rate. The flag's `stage_end → B::sync` pattern necessarily syncs because it times GPU work with a CPU clock (`Instant::now() + elapsed_after_sync`). True production sync/iter (without the flag) is single-digit at steady state under graph replay.

## Test plan
- [x] iter-1 A/B at no-VLLM_MOE regime: +15.8%
- [x] iter-1.5 A/B at VLLM_MOE=1 + MOE_GRAPH=1: +9.5%
- [x] paris correctness check on flag-off path passes
- [ ] (follow-up) migrate the 4 stage_end sites in qwen3_moe.rs:2849/3066/3290/3637 onto BackendTimer (cuEvent-based, no sync paid) so the flag can stay on without the perf cost. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)