### PR TITLE
feat: add stateless Responses API

### DIFF
--- a/.github/workflows/release-cuda.yml
+++ b/.github/workflows/release-cuda.yml
@@ -10,12 +10,12 @@ on:
       release_candidate_tag:
         description: Annotated RC tag whose peeled commit is release_candidate_sha
         required: true
-        default: v0.8.1-rc.1
+        default: v0.8.2-rc.1
         type: string
       staging_label:
         description: Immutable artifact label; this does not create a tag or release
         required: true
-        default: v0.8.1-rc
+        default: v0.8.2-rc
         type: string
       publish_release:
         description: Safety lock; production staging requires false
@@ -58,8 +58,8 @@ jobs:
             echo "release_candidate_sha must be a full lowercase commit SHA" >&2
             exit 1
           fi
-          if ! [[ "${{ inputs.release_candidate_tag }}" =~ ^v0\.8\.1-rc\.[1-9][0-9]*$ ]]; then
-            echo "release_candidate_tag must match v0.8.1-rc.N" >&2
+          if ! [[ "${{ inputs.release_candidate_tag }}" =~ ^v0\.8\.2-rc\.[1-9][0-9]*$ ]]; then
+            echo "release_candidate_tag must match v0.8.2-rc.N" >&2
             exit 1
           fi
           if ! [[ "${{ inputs.staging_label }}" =~ ^[A-Za-z0-9._-]+$ ]]; then
@@ -129,7 +129,7 @@ jobs:
         run: |
           export PATH="$HOME/.cargo/bin:$PATH"
           version="$(cargo metadata --no-deps --format-version 1 | python3 -c 'import json,sys; data=json.load(sys.stdin); print(next(p["version"] for p in data["packages"] if p["name"] == "ferrum-cli"))')"
-          test "$version" = "0.8.1"
+          test "$version" = "0.8.2"
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
       - uses: actions/cache@v4
@@ -137,8 +137,8 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-          key: stage-v0.8.1-linux-x86_64-cuda-sm89-cuda12.4-native-b450d931-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: stage-v0.8.1-linux-x86_64-cuda-sm89-cuda12.4-native-b450d931-cargo-
+          key: stage-v0.8.2-linux-x86_64-cuda-sm89-cuda12.4-native-b450d931-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: stage-v0.8.2-linux-x86_64-cuda-sm89-cuda12.4-native-b450d931-cargo-
 
       - name: Build release CUDA sm89 binary exactly once
         run: |
@@ -171,7 +171,7 @@ jobs:
           cp LICENSE dist/LICENSE
           cp README.md dist/README.md
           cat > dist/CUDA-BUILD.txt <<'EOF'
-          Ferrum v0.8.1 CUDA release binary
+          Ferrum v0.8.2 CUDA release binary
           CUDA toolkit image: nvidia/cuda:12.4.0-devel-ubuntu22.04
           CUDA_COMPUTE_CAP: 89
           Cargo features: cuda,vllm-moe-marlin,vllm-paged-attn-v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,12 +10,12 @@ on:
       release_candidate_tag:
         description: Annotated RC tag whose peeled commit is release_candidate_sha
         required: true
-        default: v0.8.1-rc.1
+        default: v0.8.2-rc.1
         type: string
       staging_label:
         description: Immutable artifact label; this does not create a tag or release
         required: true
-        default: v0.8.1-rc
+        default: v0.8.2-rc
         type: string
       publish_release:
         description: Safety lock; production staging requires false
@@ -46,8 +46,8 @@ jobs:
             echo "release_candidate_sha must be a full lowercase commit SHA" >&2
             exit 1
           fi
-          if ! [[ "${{ inputs.release_candidate_tag }}" =~ ^v0\.8\.1-rc\.[1-9][0-9]*$ ]]; then
-            echo "release_candidate_tag must match v0.8.1-rc.N" >&2
+          if ! [[ "${{ inputs.release_candidate_tag }}" =~ ^v0\.8\.2-rc\.[1-9][0-9]*$ ]]; then
+            echo "release_candidate_tag must match v0.8.2-rc.N" >&2
             exit 1
           fi
           if ! [[ "${{ inputs.staging_label }}" =~ ^[A-Za-z0-9._-]+$ ]]; then
@@ -94,15 +94,15 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: stage-v0.8.1-linux-x86_64-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: stage-v0.8.1-linux-x86_64-
+          key: stage-v0.8.2-linux-x86_64-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: stage-v0.8.2-linux-x86_64-
 
       - name: Verify workspace release version
         id: metadata
         shell: bash
         run: |
           version="$(cargo metadata --no-deps --format-version 1 | python3 -c 'import json,sys; data=json.load(sys.stdin); print(next(p["version"] for p in data["packages"] if p["name"] == "ferrum-cli"))')"
-          test "$version" = "0.8.1"
+          test "$version" = "0.8.2"
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
       - name: Build release CPU binary exactly once
@@ -232,8 +232,8 @@ jobs:
             echo "release_candidate_sha must be a full lowercase commit SHA" >&2
             exit 1
           fi
-          if ! [[ "${{ inputs.release_candidate_tag }}" =~ ^v0\.8\.1-rc\.[1-9][0-9]*$ ]]; then
-            echo "release_candidate_tag must match v0.8.1-rc.N" >&2
+          if ! [[ "${{ inputs.release_candidate_tag }}" =~ ^v0\.8\.2-rc\.[1-9][0-9]*$ ]]; then
+            echo "release_candidate_tag must match v0.8.2-rc.N" >&2
             exit 1
           fi
           if ! [[ "${{ inputs.staging_label }}" =~ ^[A-Za-z0-9._-]+$ ]]; then
@@ -267,15 +267,15 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: stage-v0.8.1-macos-aarch64-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: stage-v0.8.1-macos-aarch64-
+          key: stage-v0.8.2-macos-aarch64-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: stage-v0.8.2-macos-aarch64-
 
       - name: Verify workspace release version
         id: metadata
         shell: bash
         run: |
           version="$(cargo metadata --no-deps --format-version 1 | python3 -c 'import json,sys; data=json.load(sys.stdin); print(next(p["version"] for p in data["packages"] if p["name"] == "ferrum-cli"))')"
-          test "$version" = "0.8.1"
+          test "$version" = "0.8.2"
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
       - name: Build release Metal binary exactly once

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1344,7 +1344,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-bench-core"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "ferrum-types",
  "rand 0.9.2",
@@ -1355,7 +1355,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-cli"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "async-openai",
@@ -1404,7 +1404,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-engine"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1461,7 +1461,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-interfaces"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1484,7 +1484,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-kernels"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "bindgen_cuda",
  "candle-core",
@@ -1506,7 +1506,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-kv"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1526,7 +1526,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-models"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1577,7 +1577,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-native-ops"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "ferrum-types",
  "libc",
@@ -1589,7 +1589,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-native-ops-builder"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "clap",
  "ferrum-native-ops",
@@ -1604,7 +1604,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-quantization"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "candle-core",
  "ferrum-interfaces",
@@ -1621,7 +1621,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-sampler"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1644,7 +1644,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-scheduler"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1672,7 +1672,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-server"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1714,7 +1714,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-testkit"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1732,7 +1732,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-tokenizer"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1758,7 +1758,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-types"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "chrono",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ resolver = "2"
 
 
 [workspace.package]
-version = "0.8.1"
+version = "0.8.2"
 edition = "2021"
 authors = ["Ferrum Team"]
 license = "MIT"
@@ -110,29 +110,29 @@ candle-flash-attn = "0.9.2"
 candle-metal-kernels = "0.9.2"
 
 # Internal crates - New refactored crates
-ferrum-types = { path = "crates/ferrum-types", version = "0.8.1" }
-ferrum-interfaces = { path = "crates/ferrum-interfaces", version = "0.8.1" }
+ferrum-types = { path = "crates/ferrum-types", version = "0.8.2" }
+ferrum-interfaces = { path = "crates/ferrum-interfaces", version = "0.8.2" }
 
 # Internal crates - Implementation crates
-ferrum-scheduler = { path = "crates/ferrum-scheduler", version = "0.8.1" }
-ferrum-tokenizer = { path = "crates/ferrum-tokenizer", version = "0.8.1" }
-ferrum-sampler = { path = "crates/ferrum-sampler", version = "0.8.1" }
-ferrum-kv = { path = "crates/ferrum-kv", version = "0.8.1" }
-ferrum-native-ops = { path = "crates/ferrum-native-ops", version = "0.8.1" }
+ferrum-scheduler = { path = "crates/ferrum-scheduler", version = "0.8.2" }
+ferrum-tokenizer = { path = "crates/ferrum-tokenizer", version = "0.8.2" }
+ferrum-sampler = { path = "crates/ferrum-sampler", version = "0.8.2" }
+ferrum-kv = { path = "crates/ferrum-kv", version = "0.8.2" }
+ferrum-native-ops = { path = "crates/ferrum-native-ops", version = "0.8.2" }
 
 # Unified compute kernels (CUDA/Metal/CPU)
-ferrum-kernels = { path = "crates/ferrum-kernels", version = "0.8.1" }
+ferrum-kernels = { path = "crates/ferrum-kernels", version = "0.8.2" }
 
 # Weight-format abstraction (Dense / GPTQ / AWQ / GGUF)
-ferrum-quantization = { path = "crates/ferrum-quantization", version = "0.8.1" }
+ferrum-quantization = { path = "crates/ferrum-quantization", version = "0.8.2" }
 
 # Internal product crates
-ferrum-engine = { path = "crates/ferrum-engine", version = "0.8.1" }
-ferrum-models = { path = "crates/ferrum-models", version = "0.8.1" }
-ferrum-server = { path = "crates/ferrum-server", version = "0.8.1" }
-ferrum-cli = { path = "crates/ferrum-cli", version = "0.8.1" }
-ferrum-testkit = { path = "crates/ferrum-testkit", version = "0.8.1" }
-ferrum-bench-core = { path = "crates/ferrum-bench-core", version = "0.8.1" }
+ferrum-engine = { path = "crates/ferrum-engine", version = "0.8.2" }
+ferrum-models = { path = "crates/ferrum-models", version = "0.8.2" }
+ferrum-server = { path = "crates/ferrum-server", version = "0.8.2" }
+ferrum-cli = { path = "crates/ferrum-cli", version = "0.8.2" }
+ferrum-testkit = { path = "crates/ferrum-testkit", version = "0.8.2" }
+ferrum-bench-core = { path = "crates/ferrum-bench-core", version = "0.8.2" }
 
 
 [profile.release]

--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ commands without downloading the model or starting an inference engine.
 ## Features
 
 - `ferrum run` and `ferrum serve` in one Rust binary.
-- OpenAI-compatible chat completions, streaming, tools, and structured output.
+- OpenAI-compatible Chat Completions and stateless Responses APIs, streaming,
+  tools, and structured output.
 - Apple Silicon Metal and NVIDIA CUDA from the same runtime.
 - Continuous batching, paged KV cache, prefix cache, and typed admission control.
 - GGUF on Metal and GPTQ/safetensors on CUDA.
@@ -95,6 +96,7 @@ mean tok/s with the 95% confidence-interval half-width across three repeats.
 Ferrum supports:
 
 - chat completions and streaming usage
+- stateless Responses text, streaming, usage, and function tools
 - function tools with `auto`, `none`, `required`, or a named function
 - `json_object` and strict `json_schema` structured output
 - multi-turn sessions, prefix cache, and session cache
@@ -134,10 +136,10 @@ Install from crates.io:
 
 ```bash
 # macOS Apple Silicon Metal
-cargo install ferrum-cli --version 0.8.1 --locked --features metal
+cargo install ferrum-cli --version 0.8.2 --locked --features metal
 
 # NVIDIA CUDA
-cargo install ferrum-cli --version 0.8.1 --locked \
+cargo install ferrum-cli --version 0.8.2 --locked \
   --features cuda,vllm-moe-marlin,vllm-paged-attn-v2
 ```
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -62,7 +62,8 @@ curl http://localhost:8000/v1/chat/completions \
 ## 功能
 
 - 一个 Rust 二进制同时提供 `ferrum run` 和 `ferrum serve`。
-- 支持 OpenAI 兼容的对话、流式输出、tools 和 structured output。
+- 支持 OpenAI 兼容的 Chat Completions 与无状态 Responses API、流式输出、
+  tools 和 structured output。
 - 同一 runtime 覆盖 Apple Silicon Metal 与 NVIDIA CUDA。
 - 支持 continuous batching、paged KV cache、prefix cache 和 typed admission。
 - Metal 使用 GGUF，CUDA 使用 GPTQ/safetensors。
@@ -90,6 +91,7 @@ curl http://localhost:8000/v1/chat/completions \
 Ferrum 支持：
 
 - chat completions 与 streaming usage
+- 无状态 Responses 文本、流式输出、usage 与 function tools
 - `auto`、`none`、`required` 或指定函数的 function tools
 - `json_object` 与 strict `json_schema` structured output
 - 多轮会话、prefix cache 与 session cache
@@ -128,10 +130,10 @@ curl -L https://github.com/sizzlecar/ferrum-infer-rs/releases/latest/download/fe
 
 ```bash
 # macOS Apple Silicon Metal
-cargo install ferrum-cli --version 0.8.1 --locked --features metal
+cargo install ferrum-cli --version 0.8.2 --locked --features metal
 
 # NVIDIA CUDA
-cargo install ferrum-cli --version 0.8.1 --locked \
+cargo install ferrum-cli --version 0.8.2 --locked \
   --features cuda,vllm-moe-marlin,vllm-paged-attn-v2
 ```
 

--- a/crates/ferrum-server/src/axum_server.rs
+++ b/crates/ferrum-server/src/axum_server.rs
@@ -54,6 +54,8 @@ use tower_http::{cors::CorsLayer, trace::TraceLayer};
 use tracing::{debug, error, info, span, warn, Level};
 use uuid::Uuid;
 
+mod responses;
+
 const DEFAULT_SAMPLING_TEMPERATURE: f32 = 0.0;
 const DEFAULT_SAMPLING_TOP_P: f32 = 1.0;
 const DEFAULT_COMPLETION_MAX_TOKENS: u32 = 4096;
@@ -321,6 +323,7 @@ impl AxumServer {
         Router::new()
             // OpenAI API routes
             .route("/v1/chat/completions", post(chat_completions_handler))
+            .route("/v1/responses", post(responses::responses_handler))
             .route("/v1/completions", post(completions_handler))
             .route("/v1/embeddings", post(embeddings_handler))
             .route("/v1/audio/transcriptions", post(transcriptions_handler))
@@ -6579,6 +6582,204 @@ mod tests {
             obj.insert(k.clone(), v.clone());
         }
         serde_json::from_value(value).expect("chat request")
+    }
+
+    #[tokio::test]
+    async fn responses_route_returns_sync_text_and_usage() {
+        let response = post_json(
+            router_with_stub("hello from ferrum"),
+            "/v1/responses",
+            json!({
+                "model": "stub-model",
+                "input": "hello",
+                "store": false
+            }),
+        )
+        .await;
+        assert_eq!(response.status(), AxumStatusCode::OK);
+        let body = response_json(response).await;
+        assert_eq!(body["object"], "response");
+        assert_eq!(body["status"], "completed");
+        assert_eq!(body["store"], false);
+        assert_eq!(body["output"][0]["type"], "message");
+        assert_eq!(body["output"][0]["content"][0]["text"], "hello from ferrum");
+        assert_eq!(body["usage"]["input_tokens"], 7);
+        assert_eq!(body["usage"]["output_tokens"], 2);
+        assert_eq!(body["usage"]["total_tokens"], 9);
+    }
+
+    #[tokio::test]
+    async fn responses_route_streams_ordered_text_events_once() {
+        let response = post_json(
+            router_with_stub_stream_chunks(&["he", "llo"]),
+            "/v1/responses",
+            json!({
+                "model": "stub-model",
+                "input": [{"role": "user", "content": "say hello"}],
+                "stream": true
+            }),
+        )
+        .await;
+        assert_eq!(response.status(), AxumStatusCode::OK);
+        let body = response_text(response).await;
+        for event in [
+            "response.created",
+            "response.output_item.added",
+            "response.output_text.delta",
+            "response.output_text.done",
+            "response.output_item.done",
+            "response.completed",
+        ] {
+            assert!(
+                body.contains(&format!("event: {event}")),
+                "missing {event}: {body}"
+            );
+        }
+        assert_eq!(
+            body.matches("event: response.completed").count(),
+            1,
+            "completed must be emitted exactly once: {body}"
+        );
+        assert!(
+            body.contains("\"delta\":\"he\""),
+            "missing first delta: {body}"
+        );
+        assert!(
+            body.contains("\"delta\":\"llo\""),
+            "missing second delta: {body}"
+        );
+        assert!(body.contains("\"input_tokens\":5"), "missing usage: {body}");
+        assert!(
+            !body.contains("[DONE]"),
+            "Responses streams do not use chat DONE: {body}"
+        );
+    }
+
+    #[tokio::test]
+    async fn responses_route_supports_stateless_function_round_trip() {
+        let tool = json!({
+            "type": "function",
+            "name": "weather",
+            "description": "Get weather",
+            "parameters": {
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+                "required": ["city"]
+            }
+        });
+        let first = post_json(
+            router_with_stub_api_response("", weather_tool_api_response()),
+            "/v1/responses",
+            json!({
+                "model": "stub-model",
+                "input": "Use the weather tool",
+                "tools": [tool.clone()],
+                "tool_choice": "auto"
+            }),
+        )
+        .await;
+        assert_eq!(first.status(), AxumStatusCode::OK);
+        let first_body = response_json(first).await;
+        let call = first_body["output"][0].clone();
+        assert_eq!(call["type"], "function_call");
+        assert_eq!(call["call_id"], "call_1");
+        assert_eq!(call["name"], "weather");
+        assert_eq!(call["arguments"], "{\"city\":\"Paris\"}");
+
+        let second = post_json(
+            router_with_stub("weather received"),
+            "/v1/responses",
+            json!({
+                "model": "stub-model",
+                "input": [
+                    {"role": "user", "content": "Use the weather tool"},
+                    call,
+                    {"type": "function_call_output", "call_id": "call_1", "output": "sunny"}
+                ],
+                "tools": [tool]
+            }),
+        )
+        .await;
+        assert_eq!(second.status(), AxumStatusCode::OK);
+        let second_body = response_json(second).await;
+        assert_eq!(
+            second_body["output"][0]["content"][0]["text"],
+            "weather received"
+        );
+    }
+
+    #[tokio::test]
+    async fn responses_route_streams_function_call_events() {
+        let response = post_json(
+            router_with_stub_api_response("", weather_tool_api_response()),
+            "/v1/responses",
+            json!({
+                "model": "stub-model",
+                "input": "Use the weather tool",
+                "stream": true,
+                "tools": [{
+                    "type": "function",
+                    "name": "weather",
+                    "parameters": {"type": "object"}
+                }]
+            }),
+        )
+        .await;
+        assert_eq!(response.status(), AxumStatusCode::OK);
+        let body = response_text(response).await;
+        assert!(
+            body.contains("event: response.function_call_arguments.delta"),
+            "missing function delta: {body}"
+        );
+        assert!(
+            body.contains("event: response.function_call_arguments.done"),
+            "missing function done: {body}"
+        );
+        assert!(
+            body.contains("\"call_id\":\"call_1\""),
+            "missing call id: {body}"
+        );
+        assert_eq!(body.matches("event: response.completed").count(), 1);
+    }
+
+    #[tokio::test]
+    async fn responses_route_rejects_state_and_non_function_tools() {
+        for (extra, param) in [
+            (json!({"store": true}), "store"),
+            (
+                json!({"previous_response_id": "resp_previous"}),
+                "previous_response_id",
+            ),
+            (
+                json!({"tools": [{"type": "mcp", "server_label": "docs"}]}),
+                "tools[0].type",
+            ),
+        ] {
+            let mut body = json!({"model": "stub-model", "input": "hello"});
+            body.as_object_mut()
+                .unwrap()
+                .extend(extra.as_object().unwrap().clone());
+            let response = post_json(router_with_stub("unused"), "/v1/responses", body).await;
+            assert_eq!(response.status(), AxumStatusCode::BAD_REQUEST);
+            let error = response_json(response).await;
+            assert_eq!(error["error"]["param"], param, "error: {error}");
+        }
+    }
+
+    #[tokio::test]
+    async fn responses_mvp_keeps_chat_completions_route_working() {
+        let response = post_json(
+            router_with_stub("chat still works"),
+            "/v1/chat/completions",
+            json!({
+                "model": "stub-model",
+                "messages": [{"role": "user", "content": "hello"}]
+            }),
+        )
+        .await;
+        assert_eq!(response.status(), AxumStatusCode::OK);
+        let body = response_json(response).await;
+        assert_eq!(body["choices"][0]["message"]["content"], "chat still works");
     }
 
     #[test]

--- a/crates/ferrum-server/src/axum_server/responses.rs
+++ b/crates/ferrum-server/src/axum_server/responses.rs
@@ -1,0 +1,1116 @@
+use super::{
+    chat_completions_handler, json_rejection_detail, AppState, ServerError,
+    DEFAULT_COMPLETION_MAX_TOKENS, DEFAULT_SAMPLING_TEMPERATURE, DEFAULT_SAMPLING_TOP_P,
+};
+use crate::openai::{
+    ChatCompletionsRequest, ChatCompletionsResponse, ChatFunction, ChatFunctionCall, ChatMessage,
+    ChatTool, ChatToolCall, MessageRole, StreamOptions, ToolChoice, ToolChoiceFunction, Usage,
+};
+use axum::{
+    body::to_bytes,
+    extract::{rejection::JsonRejection, State},
+    http::HeaderMap,
+    response::{sse::Event, IntoResponse, Response, Sse},
+    Json,
+};
+use futures::StreamExt;
+use serde::Deserialize;
+use serde_json::{json, Map, Value};
+use std::{collections::BTreeMap, convert::Infallible};
+use tokio::sync::mpsc;
+use tokio_stream::wrappers::UnboundedReceiverStream;
+use uuid::Uuid;
+
+const MAX_SYNC_ADAPTER_BODY_BYTES: usize = 16 * 1024 * 1024;
+
+#[derive(Debug, Clone, Deserialize)]
+pub(super) struct ResponsesRequest {
+    #[serde(default)]
+    model: Option<String>,
+    #[serde(default)]
+    input: Value,
+    #[serde(default)]
+    instructions: Option<String>,
+    #[serde(default)]
+    max_output_tokens: Option<u32>,
+    #[serde(default)]
+    temperature: Option<f32>,
+    #[serde(default)]
+    top_p: Option<f32>,
+    #[serde(default)]
+    stream: Option<bool>,
+    #[serde(default)]
+    tools: Option<Vec<Value>>,
+    #[serde(default)]
+    tool_choice: Option<Value>,
+    #[serde(default)]
+    store: Option<bool>,
+    #[serde(default)]
+    previous_response_id: Option<String>,
+    #[serde(default)]
+    conversation: Option<Value>,
+    #[serde(default)]
+    background: Option<bool>,
+    #[serde(default)]
+    include: Option<Vec<String>>,
+    #[serde(default)]
+    parallel_tool_calls: Option<bool>,
+    #[serde(default)]
+    truncation: Option<String>,
+    #[serde(default)]
+    metadata: Option<Map<String, Value>>,
+    #[serde(flatten)]
+    extra: BTreeMap<String, Value>,
+}
+
+struct ConvertedRequest {
+    chat: ChatCompletionsRequest,
+    response: ResponseContext,
+    stream: bool,
+}
+
+#[derive(Clone)]
+struct ResponseContext {
+    id: String,
+    created_at: u64,
+    model: String,
+    instructions: Option<String>,
+    max_output_tokens: u32,
+    temperature: f32,
+    top_p: f32,
+    parallel_tool_calls: bool,
+    tools: Vec<Value>,
+    tool_choice: Value,
+    metadata: Map<String, Value>,
+}
+
+pub(super) async fn responses_handler(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    request: std::result::Result<Json<ResponsesRequest>, JsonRejection>,
+) -> std::result::Result<Response, ServerError> {
+    let Json(request) = request.map_err(|error| {
+        ServerError::invalid_request(
+            format!(
+                "invalid responses request: {}",
+                json_rejection_detail(&error)
+            ),
+            None,
+        )
+    })?;
+    let converted = request.convert()?;
+    let chat_response =
+        chat_completions_handler(State(state), headers, Ok(Json(converted.chat))).await?;
+    if converted.stream {
+        Ok(adapt_chat_stream(chat_response, converted.response))
+    } else {
+        adapt_chat_sync(chat_response, converted.response).await
+    }
+}
+
+impl ResponsesRequest {
+    fn convert(self) -> std::result::Result<ConvertedRequest, ServerError> {
+        self.validate_stateless_scope()?;
+
+        let model = self
+            .model
+            .as_deref()
+            .filter(|model| !model.trim().is_empty())
+            .ok_or_else(|| ServerError::invalid_request("model is required", Some("model")))?
+            .to_string();
+        let mut messages = parse_input(&self.input)?;
+        if let Some(instructions) = self.instructions.as_ref() {
+            messages.insert(0, chat_message(MessageRole::System, instructions.clone()));
+        }
+        if messages.is_empty() {
+            return Err(ServerError::invalid_request(
+                "input must contain at least one text message or function item",
+                Some("input"),
+            ));
+        }
+
+        let (chat_tools, response_tools) = parse_tools(self.tools.as_deref())?;
+        let (chat_tool_choice, response_tool_choice) =
+            parse_tool_choice(self.tool_choice.as_ref())?;
+        let stream = self.stream.unwrap_or(false);
+        let max_output_tokens = self
+            .max_output_tokens
+            .unwrap_or(DEFAULT_COMPLETION_MAX_TOKENS);
+        let temperature = self.temperature.unwrap_or(DEFAULT_SAMPLING_TEMPERATURE);
+        let top_p = self.top_p.unwrap_or(DEFAULT_SAMPLING_TOP_P);
+
+        let chat = ChatCompletionsRequest {
+            model: model.clone(),
+            messages,
+            max_tokens: None,
+            max_completion_tokens: Some(max_output_tokens),
+            temperature: self.temperature,
+            top_p: self.top_p,
+            top_k: None,
+            min_p: None,
+            repetition_penalty: None,
+            n: Some(1),
+            stream: Some(stream),
+            ignore_eos: None,
+            stop: None,
+            presence_penalty: None,
+            frequency_penalty: None,
+            logit_bias: None,
+            logprobs: None,
+            top_logprobs: None,
+            user: None,
+            seed: None,
+            response_format: None,
+            tools: (!chat_tools.is_empty()).then_some(chat_tools),
+            tool_choice: chat_tool_choice,
+            stream_options: stream.then_some(StreamOptions {
+                include_usage: Some(true),
+            }),
+            functions: None,
+            function_call: None,
+            metadata: None,
+            chat_template_kwargs: None,
+        };
+        let response = ResponseContext {
+            id: format!("resp_{}", Uuid::new_v4().simple()),
+            created_at: chrono::Utc::now().timestamp() as u64,
+            model,
+            instructions: self.instructions,
+            max_output_tokens,
+            temperature,
+            top_p,
+            parallel_tool_calls: self.parallel_tool_calls.unwrap_or(true),
+            tools: response_tools,
+            tool_choice: response_tool_choice,
+            metadata: self.metadata.unwrap_or_default(),
+        };
+
+        Ok(ConvertedRequest {
+            chat,
+            response,
+            stream,
+        })
+    }
+
+    fn validate_stateless_scope(&self) -> std::result::Result<(), ServerError> {
+        if self.store == Some(true) {
+            return Err(unsupported(
+                "Ferrum's stateless Responses API requires store=false",
+                "store",
+            ));
+        }
+        if self.previous_response_id.is_some() {
+            return Err(unsupported(
+                "previous_response_id requires response state storage",
+                "previous_response_id",
+            ));
+        }
+        if self.conversation.is_some() {
+            return Err(unsupported(
+                "conversation requires response state storage",
+                "conversation",
+            ));
+        }
+        if self.background == Some(true) {
+            return Err(unsupported(
+                "background responses are not supported by the stateless endpoint",
+                "background",
+            ));
+        }
+        if self
+            .include
+            .as_ref()
+            .is_some_and(|include| !include.is_empty())
+        {
+            return Err(unsupported(
+                "include expansions are not supported by the stateless endpoint",
+                "include",
+            ));
+        }
+        if self.parallel_tool_calls == Some(false) {
+            return Err(unsupported(
+                "parallel_tool_calls=false is not supported yet",
+                "parallel_tool_calls",
+            ));
+        }
+        if self
+            .truncation
+            .as_deref()
+            .is_some_and(|truncation| truncation != "disabled")
+        {
+            return Err(unsupported(
+                "only truncation=disabled is supported",
+                "truncation",
+            ));
+        }
+        if let Some((name, _)) = self.extra.iter().find(|(_, value)| !value.is_null()) {
+            return Err(ServerError::unsupported_feature(
+                format!("Responses API field `{name}` is not supported yet"),
+                Some(name),
+            ));
+        }
+        Ok(())
+    }
+}
+
+fn unsupported(message: impl Into<String>, param: &str) -> ServerError {
+    ServerError::unsupported_feature(message, Some(param))
+}
+
+fn chat_message(role: MessageRole, content: String) -> ChatMessage {
+    ChatMessage {
+        role,
+        content,
+        reasoning: None,
+        name: None,
+        tool_calls: None,
+        tool_call_id: None,
+        function_call: None,
+    }
+}
+
+fn parse_input(input: &Value) -> std::result::Result<Vec<ChatMessage>, ServerError> {
+    match input {
+        Value::String(text) => Ok(vec![chat_message(MessageRole::User, text.clone())]),
+        Value::Array(items) => {
+            let mut messages = Vec::new();
+            for (index, item) in items.iter().enumerate() {
+                parse_input_item(item, index, &mut messages)?;
+            }
+            Ok(messages)
+        }
+        _ => Err(ServerError::invalid_request(
+            "input must be a string or an array of input items",
+            Some("input"),
+        )),
+    }
+}
+
+fn parse_input_item(
+    item: &Value,
+    index: usize,
+    messages: &mut Vec<ChatMessage>,
+) -> std::result::Result<(), ServerError> {
+    let object = item.as_object().ok_or_else(|| {
+        ServerError::invalid_request(
+            "each input item must be an object",
+            Some(&format!("input[{index}]")),
+        )
+    })?;
+    let item_type = object
+        .get("type")
+        .and_then(Value::as_str)
+        .unwrap_or("message");
+    match item_type {
+        "message" => {
+            let role_param = format!("input[{index}].role");
+            let role = match required_string(object, "role", &role_param)?.as_str() {
+                "user" => MessageRole::User,
+                "assistant" => MessageRole::Assistant,
+                "system" | "developer" => MessageRole::System,
+                _ => {
+                    return Err(ServerError::invalid_request(
+                        "message role must be user, assistant, system, or developer",
+                        Some(&role_param),
+                    ))
+                }
+            };
+            let content_param = format!("input[{index}].content");
+            let content = parse_message_content(object.get("content"), &content_param)?;
+            messages.push(chat_message(role, content));
+        }
+        "function_call" => {
+            let call_id_param = format!("input[{index}].call_id");
+            let name_param = format!("input[{index}].name");
+            let arguments_param = format!("input[{index}].arguments");
+            let call = ChatToolCall {
+                index: None,
+                id: required_string(object, "call_id", &call_id_param)?,
+                tool_type: "function".to_string(),
+                function: ChatFunctionCall {
+                    name: required_string(object, "name", &name_param)?,
+                    arguments: required_string(object, "arguments", &arguments_param)?,
+                },
+            };
+            if let Some(last) = messages.last_mut().filter(|message| {
+                message.role == MessageRole::Assistant
+                    && message.content.is_empty()
+                    && message.tool_calls.is_some()
+            }) {
+                last.tool_calls.get_or_insert_with(Vec::new).push(call);
+            } else {
+                let mut message = chat_message(MessageRole::Assistant, String::new());
+                message.tool_calls = Some(vec![call]);
+                messages.push(message);
+            }
+        }
+        "function_call_output" => {
+            let call_id_param = format!("input[{index}].call_id");
+            let output_param = format!("input[{index}].output");
+            let mut message = chat_message(
+                MessageRole::Tool,
+                required_string(object, "output", &output_param)?,
+            );
+            message.tool_call_id = Some(required_string(object, "call_id", &call_id_param)?);
+            messages.push(message);
+        }
+        unsupported_type => {
+            return Err(ServerError::unsupported_feature(
+                format!("input item type `{unsupported_type}` is not supported yet"),
+                Some(&format!("input[{index}].type")),
+            ))
+        }
+    }
+    Ok(())
+}
+
+fn parse_message_content(
+    content: Option<&Value>,
+    param: &str,
+) -> std::result::Result<String, ServerError> {
+    match content {
+        Some(Value::String(text)) => Ok(text.clone()),
+        Some(Value::Array(parts)) => {
+            let mut texts = Vec::with_capacity(parts.len());
+            for (index, part) in parts.iter().enumerate() {
+                let object = part.as_object().ok_or_else(|| {
+                    ServerError::invalid_request(
+                        "message content parts must be objects",
+                        Some(&format!("{param}[{index}]")),
+                    )
+                })?;
+                let part_type = object.get("type").and_then(Value::as_str).ok_or_else(|| {
+                    ServerError::invalid_request(
+                        "message content part is missing type",
+                        Some(&format!("{param}[{index}].type")),
+                    )
+                })?;
+                if !matches!(part_type, "input_text" | "output_text" | "text") {
+                    return Err(ServerError::unsupported_feature(
+                        format!("message content type `{part_type}` is not supported yet"),
+                        Some(&format!("{param}[{index}].type")),
+                    ));
+                }
+                texts.push(required_string(
+                    object,
+                    "text",
+                    &format!("{param}[{index}].text"),
+                )?);
+            }
+            Ok(texts.join("\n"))
+        }
+        Some(Value::Null) | None => Ok(String::new()),
+        _ => Err(ServerError::invalid_request(
+            "message content must be a string or an array of text parts",
+            Some(param),
+        )),
+    }
+}
+
+fn required_string(
+    object: &Map<String, Value>,
+    key: &str,
+    param: &str,
+) -> std::result::Result<String, ServerError> {
+    object
+        .get(key)
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+        .ok_or_else(|| {
+            ServerError::invalid_request(format!("{param} must be a non-empty string"), Some(param))
+        })
+}
+
+fn parse_tools(
+    tools: Option<&[Value]>,
+) -> std::result::Result<(Vec<ChatTool>, Vec<Value>), ServerError> {
+    let mut chat_tools = Vec::new();
+    let mut response_tools = Vec::new();
+    for (index, tool) in tools.unwrap_or_default().iter().enumerate() {
+        let object = tool.as_object().ok_or_else(|| {
+            ServerError::invalid_request(
+                "tools entries must be objects",
+                Some(&format!("tools[{index}]")),
+            )
+        })?;
+        let type_param = format!("tools[{index}].type");
+        let tool_type = required_string(object, "type", &type_param)?;
+        if tool_type != "function" {
+            return Err(ServerError::unsupported_feature(
+                format!(
+                    "tool type `{tool_type}` is not supported; only function tools are supported"
+                ),
+                Some(&type_param),
+            ));
+        }
+        let name_param = format!("tools[{index}].name");
+        let name = required_string(object, "name", &name_param)?;
+        let description = optional_string(
+            object,
+            "description",
+            &format!("tools[{index}].description"),
+        )?;
+        let parameters = object.get("parameters").cloned();
+        if parameters.as_ref().is_some_and(|value| !value.is_object()) {
+            return Err(ServerError::invalid_request(
+                "function parameters must be a JSON object",
+                Some(&format!("tools[{index}].parameters")),
+            ));
+        }
+        let strict = optional_bool(object, "strict", &format!("tools[{index}].strict"))?;
+        chat_tools.push(ChatTool {
+            tool_type: "function".to_string(),
+            function: ChatFunction {
+                name: name.clone(),
+                description: description.clone(),
+                parameters: parameters.clone(),
+                strict,
+            },
+        });
+        let mut normalized = Map::new();
+        normalized.insert("type".to_string(), json!("function"));
+        normalized.insert("name".to_string(), json!(name));
+        if let Some(description) = description {
+            normalized.insert("description".to_string(), json!(description));
+        }
+        if let Some(parameters) = parameters {
+            normalized.insert("parameters".to_string(), parameters);
+        }
+        if let Some(strict) = strict {
+            normalized.insert("strict".to_string(), json!(strict));
+        }
+        response_tools.push(Value::Object(normalized));
+    }
+    Ok((chat_tools, response_tools))
+}
+
+fn optional_string(
+    object: &Map<String, Value>,
+    key: &str,
+    param: &str,
+) -> std::result::Result<Option<String>, ServerError> {
+    match object.get(key) {
+        None | Some(Value::Null) => Ok(None),
+        Some(Value::String(value)) => Ok(Some(value.clone())),
+        _ => Err(ServerError::invalid_request(
+            format!("{param} must be a string"),
+            Some(param),
+        )),
+    }
+}
+
+fn optional_bool(
+    object: &Map<String, Value>,
+    key: &str,
+    param: &str,
+) -> std::result::Result<Option<bool>, ServerError> {
+    match object.get(key) {
+        None | Some(Value::Null) => Ok(None),
+        Some(Value::Bool(value)) => Ok(Some(*value)),
+        _ => Err(ServerError::invalid_request(
+            format!("{param} must be a boolean"),
+            Some(param),
+        )),
+    }
+}
+
+fn parse_tool_choice(
+    choice: Option<&Value>,
+) -> std::result::Result<(Option<ToolChoice>, Value), ServerError> {
+    let Some(choice) = choice else {
+        return Ok((None, json!("auto")));
+    };
+    match choice {
+        Value::String(mode) if matches!(mode.as_str(), "auto" | "none" | "required") => {
+            Ok((Some(ToolChoice::Mode(mode.clone())), json!(mode)))
+        }
+        Value::Object(object) => {
+            let tool_type = required_string(object, "type", "tool_choice.type")?;
+            if tool_type != "function" {
+                return Err(unsupported(
+                    "only function tool_choice objects are supported",
+                    "tool_choice.type",
+                ));
+            }
+            let name = required_string(object, "name", "tool_choice.name")?;
+            Ok((
+                Some(ToolChoice::Function {
+                    tool_type: "function".to_string(),
+                    function: ToolChoiceFunction { name: name.clone() },
+                }),
+                json!({"type": "function", "name": name}),
+            ))
+        }
+        _ => Err(ServerError::invalid_request(
+            "tool_choice must be auto, none, required, or a function selector",
+            Some("tool_choice"),
+        )),
+    }
+}
+
+impl ResponseContext {
+    fn response(
+        &self,
+        status: &str,
+        output: Vec<Value>,
+        usage: Option<&Usage>,
+        error: Option<Value>,
+    ) -> Value {
+        let incomplete_details = (status == "incomplete")
+            .then(|| json!({"reason": "max_output_tokens"}))
+            .unwrap_or(Value::Null);
+        let completed_at = matches!(status, "completed" | "incomplete" | "failed")
+            .then(|| chrono::Utc::now().timestamp() as u64)
+            .map(Value::from)
+            .unwrap_or(Value::Null);
+        json!({
+            "id": self.id,
+            "object": "response",
+            "created_at": self.created_at,
+            "completed_at": completed_at,
+            "status": status,
+            "background": false,
+            "error": error,
+            "incomplete_details": incomplete_details,
+            "instructions": self.instructions,
+            "max_output_tokens": self.max_output_tokens,
+            "max_tool_calls": null,
+            "metadata": self.metadata,
+            "model": self.model,
+            "output": output,
+            "parallel_tool_calls": self.parallel_tool_calls,
+            "previous_response_id": null,
+            "reasoning": null,
+            "service_tier": "default",
+            "store": false,
+            "temperature": self.temperature,
+            "text": {"format": {"type": "text"}},
+            "tool_choice": self.tool_choice,
+            "tools": self.tools,
+            "top_logprobs": 0,
+            "top_p": self.top_p,
+            "truncation": "disabled",
+            "usage": usage.map(response_usage),
+            "user": null
+        })
+    }
+}
+
+fn response_usage(usage: &Usage) -> Value {
+    json!({
+        "input_tokens": usage.prompt_tokens,
+        "input_tokens_details": {"cached_tokens": 0},
+        "output_tokens": usage.completion_tokens,
+        "output_tokens_details": {"reasoning_tokens": 0},
+        "total_tokens": usage.total_tokens
+    })
+}
+
+async fn adapt_chat_sync(
+    response: Response,
+    context: ResponseContext,
+) -> std::result::Result<Response, ServerError> {
+    let bytes = to_bytes(response.into_body(), MAX_SYNC_ADAPTER_BODY_BYTES)
+        .await
+        .map_err(|error| {
+            ServerError::InternalError(format!("failed to read chat response: {error}"))
+        })?;
+    let chat: ChatCompletionsResponse = serde_json::from_slice(&bytes).map_err(|error| {
+        ServerError::InternalError(format!("failed to decode chat response: {error}"))
+    })?;
+    let choice = chat.choices.into_iter().next().ok_or_else(|| {
+        ServerError::InternalError("chat response did not contain a choice".to_string())
+    })?;
+    let message = choice.message.ok_or_else(|| {
+        ServerError::InternalError("chat response did not contain a message".to_string())
+    })?;
+    let output = response_output_from_message(message);
+    let status = if choice.finish_reason.as_deref() == Some("length") {
+        "incomplete"
+    } else {
+        "completed"
+    };
+    Ok(Json(context.response(status, output, chat.usage.as_ref(), None)).into_response())
+}
+
+fn response_output_from_message(message: ChatMessage) -> Vec<Value> {
+    let mut output = Vec::new();
+    let has_calls = message
+        .tool_calls
+        .as_ref()
+        .is_some_and(|calls| !calls.is_empty())
+        || message.function_call.is_some();
+    if !message.content.is_empty() || !has_calls {
+        output.push(message_output_item(
+            format!("msg_{}", Uuid::new_v4().simple()),
+            message.content,
+            "completed",
+        ));
+    }
+    for call in message.tool_calls.unwrap_or_default() {
+        output.push(function_output_item(&call, "completed"));
+    }
+    if let Some(function) = message.function_call {
+        let call = ChatToolCall {
+            index: None,
+            id: format!("call_{}", Uuid::new_v4().simple()),
+            tool_type: "function".to_string(),
+            function,
+        };
+        output.push(function_output_item(&call, "completed"));
+    }
+    output
+}
+
+fn message_output_item(id: String, text: String, status: &str) -> Value {
+    json!({
+        "id": id,
+        "type": "message",
+        "status": status,
+        "role": "assistant",
+        "content": [{
+            "type": "output_text",
+            "text": text,
+            "annotations": [],
+            "logprobs": []
+        }]
+    })
+}
+
+fn function_output_item(call: &ChatToolCall, status: &str) -> Value {
+    json!({
+        "id": format!("fc_{}", Uuid::new_v4().simple()),
+        "type": "function_call",
+        "status": status,
+        "call_id": call.id,
+        "name": call.function.name,
+        "arguments": call.function.arguments
+    })
+}
+
+type EventSender = mpsc::UnboundedSender<std::result::Result<Event, Infallible>>;
+
+fn adapt_chat_stream(response: Response, context: ResponseContext) -> Response {
+    let (tx, rx) = mpsc::unbounded_channel();
+    tokio::spawn(async move {
+        let mut state = ResponsesStreamState::new(context);
+        state.send_initial_events(&tx);
+        let mut decoder = SseDecoder::default();
+        let mut body = response.into_body().into_data_stream();
+        while let Some(chunk) = body.next().await {
+            match chunk {
+                Ok(bytes) => {
+                    for data in decoder.push(&bytes) {
+                        state.consume_chat_event(&data, &tx);
+                    }
+                }
+                Err(error) => {
+                    state.fail(format!("failed to read chat stream: {error}"), &tx);
+                    return;
+                }
+            }
+            if state.terminal {
+                return;
+            }
+        }
+        for data in decoder.finish() {
+            state.consume_chat_event(&data, &tx);
+        }
+        if !state.terminal {
+            state.fail("chat stream ended before [DONE]".to_string(), &tx);
+        }
+    });
+    Sse::new(UnboundedReceiverStream::new(rx)).into_response()
+}
+
+struct ResponsesStreamState {
+    context: ResponseContext,
+    sequence: u64,
+    text_item_id: String,
+    text: String,
+    text_started: bool,
+    tool_calls: BTreeMap<u32, ToolCallAccumulator>,
+    finish_reason: Option<String>,
+    usage: Option<Usage>,
+    terminal: bool,
+}
+
+#[derive(Default)]
+struct ToolCallAccumulator {
+    id: String,
+    name: String,
+    arguments: String,
+}
+
+impl ResponsesStreamState {
+    fn new(context: ResponseContext) -> Self {
+        Self {
+            context,
+            sequence: 0,
+            text_item_id: format!("msg_{}", Uuid::new_v4().simple()),
+            text: String::new(),
+            text_started: false,
+            tool_calls: BTreeMap::new(),
+            finish_reason: None,
+            usage: None,
+            terminal: false,
+        }
+    }
+
+    fn send_initial_events(&mut self, tx: &EventSender) {
+        let response = self.context.response("in_progress", vec![], None, None);
+        self.send(tx, "response.created", json!({"response": response}));
+        let response = self.context.response("in_progress", vec![], None, None);
+        self.send(tx, "response.in_progress", json!({"response": response}));
+    }
+
+    fn consume_chat_event(&mut self, data: &str, tx: &EventSender) {
+        if self.terminal {
+            return;
+        }
+        if data == "[DONE]" {
+            self.complete(tx);
+            return;
+        }
+        let value: Value = match serde_json::from_str(data) {
+            Ok(value) => value,
+            Err(error) => {
+                self.fail(format!("invalid chat stream event: {error}"), tx);
+                return;
+            }
+        };
+        if let Some(error) = value.get("error") {
+            let message = error
+                .get("message")
+                .and_then(Value::as_str)
+                .unwrap_or("chat stream failed")
+                .to_string();
+            self.fail(message, tx);
+            return;
+        }
+        let chunk: ChatCompletionsResponse = match serde_json::from_value(value) {
+            Ok(chunk) => chunk,
+            Err(error) => {
+                self.fail(format!("invalid chat completion chunk: {error}"), tx);
+                return;
+            }
+        };
+        if let Some(usage) = chunk.usage {
+            self.usage = Some(usage);
+        }
+        for choice in chunk.choices {
+            if let Some(delta) = choice.delta {
+                if !delta.content.is_empty() {
+                    self.push_text(&delta.content, tx);
+                }
+                for (position, call) in delta.tool_calls.unwrap_or_default().into_iter().enumerate()
+                {
+                    let index = call.index.unwrap_or(position as u32);
+                    let accumulated = self.tool_calls.entry(index).or_default();
+                    if !call.id.is_empty() {
+                        accumulated.id = call.id;
+                    }
+                    if !call.function.name.is_empty() {
+                        accumulated.name = call.function.name;
+                    }
+                    accumulated.arguments.push_str(&call.function.arguments);
+                }
+                if let Some(function) = delta.function_call {
+                    let accumulated = self.tool_calls.entry(0).or_default();
+                    accumulated.id = accumulated
+                        .id
+                        .is_empty()
+                        .then(|| format!("call_{}", Uuid::new_v4().simple()))
+                        .unwrap_or_else(|| accumulated.id.clone());
+                    accumulated.name = function.name;
+                    accumulated.arguments.push_str(&function.arguments);
+                }
+            }
+            if choice.finish_reason.is_some() {
+                self.finish_reason = choice.finish_reason;
+            }
+        }
+    }
+
+    fn push_text(&mut self, delta: &str, tx: &EventSender) {
+        if !self.text_started {
+            self.text_started = true;
+            self.send(
+                tx,
+                "response.output_item.added",
+                json!({
+                    "output_index": 0,
+                    "item": {
+                        "id": self.text_item_id,
+                        "type": "message",
+                        "role": "assistant",
+                        "content": [],
+                        "status": "in_progress"
+                    }
+                }),
+            );
+            self.send(
+                tx,
+                "response.content_part.added",
+                json!({
+                    "item_id": self.text_item_id,
+                    "output_index": 0,
+                    "content_index": 0,
+                    "part": {"type": "output_text", "text": "", "annotations": [], "logprobs": []}
+                }),
+            );
+        }
+        self.text.push_str(delta);
+        self.send(
+            tx,
+            "response.output_text.delta",
+            json!({
+                "item_id": self.text_item_id,
+                "output_index": 0,
+                "content_index": 0,
+                "delta": delta,
+                "logprobs": []
+            }),
+        );
+    }
+
+    fn complete(&mut self, tx: &EventSender) {
+        if self.terminal {
+            return;
+        }
+        let mut output = Vec::new();
+        if self.text_started || self.tool_calls.is_empty() {
+            if !self.text_started {
+                self.push_text("", tx);
+            }
+            self.send(
+                tx,
+                "response.output_text.done",
+                json!({
+                    "item_id": self.text_item_id,
+                    "output_index": 0,
+                    "content_index": 0,
+                    "text": self.text,
+                    "logprobs": []
+                }),
+            );
+            let item =
+                message_output_item(self.text_item_id.clone(), self.text.clone(), "completed");
+            self.send(
+                tx,
+                "response.content_part.done",
+                json!({
+                    "item_id": self.text_item_id,
+                    "output_index": 0,
+                    "content_index": 0,
+                    "part": item["content"][0].clone()
+                }),
+            );
+            self.send(
+                tx,
+                "response.output_item.done",
+                json!({"output_index": 0, "item": item.clone()}),
+            );
+            output.push(item);
+        }
+
+        let calls = std::mem::take(&mut self.tool_calls);
+        for (_, call) in calls {
+            let output_index = output.len();
+            let call_id = if call.id.is_empty() {
+                format!("call_{}", Uuid::new_v4().simple())
+            } else {
+                call.id
+            };
+            let item_id = format!("fc_{}", Uuid::new_v4().simple());
+            let in_progress = json!({
+                "id": item_id,
+                "type": "function_call",
+                "status": "in_progress",
+                "call_id": call_id,
+                "name": call.name,
+                "arguments": ""
+            });
+            self.send(
+                tx,
+                "response.output_item.added",
+                json!({"output_index": output_index, "item": in_progress}),
+            );
+            if !call.arguments.is_empty() {
+                self.send(
+                    tx,
+                    "response.function_call_arguments.delta",
+                    json!({
+                        "item_id": item_id,
+                        "output_index": output_index,
+                        "delta": call.arguments
+                    }),
+                );
+            }
+            self.send(
+                tx,
+                "response.function_call_arguments.done",
+                json!({
+                    "item_id": item_id,
+                    "output_index": output_index,
+                    "call_id": call_id,
+                    "name": call.name,
+                    "arguments": call.arguments
+                }),
+            );
+            let item = json!({
+                "id": item_id,
+                "type": "function_call",
+                "status": "completed",
+                "call_id": call_id,
+                "name": call.name,
+                "arguments": call.arguments
+            });
+            self.send(
+                tx,
+                "response.output_item.done",
+                json!({"output_index": output_index, "item": item.clone()}),
+            );
+            output.push(item);
+        }
+
+        let status = if self.finish_reason.as_deref() == Some("length") {
+            "incomplete"
+        } else {
+            "completed"
+        };
+        let response = self
+            .context
+            .response(status, output, self.usage.as_ref(), None);
+        self.send(tx, "response.completed", json!({"response": response}));
+        self.terminal = true;
+    }
+
+    fn fail(&mut self, message: String, tx: &EventSender) {
+        if self.terminal {
+            return;
+        }
+        let response = self.context.response(
+            "failed",
+            vec![],
+            self.usage.as_ref(),
+            Some(json!({"code": "internal_server_error", "message": message})),
+        );
+        self.send(tx, "response.failed", json!({"response": response}));
+        self.terminal = true;
+    }
+
+    fn send(&mut self, tx: &EventSender, event_type: &str, mut event: Value) {
+        if let Some(object) = event.as_object_mut() {
+            object.insert("type".to_string(), json!(event_type));
+            object.insert("sequence_number".to_string(), json!(self.sequence));
+        }
+        self.sequence += 1;
+        let _ = tx.send(Ok(Event::default()
+            .event(event_type)
+            .data(event.to_string())));
+    }
+}
+
+#[derive(Default)]
+struct SseDecoder {
+    buffer: Vec<u8>,
+}
+
+impl SseDecoder {
+    fn push(&mut self, bytes: &[u8]) -> Vec<String> {
+        self.buffer.extend_from_slice(bytes);
+        let mut data = Vec::new();
+        while let Some((start, separator_len)) = find_sse_separator(&self.buffer) {
+            let frame = self.buffer.drain(..start).collect::<Vec<_>>();
+            self.buffer.drain(..separator_len);
+            if let Some(value) = sse_data(&frame) {
+                data.push(value);
+            }
+        }
+        data
+    }
+
+    fn finish(&mut self) -> Vec<String> {
+        if self.buffer.is_empty() {
+            return Vec::new();
+        }
+        let frame = std::mem::take(&mut self.buffer);
+        sse_data(&frame).into_iter().collect()
+    }
+}
+
+fn find_sse_separator(bytes: &[u8]) -> Option<(usize, usize)> {
+    let lf = bytes.windows(2).position(|window| window == b"\n\n");
+    let crlf = bytes.windows(4).position(|window| window == b"\r\n\r\n");
+    match (lf, crlf) {
+        (Some(left), Some(right)) if left <= right => Some((left, 2)),
+        (Some(_), Some(right)) => Some((right, 4)),
+        (Some(left), None) => Some((left, 2)),
+        (None, Some(right)) => Some((right, 4)),
+        (None, None) => None,
+    }
+}
+
+fn sse_data(frame: &[u8]) -> Option<String> {
+    let text = String::from_utf8_lossy(frame);
+    let lines = text
+        .lines()
+        .filter_map(|line| line.strip_prefix("data:"))
+        .map(|line| line.strip_prefix(' ').unwrap_or(line))
+        .collect::<Vec<_>>();
+    (!lines.is_empty()).then(|| lines.join("\n"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn responses_request_maps_instructions_and_sampling_to_chat() {
+        let request: ResponsesRequest = serde_json::from_value(json!({
+            "model": "qwen3",
+            "instructions": "Be concise",
+            "input": [{"role": "user", "content": "hello"}],
+            "max_output_tokens": 17,
+            "temperature": 0.2,
+            "top_p": 0.8
+        }))
+        .expect("request");
+        let converted = request.convert().expect("converted request");
+        assert_eq!(converted.chat.messages.len(), 2);
+        assert_eq!(converted.chat.messages[0].role, MessageRole::System);
+        assert_eq!(converted.chat.messages[0].content, "Be concise");
+        assert_eq!(converted.chat.messages[1].role, MessageRole::User);
+        assert_eq!(converted.chat.max_completion_tokens, Some(17));
+        assert_eq!(converted.chat.temperature, Some(0.2));
+        assert_eq!(converted.chat.top_p, Some(0.8));
+    }
+
+    #[test]
+    fn responses_input_maps_messages_and_function_history() {
+        let messages = parse_input(&json!([
+            {"role": "user", "content": [{"type": "input_text", "text": "weather"}]},
+            {"type": "function_call", "call_id": "call_1", "name": "weather", "arguments": "{\"city\":\"Paris\"}"},
+            {"type": "function_call_output", "call_id": "call_1", "output": "sunny"}
+        ]))
+        .expect("responses input");
+        assert_eq!(messages.len(), 3);
+        assert_eq!(messages[0].content, "weather");
+        assert_eq!(messages[1].tool_calls.as_ref().unwrap()[0].id, "call_1");
+        assert_eq!(messages[2].role, MessageRole::Tool);
+        assert_eq!(messages[2].tool_call_id.as_deref(), Some("call_1"));
+        assert_eq!(messages[2].content, "sunny");
+    }
+
+    #[test]
+    fn responses_sse_decoder_handles_split_frames() {
+        let mut decoder = SseDecoder::default();
+        assert!(decoder.push(b"data: {\"a\":").is_empty());
+        assert_eq!(
+            decoder.push(b"1}\n\ndata: [DONE]\n\n"),
+            vec!["{\"a\":1}", "[DONE]"]
+        );
+    }
+}

--- a/docs/openai-api-compatibility.md
+++ b/docs/openai-api-compatibility.md
@@ -13,6 +13,7 @@ support matrix and are hidden from the default CLI help.
 | Endpoint | Status | Notes |
 |---|---|---|
 | `POST /v1/chat/completions` | Supported | Non-streaming and streaming chat responses. |
+| `POST /v1/responses` | Supported, stateless | Text/message input, non-streaming and streaming text, usage, and caller-owned function-tool loops. |
 | `POST /v1/completions` | Supported | Non-streaming and streaming text completions with a single string `prompt`; prompt arrays/objects are rejected with `param=prompt`. |
 | `GET /v1/models` | Supported | Lists models known to the server. |
 | `POST /v1/embeddings` | Experimental / outside v0.8 release scope | Text and image embedding support depends on a specialized loaded model. |
@@ -59,6 +60,19 @@ support matrix and are hidden from the default CLI help.
 | `tool_choice=required` | Supported | Requires at least one function tool. Ferrum steers generation toward the first declared tool's argument schema and returns OpenAI-shaped `tool_calls`. If no valid tool call can be parsed, non-streaming requests return HTTP 400 with `param=tool_choice`; streaming requests emit an OpenAI-shaped SSE error and `[DONE]` without first leaking invalid content. |
 | legacy `functions` / `function_call=auto/none` | Supported | Parsed for SDK compatibility and carried through structured request data. Assistant `function_call` responses serialize in the legacy OpenAI shape, including non-streaming responses and streaming deltas when engine output emits matching function-call JSON. |
 | specific legacy `function_call` | Supported | Named function-call selectors validate against declared legacy functions and constrain generated function-call JSON parsing to the selected function. Undeclared function names return HTTP 400 with `param=function_call`. |
+
+## Stateless Responses API
+
+`POST /v1/responses` reuses the same model, tokenizer, sampling, and function-call
+path as Chat Completions. It accepts string or message input, `instructions`,
+`max_output_tokens`, `temperature`, `top_p`, `stream`, function `tools`, and
+`tool_choice`. Streaming uses typed Responses SSE events and ends with exactly
+one `response.completed` event rather than a chat `[DONE]` sentinel.
+
+Ferrum does not store Response objects. Requests for `store=true`,
+`previous_response_id`, conversations, background execution, built-in tools, or
+remote MCP return HTTP 400 with the failing field in `param`. Function execution
+and resubmission of `function_call_output` remain caller-owned.
 
 ## Structured Output
 

--- a/scripts/release/runtime_vnext_release_workflow_policy.py
+++ b/scripts/release/runtime_vnext_release_workflow_policy.py
@@ -18,9 +18,9 @@ from typing import Any, Iterable
 PASS_PREFIX = "FERRUM RELEASE WORKFLOW POLICY PASS"
 SELFTEST_PASS_LINE = "FERRUM RELEASE WORKFLOW POLICY SELFTEST PASS"
 PREPROMOTION_READY_PREFIX = "FERRUM PREPROMOTION MANIFEST CONSUMPTION READY"
-STAGING_VERSION = "0.8.1"
-STAGING_RC_TAG = "v0.8.1-rc.1"
-STAGING_LABEL = "v0.8.1-rc"
+STAGING_VERSION = "0.8.2"
+STAGING_RC_TAG = "v0.8.2-rc.1"
+STAGING_LABEL = "v0.8.2-rc"
 EXPECTED_VERSION = "0.8.0"
 EXPECTED_TAG = "v0.8.0"
 EXPECTED_RC_TAG = "v0.8.0-rc.1"
@@ -336,7 +336,7 @@ def validate_cuda_workflow(document: dict[str, Any]) -> None:
         "release-cuda.yml must not restore target/ across CUDA/native-set identities",
     )
     cache_prefix = (
-        "stage-v0.8.1-linux-x86_64-cuda-sm89-"
+        "stage-v0.8.2-linux-x86_64-cuda-sm89-"
         "cuda12.4-native-b450d931-cargo-"
     )
     require(


### PR DESCRIPTION
Adds an OpenAI-compatible stateless POST /v1/responses adapter over the existing Chat Completions path.

Scope:
- string/message input, instructions, sampling, sync text and typed SSE
- usage and caller-owned function tool loops
- explicit 400s for state, background, MCP, and built-in tools
- version/workflow preparation for v0.8.2

Validation:
- focused Responses tests: 9 passed
- FERRUM GATE unit PASS: target/responses-api-stateless/unit
- Metal run/serve Responses sync, stream, function sample: PASS
- RTX 4050 CUDA run/serve Responses sync, stream, function sample: PASS

The accelerator samples are correctness-only and do not claim full G0 or performance readiness.