### PR TITLE
fix(cuda): validate stable native operator contracts

### DIFF
--- a/crates/ferrum-kernels/src/native_ops.rs
+++ b/crates/ferrum-kernels/src/native_ops.rs
@@ -97,13 +97,13 @@ pub fn validate_compiled_native_operator_provider_catalog(
                         artifact.operator, binding.operation_id, binding.provider_id
                     )
                 })?;
-            if live.operation_contract_version != binding.operation_contract_version
-                || live.provider_version != binding.provider_version
-                || live.provider_implementation_fingerprint
-                    != binding.provider_implementation_fingerprint
+            if !contract_version_satisfies(
+                live.operation_contract_version,
+                binding.operation_contract_version,
+            ) || !contract_version_satisfies(live.provider_version, binding.provider_version)
             {
                 return Err(format!(
-                    "compiled native operator {} binding {}/{} differs from the live provider identity",
+                    "compiled native operator {} binding {}/{} is incompatible with the live versioned contract",
                     artifact.operator, binding.operation_id, binding.provider_id
                 ));
             }
@@ -128,6 +128,13 @@ pub fn validate_compiled_native_operator_provider_catalog(
         );
     }
     Ok(())
+}
+
+fn contract_version_satisfies(
+    available: ferrum_types::NativeOperatorContractVersion,
+    required: ferrum_types::NativeOperatorContractVersion,
+) -> bool {
+    available.major == required.major && available.minor >= required.minor
 }
 
 fn is_lowercase_sha256(value: &str) -> bool {

--- a/crates/ferrum-kernels/tests/native_ops.rs
+++ b/crates/ferrum-kernels/tests/native_ops.rs
@@ -306,14 +306,50 @@ fn compiled_native_operator_bindings_accept_unrelated_catalog_provenance_change(
 }
 
 #[test]
-fn compiled_native_operator_bindings_reject_changed_bound_provider_identity() {
+fn compiled_native_operator_bindings_accept_implementation_provenance_change() {
     let catalog = live_provider_catalog();
     let mut stale_provider = compiled_provider(&catalog);
     stale_provider.operation_bindings[0].provider_implementation_fingerprint = digest('0');
+    validate_compiled_native_operator_provider_catalog(&catalog, &[stale_provider]).unwrap();
+}
+
+#[test]
+fn compiled_native_operator_bindings_accept_compatible_minor_versions() {
+    let mut catalog = live_provider_catalog();
+    let artifact = compiled_provider(&catalog);
+    catalog.providers[0].operation_contract_version.minor += 1;
+    catalog.providers[0].provider_version.minor += 1;
+    validate_compiled_native_operator_provider_catalog(&catalog, &[artifact]).unwrap();
+}
+
+#[test]
+fn compiled_native_operator_bindings_reject_incompatible_versioned_contract() {
+    let catalog = live_provider_catalog();
+
+    let mut stale_operation = compiled_provider(&catalog);
+    stale_operation.operation_bindings[0].operation_contract_version =
+        NativeOperatorContractVersion::new(9, 0);
+    assert!(
+        validate_compiled_native_operator_provider_catalog(&catalog, &[stale_operation])
+            .unwrap_err()
+            .contains("is incompatible with the live versioned contract")
+    );
+
+    let mut stale_provider = compiled_provider(&catalog);
+    stale_provider.operation_bindings[0].provider_version =
+        NativeOperatorContractVersion::new(9, 0);
     assert!(
         validate_compiled_native_operator_provider_catalog(&catalog, &[stale_provider])
             .unwrap_err()
-            .contains("differs from the live provider identity")
+            .contains("is incompatible with the live versioned contract")
+    );
+
+    let mut newer_provider = compiled_provider(&catalog);
+    newer_provider.operation_bindings[0].provider_version.minor += 1;
+    assert!(
+        validate_compiled_native_operator_provider_catalog(&catalog, &[newer_provider])
+            .unwrap_err()
+            .contains("is incompatible with the live versioned contract")
     );
 }
 


### PR DESCRIPTION
Fixes the v0.8.2/v0.8.3-rc CUDA startup rejection caused by build-dependent implementation fingerprints.

Hard compatibility remains versioned and stable: schema/backend, operation/provider IDs, contract/provider versions, binding presence, and the embedded native operator lock SHA. Implementation fingerprints remain diagnostic provenance.

Focused validation:
- cargo test -p ferrum-kernels --test native_ops --offline -- --test-threads=1
- cargo check -p ferrum-cli --offline
- cargo fmt --all -- --check
- FERRUM RELEASE WORKFLOW POLICY SELFTEST PASS