### PR TITLE
fix(autosize): default-on FERRUM_MOE_GRAPH=1 actually lands for HF repo names

### DIFF
--- a/crates/ferrum-cli/src/commands/run.rs
+++ b/crates/ferrum-cli/src/commands/run.rs
@@ -175,6 +175,12 @@ pub struct RunCommand {
 }
 
 pub async fn execute(cmd: RunCommand, config: CliConfig) -> Result<()> {
+    // Default-ON `FERRUM_MOE_GRAPH=1`. Independent of the autosizer
+    // run below — autosize early-returns when the user has set
+    // KV_MAX_BLOCKS + PAGED_MAX_SEQS, skipping the MOE_GRAPH setter
+    // that used to follow.
+    crate::gpu_mem_autosize::apply_moe_graph_default();
+
     // Resolve the model through the central source resolver. Handles
     // .gguf paths, local model dirs, HF cache hits, and HF download in
     // one entry; runs the chat-profile GPU autosize + (for GGUF) sets

--- a/crates/ferrum-cli/src/commands/serve.rs
+++ b/crates/ferrum-cli/src/commands/serve.rs
@@ -129,6 +129,12 @@ pub async fn execute(cmd: ServeCommand, config: CliConfig) -> Result<()> {
         None
     };
 
+    // Default-ON `FERRUM_MOE_GRAPH=1` — kept separate from the
+    // local-dir-gated GPU autosizer below so it lands when the user
+    // passes an HF repo name (most common) instead of a local
+    // safetensors directory.
+    crate::gpu_mem_autosize::apply_moe_graph_default();
+
     // GPU-memory auto-sizing: scale FERRUM_KV_MAX_BLOCKS so weights +
     // KV pool + 4 GB scratch reserve fit in `total_gpu_mem * gpu_util`.
     // Skipped on Mac / when nvidia-smi is missing; respects user-set

--- a/crates/ferrum-cli/src/gpu_mem_autosize.rs
+++ b/crates/ferrum-cli/src/gpu_mem_autosize.rs
@@ -157,6 +157,36 @@ pub enum AutoSizeProfile {
     Chat,
 }
 
+/// Default-ON `FERRUM_MOE_GRAPH=1` for Qwen3-MoE. Read only by
+/// `qwen3_moe.rs::decode_batch_internal`; ignored by every other
+/// model so safe to set unconditionally. Empirically measured at c=32
+/// on RTX 4090 post-moe_align fix:
+///   FERRUM_MOE_GRAPH=0 = 872 tok/s
+///   FERRUM_MOE_GRAPH=1 = 1006 tok/s  (+15.5%)
+///
+/// Standalone (not gated on autosizer running) because:
+///  1. The `apply_auto_size` early-returns when the user sets both
+///     `FERRUM_KV_MAX_BLOCKS` + `FERRUM_PAGED_MAX_SEQS` (apples bench
+///     does this — see sweep_bottleneck.sh), skipping the MOE_GRAPH
+///     setter that follows.
+///  2. `serve` only calls `apply_auto_size` when `--model` is a local
+///     directory; HF repo names (`Qwen/Qwen3-30B-A3B-GPTQ-Int4`)
+///     short-circuit before the autosizer runs.
+///
+/// Both cases left users on `FERRUM_MOE_GRAPH=0` despite the PR #217
+/// default-on intent. Extracting the setter and calling it from
+/// `serve` / `run` unconditionally restores it.
+pub fn apply_moe_graph_default() {
+    let moe_graph_overridden = std::env::var("FERRUM_MOE_GRAPH").is_ok();
+    if !moe_graph_overridden {
+        // SAFETY: set_var is unsafe on Rust 2024; runs once before threads spawn.
+        unsafe {
+            std::env::set_var("FERRUM_MOE_GRAPH", "1");
+        }
+        eprintln!("[auto-size] MOE_GRAPH=1 (default-on for Qwen3-MoE)");
+    }
+}
+
 /// Apply auto-sizing: read CLI flag, query nvidia-smi, set env vars.
 /// Sets BOTH `FERRUM_KV_MAX_BLOCKS` (engine-side BlockPool) and
 /// `FERRUM_PAGED_MAX_SEQS` (model-side paged_pools — sizes the GPU
@@ -268,10 +298,12 @@ pub fn apply_auto_size_with_profile(model_dir: &Path, gpu_util: f32, profile: Au
     };
 
     let kv_capacity_overridden = std::env::var("FERRUM_KV_CAPACITY").is_ok();
-    let moe_graph_overridden = std::env::var("FERRUM_MOE_GRAPH").is_ok();
     // SAFETY: set_var is unsafe on Rust 2024; runs once before threads spawn.
     // MAX_BATCHED_TOKENS already set above (it's independent of the KV pool
     // sizing logic, runs even when the user overrode KV_MAX_BLOCKS + SEQS).
+    // FERRUM_MOE_GRAPH is set by `apply_moe_graph_default()` at the CLI
+    // entry — moved out of here so it lands even when this function
+    // early-returns on full-override.
     unsafe {
         if !kv_overridden {
             std::env::set_var("FERRUM_KV_MAX_BLOCKS", result.max_blocks.to_string());
@@ -282,23 +314,9 @@ pub fn apply_auto_size_with_profile(model_dir: &Path, gpu_util: f32, profile: Au
         if kv_capacity > 0 && !kv_capacity_overridden {
             std::env::set_var("FERRUM_KV_CAPACITY", kv_capacity.to_string());
         }
-        // Default-ON CUDA graph capture for Qwen3-MoE decode layer loop.
-        // Read only by `qwen3_moe.rs::decode_batch_internal`; ignored by
-        // every other model so safe to set unconditionally. Empirically
-        // measured at c=32 on RTX 4090 post-moe_align fix:
-        //   FERRUM_MOE_GRAPH=0 = 872 tok/s
-        //   FERRUM_MOE_GRAPH=1 = 1006 tok/s  (+15.5%)
-        // The "c=32 -6%" regression noted in earlier sessions was on the
-        // pre-fix garbage-emission code path; with the moe_align fix the
-        // graph replay reads correct sorted_token_ids and the cuGraphLaunch
-        // overhead is amortized by the eliminated per-kernel launch cost
-        // (which dominated the eager path's 480-launch/iter MoE block).
-        if !moe_graph_overridden {
-            std::env::set_var("FERRUM_MOE_GRAPH", "1");
-        }
     }
     eprintln!(
-        "[auto-size] KV_MAX_BLOCKS={} PAGED_MAX_SEQS={} KV_CAPACITY={} MOE_GRAPH={}",
+        "[auto-size] KV_MAX_BLOCKS={} PAGED_MAX_SEQS={} KV_CAPACITY={}",
         if kv_overridden {
             "<user>".to_string()
         } else {
@@ -315,11 +333,6 @@ pub fn apply_auto_size_with_profile(model_dir: &Path, gpu_util: f32, profile: Au
             kv_capacity.to_string()
         } else {
             "<default>".to_string()
-        },
-        if moe_graph_overridden {
-            "<user>".to_string()
-        } else {
-            "1".to_string()
         },
     );
 }


### PR DESCRIPTION
## Summary

PR #217 added the autosizer setter for `FERRUM_MOE_GRAPH=1` so Qwen3-MoE
gets the +15.5% CUDA-graph win by default. Two unrelated guards
ended up making the setter dead code on the very workload it was
meant to accelerate:

1. **`apply_auto_size_with_profile` short-circuits when the user
   sets both `FERRUM_KV_MAX_BLOCKS` and `FERRUM_PAGED_MAX_SEQS`**
   (e.g. `scripts/sweep_bottleneck.sh`) — returns at L215 before
   reaching the MOE_GRAPH setter at L296.
2. **`commands/serve.rs` only calls the autosizer when `--model`
   is a literal directory path.** HF repo names (`Qwen/Qwen3-30B-A3B-GPTQ-Int4`,
   the common path) take the `else` branch and skip the autosizer
   entirely.

Either alone is enough to leave production users on
`FERRUM_MOE_GRAPH=0` despite the PR #217 intent.

## Fix

- Extract the MOE_GRAPH setter into `apply_moe_graph_default()` —
  an unconditional default-on with `eprintln!` for visibility.
- Call from both `serve::execute` and `run::execute` before any
  source-resolution gate.
- Remove the now-duplicated setter from
  `apply_auto_size_with_profile` (deduplicates after extraction).

## Test plan

Verified on Vast RTX 4090 (driver 580.159.04, CUDA 13.0,
nvidia/cuda:13.0.0-devel-ubuntu24.04, branch
`session-2026-05-28-perf-loop`):

- [x] `cargo check --workspace` (Mac, no GPU features)
- [x] Build with `cuda,vllm-moe-marlin,vllm-paged-attn-v2`
- [x] `ferrum run Qwen/Qwen3-30B-A3B-GPTQ-Int4 --prompt "..."` —
      paris bisect ✓, autosize log now shows
      `[auto-size] MOE_GRAPH=1 (default-on for Qwen3-MoE)`
- [x] `ferrum serve` c=32 bench-serve, N=2 each — within noise
      vs. pre-fix (auto mean=851 vs. no-flag mean=865 tok/s,
      delta within stddev — see Notes).

## Notes — realized gain depends on hardware

- PR #217 measured +15.5% (872 → 1006 tok/s c=32) on its
  reference 4090. Realized gain on the session-2026-05-28
  Vast pod was within noise (-1.6% mean, ±2% per-run stddev),
  consistent with the iter-3 finding that production sync-rate
  is already single-digit per iter and CPU launch overhead is
  overlapped with GPU on this workload.
- The fix is still correct — it restores PR #217's intended
  default behavior on the production code paths. Users on
  hardware where graph capture amortizes per-call launch
  overhead (e.g. lower CPU contention, locked clocks, or
  different memory-bandwidth profile) will get the +15% PR
  #217 measured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)