### PR TITLE
fix(release): rebuild CUDA native operator set for 0.8.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,8 +212,8 @@ jobs:
       CUDA_COMPUTE_CAP: "89"
       # Build-time, content-addressed component. The resulting ferrum binary
       # links these operators statically and performs no runtime download.
-      NATIVE_OPERATOR_SET_ARCHIVE_URL: https://github.com/sizzlecar/ferrum-infer-rs/releases/download/ferrum-native-cuda12.4-sm89-v1/native-operator-set-cuda12.4-sm89-v1.tar.zst
-      NATIVE_OPERATOR_SET_ARCHIVE_SHA256: b450d93182112a57cb96e9a1dd14ec147c7fd549dc4bd3ed9648bfc67e17eb37
+      NATIVE_OPERATOR_SET_ARCHIVE_URL: https://github.com/sizzlecar/ferrum-infer-rs/releases/download/ferrum-native-cuda12.4-sm89-v2/native-operator-set-cuda12.4-sm89-v2.tar.zst
+      NATIVE_OPERATOR_SET_ARCHIVE_SHA256: 765f845ae20c305edc10b31650339f8a2782e9e56687c8bda3f8e843a50c636b
     steps:
       - name: Install deps
         run: |
@@ -228,7 +228,7 @@ jobs:
 
       - name: Materialize pinned CUDA native operator set
         run: |
-          archive="$RUNNER_TEMP/native-operator-set-cuda12.4-sm89-v1.tar.zst"
+          archive="$RUNNER_TEMP/native-operator-set-cuda12.4-sm89-v2.tar.zst"
           root="$RUNNER_TEMP/ferrum-native-operator-set"
           curl --fail --location --retry 5 --retry-all-errors \
             --output "$archive" "$NATIVE_OPERATOR_SET_ARCHIVE_URL"

--- a/.github/workflows/release-cuda.yml
+++ b/.github/workflows/release-cuda.yml
@@ -10,12 +10,12 @@ on:
       release_candidate_tag:
         description: Annotated RC tag whose peeled commit is release_candidate_sha
         required: true
-        default: v0.8.2-rc.1
+        default: v0.8.3-rc.1
         type: string
       staging_label:
         description: Immutable artifact label; this does not create a tag or release
         required: true
-        default: v0.8.2-rc
+        default: v0.8.3-rc
         type: string
       publish_release:
         description: Safety lock; production staging requires false
@@ -38,8 +38,8 @@ env:
   CUDA_COMPUTE_CAP: 89
   # Build-time, content-addressed component. The staged ferrum binary links
   # these operators statically and performs no runtime download.
-  NATIVE_OPERATOR_SET_ARCHIVE_URL: https://github.com/sizzlecar/ferrum-infer-rs/releases/download/ferrum-native-cuda12.4-sm89-v1/native-operator-set-cuda12.4-sm89-v1.tar.zst
-  NATIVE_OPERATOR_SET_ARCHIVE_SHA256: b450d93182112a57cb96e9a1dd14ec147c7fd549dc4bd3ed9648bfc67e17eb37
+  NATIVE_OPERATOR_SET_ARCHIVE_URL: https://github.com/sizzlecar/ferrum-infer-rs/releases/download/ferrum-native-cuda12.4-sm89-v2/native-operator-set-cuda12.4-sm89-v2.tar.zst
+  NATIVE_OPERATOR_SET_ARCHIVE_SHA256: 765f845ae20c305edc10b31650339f8a2782e9e56687c8bda3f8e843a50c636b
 
 jobs:
   linux-x86_64-cuda-sm89:
@@ -58,8 +58,8 @@ jobs:
             echo "release_candidate_sha must be a full lowercase commit SHA" >&2
             exit 1
           fi
-          if ! [[ "${{ inputs.release_candidate_tag }}" =~ ^v0\.8\.2-rc\.[1-9][0-9]*$ ]]; then
-            echo "release_candidate_tag must match v0.8.2-rc.N" >&2
+          if ! [[ "${{ inputs.release_candidate_tag }}" =~ ^v0\.8\.3-rc\.[1-9][0-9]*$ ]]; then
+            echo "release_candidate_tag must match v0.8.3-rc.N" >&2
             exit 1
           fi
           if ! [[ "${{ inputs.staging_label }}" =~ ^[A-Za-z0-9._-]+$ ]]; then
@@ -96,7 +96,7 @@ jobs:
 
       - name: Materialize pinned CUDA native operator set
         run: |
-          archive="$RUNNER_TEMP/native-operator-set-cuda12.4-sm89-v1.tar.zst"
+          archive="$RUNNER_TEMP/native-operator-set-cuda12.4-sm89-v2.tar.zst"
           root="$RUNNER_TEMP/ferrum-native-operator-set"
           curl --fail --location --retry 5 --retry-all-errors \
             --output "$archive" "$NATIVE_OPERATOR_SET_ARCHIVE_URL"
@@ -129,7 +129,7 @@ jobs:
         run: |
           export PATH="$HOME/.cargo/bin:$PATH"
           version="$(cargo metadata --no-deps --format-version 1 | python3 -c 'import json,sys; data=json.load(sys.stdin); print(next(p["version"] for p in data["packages"] if p["name"] == "ferrum-cli"))')"
-          test "$version" = "0.8.2"
+          test "$version" = "0.8.3"
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
       - uses: actions/cache@v4
@@ -137,8 +137,8 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-          key: stage-v0.8.2-linux-x86_64-cuda-sm89-cuda12.4-native-b450d931-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: stage-v0.8.2-linux-x86_64-cuda-sm89-cuda12.4-native-b450d931-cargo-
+          key: stage-v0.8.3-linux-x86_64-cuda-sm89-cuda12.4-native-765f845a-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: stage-v0.8.3-linux-x86_64-cuda-sm89-cuda12.4-native-765f845a-cargo-
 
       - name: Build release CUDA sm89 binary exactly once
         run: |
@@ -171,7 +171,7 @@ jobs:
           cp LICENSE dist/LICENSE
           cp README.md dist/README.md
           cat > dist/CUDA-BUILD.txt <<'EOF'
-          Ferrum v0.8.2 CUDA release binary
+          Ferrum v0.8.3 CUDA release binary
           CUDA toolkit image: nvidia/cuda:12.4.0-devel-ubuntu22.04
           CUDA_COMPUTE_CAP: 89
           Cargo features: cuda,vllm-moe-marlin,vllm-paged-attn-v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,12 +10,12 @@ on:
       release_candidate_tag:
         description: Annotated RC tag whose peeled commit is release_candidate_sha
         required: true
-        default: v0.8.2-rc.1
+        default: v0.8.3-rc.1
         type: string
       staging_label:
         description: Immutable artifact label; this does not create a tag or release
         required: true
-        default: v0.8.2-rc
+        default: v0.8.3-rc
         type: string
       publish_release:
         description: Safety lock; production staging requires false
@@ -46,8 +46,8 @@ jobs:
             echo "release_candidate_sha must be a full lowercase commit SHA" >&2
             exit 1
           fi
-          if ! [[ "${{ inputs.release_candidate_tag }}" =~ ^v0\.8\.2-rc\.[1-9][0-9]*$ ]]; then
-            echo "release_candidate_tag must match v0.8.2-rc.N" >&2
+          if ! [[ "${{ inputs.release_candidate_tag }}" =~ ^v0\.8\.3-rc\.[1-9][0-9]*$ ]]; then
+            echo "release_candidate_tag must match v0.8.3-rc.N" >&2
             exit 1
           fi
           if ! [[ "${{ inputs.staging_label }}" =~ ^[A-Za-z0-9._-]+$ ]]; then
@@ -94,15 +94,15 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: stage-v0.8.2-linux-x86_64-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: stage-v0.8.2-linux-x86_64-
+          key: stage-v0.8.3-linux-x86_64-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: stage-v0.8.3-linux-x86_64-
 
       - name: Verify workspace release version
         id: metadata
         shell: bash
         run: |
           version="$(cargo metadata --no-deps --format-version 1 | python3 -c 'import json,sys; data=json.load(sys.stdin); print(next(p["version"] for p in data["packages"] if p["name"] == "ferrum-cli"))')"
-          test "$version" = "0.8.2"
+          test "$version" = "0.8.3"
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
       - name: Build release CPU binary exactly once
@@ -232,8 +232,8 @@ jobs:
             echo "release_candidate_sha must be a full lowercase commit SHA" >&2
             exit 1
           fi
-          if ! [[ "${{ inputs.release_candidate_tag }}" =~ ^v0\.8\.2-rc\.[1-9][0-9]*$ ]]; then
-            echo "release_candidate_tag must match v0.8.2-rc.N" >&2
+          if ! [[ "${{ inputs.release_candidate_tag }}" =~ ^v0\.8\.3-rc\.[1-9][0-9]*$ ]]; then
+            echo "release_candidate_tag must match v0.8.3-rc.N" >&2
             exit 1
           fi
           if ! [[ "${{ inputs.staging_label }}" =~ ^[A-Za-z0-9._-]+$ ]]; then
@@ -267,15 +267,15 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: stage-v0.8.2-macos-aarch64-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: stage-v0.8.2-macos-aarch64-
+          key: stage-v0.8.3-macos-aarch64-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: stage-v0.8.3-macos-aarch64-
 
       - name: Verify workspace release version
         id: metadata
         shell: bash
         run: |
           version="$(cargo metadata --no-deps --format-version 1 | python3 -c 'import json,sys; data=json.load(sys.stdin); print(next(p["version"] for p in data["packages"] if p["name"] == "ferrum-cli"))')"
-          test "$version" = "0.8.2"
+          test "$version" = "0.8.3"
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
       - name: Build release Metal binary exactly once

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1344,7 +1344,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-bench-core"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "ferrum-types",
  "rand 0.9.2",
@@ -1355,7 +1355,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-cli"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "anyhow",
  "async-openai",
@@ -1404,7 +1404,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-engine"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1461,7 +1461,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-interfaces"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1484,7 +1484,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-kernels"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "bindgen_cuda",
  "candle-core",
@@ -1506,7 +1506,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-kv"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1526,7 +1526,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-models"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1577,7 +1577,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-native-ops"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "ferrum-types",
  "libc",
@@ -1589,7 +1589,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-native-ops-builder"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "clap",
  "ferrum-native-ops",
@@ -1604,7 +1604,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-quantization"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "candle-core",
  "ferrum-interfaces",
@@ -1621,7 +1621,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-sampler"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1644,7 +1644,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-scheduler"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1672,7 +1672,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-server"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1714,7 +1714,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-testkit"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1732,7 +1732,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-tokenizer"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1758,7 +1758,7 @@ dependencies = [
 
 [[package]]
 name = "ferrum-types"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "chrono",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ resolver = "2"
 
 
 [workspace.package]
-version = "0.8.2"
+version = "0.8.3"
 edition = "2021"
 authors = ["Ferrum Team"]
 license = "MIT"
@@ -110,29 +110,29 @@ candle-flash-attn = "0.9.2"
 candle-metal-kernels = "0.9.2"
 
 # Internal crates - New refactored crates
-ferrum-types = { path = "crates/ferrum-types", version = "0.8.2" }
-ferrum-interfaces = { path = "crates/ferrum-interfaces", version = "0.8.2" }
+ferrum-types = { path = "crates/ferrum-types", version = "0.8.3" }
+ferrum-interfaces = { path = "crates/ferrum-interfaces", version = "0.8.3" }
 
 # Internal crates - Implementation crates
-ferrum-scheduler = { path = "crates/ferrum-scheduler", version = "0.8.2" }
-ferrum-tokenizer = { path = "crates/ferrum-tokenizer", version = "0.8.2" }
-ferrum-sampler = { path = "crates/ferrum-sampler", version = "0.8.2" }
-ferrum-kv = { path = "crates/ferrum-kv", version = "0.8.2" }
-ferrum-native-ops = { path = "crates/ferrum-native-ops", version = "0.8.2" }
+ferrum-scheduler = { path = "crates/ferrum-scheduler", version = "0.8.3" }
+ferrum-tokenizer = { path = "crates/ferrum-tokenizer", version = "0.8.3" }
+ferrum-sampler = { path = "crates/ferrum-sampler", version = "0.8.3" }
+ferrum-kv = { path = "crates/ferrum-kv", version = "0.8.3" }
+ferrum-native-ops = { path = "crates/ferrum-native-ops", version = "0.8.3" }
 
 # Unified compute kernels (CUDA/Metal/CPU)
-ferrum-kernels = { path = "crates/ferrum-kernels", version = "0.8.2" }
+ferrum-kernels = { path = "crates/ferrum-kernels", version = "0.8.3" }
 
 # Weight-format abstraction (Dense / GPTQ / AWQ / GGUF)
-ferrum-quantization = { path = "crates/ferrum-quantization", version = "0.8.2" }
+ferrum-quantization = { path = "crates/ferrum-quantization", version = "0.8.3" }
 
 # Internal product crates
-ferrum-engine = { path = "crates/ferrum-engine", version = "0.8.2" }
-ferrum-models = { path = "crates/ferrum-models", version = "0.8.2" }
-ferrum-server = { path = "crates/ferrum-server", version = "0.8.2" }
-ferrum-cli = { path = "crates/ferrum-cli", version = "0.8.2" }
-ferrum-testkit = { path = "crates/ferrum-testkit", version = "0.8.2" }
-ferrum-bench-core = { path = "crates/ferrum-bench-core", version = "0.8.2" }
+ferrum-engine = { path = "crates/ferrum-engine", version = "0.8.3" }
+ferrum-models = { path = "crates/ferrum-models", version = "0.8.3" }
+ferrum-server = { path = "crates/ferrum-server", version = "0.8.3" }
+ferrum-cli = { path = "crates/ferrum-cli", version = "0.8.3" }
+ferrum-testkit = { path = "crates/ferrum-testkit", version = "0.8.3" }
+ferrum-bench-core = { path = "crates/ferrum-bench-core", version = "0.8.3" }
 
 
 [profile.release]

--- a/README.md
+++ b/README.md
@@ -136,10 +136,10 @@ Install from crates.io:
 
 ```bash
 # macOS Apple Silicon Metal
-cargo install ferrum-cli --version 0.8.2 --locked --features metal
+cargo install ferrum-cli --version 0.8.3 --locked --features metal
 
 # NVIDIA CUDA
-cargo install ferrum-cli --version 0.8.2 --locked \
+cargo install ferrum-cli --version 0.8.3 --locked \
   --features cuda,vllm-moe-marlin,vllm-paged-attn-v2
 ```
 

--- a/scripts/release/runtime_vnext_release_workflow_policy.py
+++ b/scripts/release/runtime_vnext_release_workflow_policy.py
@@ -18,9 +18,9 @@ from typing import Any, Iterable
 PASS_PREFIX = "FERRUM RELEASE WORKFLOW POLICY PASS"
 SELFTEST_PASS_LINE = "FERRUM RELEASE WORKFLOW POLICY SELFTEST PASS"
 PREPROMOTION_READY_PREFIX = "FERRUM PREPROMOTION MANIFEST CONSUMPTION READY"
-STAGING_VERSION = "0.8.2"
-STAGING_RC_TAG = "v0.8.2-rc.1"
-STAGING_LABEL = "v0.8.2-rc"
+STAGING_VERSION = "0.8.3"
+STAGING_RC_TAG = "v0.8.3-rc.1"
+STAGING_LABEL = "v0.8.3-rc"
 EXPECTED_VERSION = "0.8.0"
 EXPECTED_TAG = "v0.8.0"
 EXPECTED_RC_TAG = "v0.8.0-rc.1"
@@ -336,23 +336,23 @@ def validate_cuda_workflow(document: dict[str, Any]) -> None:
         "release-cuda.yml must not restore target/ across CUDA/native-set identities",
     )
     cache_prefix = (
-        "stage-v0.8.2-linux-x86_64-cuda-sm89-"
-        "cuda12.4-native-b450d931-cargo-"
+        "stage-v0.8.3-linux-x86_64-cuda-sm89-"
+        "cuda12.4-native-765f845a-cargo-"
     )
     require(
         cache_with.get("key")
         == cache_prefix + "${{ hashFiles('**/Cargo.lock') }}"
         and cache_with.get("restore-keys") == cache_prefix,
-        "release-cuda.yml cache key must bind CUDA 12.4 and native set b450d931",
+        "release-cuda.yml cache key must bind CUDA 12.4 and native set 765f845a",
     )
     require(
         env.get("NATIVE_OPERATOR_SET_ARCHIVE_URL")
-        == "https://github.com/sizzlecar/ferrum-infer-rs/releases/download/ferrum-native-cuda12.4-sm89-v1/native-operator-set-cuda12.4-sm89-v1.tar.zst",
+        == "https://github.com/sizzlecar/ferrum-infer-rs/releases/download/ferrum-native-cuda12.4-sm89-v2/native-operator-set-cuda12.4-sm89-v2.tar.zst",
         "release-cuda.yml native operator set URL is not frozen",
     )
     require(
         env.get("NATIVE_OPERATOR_SET_ARCHIVE_SHA256")
-        == "b450d93182112a57cb96e9a1dd14ec147c7fd549dc4bd3ed9648bfc67e17eb37",
+        == "765f845ae20c305edc10b31650339f8a2782e9e56687c8bda3f8e843a50c636b",
         "release-cuda.yml native operator set SHA256 is not frozen",
     )
     scripts = "\n".join(
@@ -845,8 +845,8 @@ def run_selftest(texts: dict[str, str]) -> None:
     cuda_cache_mismatch = dict(texts)
     cuda_cache_mismatch["release-cuda.yml"] = _replace_once(
         cuda_cache_mismatch["release-cuda.yml"],
-        "cuda12.4-native-b450d931-cargo-${{ hashFiles('**/Cargo.lock') }}",
-        "cuda12.6-native-b450d931-cargo-${{ hashFiles('**/Cargo.lock') }}",
+        "cuda12.4-native-765f845a-cargo-${{ hashFiles('**/Cargo.lock') }}",
+        "cuda12.6-native-765f845a-cargo-${{ hashFiles('**/Cargo.lock') }}",
         "cuda-cache-toolchain-mismatch",
     )
     _expect_policy_failure(


### PR DESCRIPTION
Emergency patch release for the broken v0.8.2 CUDA asset.

- bumps workspace/install/staging metadata to 0.8.3
- pins CUDA CI and release staging to native operator set v2
- updates the workflow policy lock/cache identity

Focused validation:
- cargo check -p ferrum-cli --offline
- cargo fmt --all -- --check
- runtime_vnext_release_workflow_policy.py --self-test