### PR TITLE
feat(models): qualify Qwen3.6 27B block-FP8

### DIFF
--- a/crates/ferrum-models/src/vnext/qwen35.rs
+++ b/crates/ferrum-models/src/vnext/qwen35.rs
@@ -5477,6 +5477,73 @@ mod tests {
     }
 
     #[test]
+    fn qwen36_27b_reuses_the_qwen35_block_fp8_execution_contract() {
+        let mut qwen38_config = test_official_marlin_block_fp8_config();
+        qwen38_config.hf_config["transformers_version"] = Value::String("5.8.0.dev0".to_owned());
+        let mut qwen36_config = qwen38_config.clone();
+        qwen36_config.hf_config["transformers_version"] = Value::String("4.57.1".to_owned());
+        assert_ne!(qwen38_config.hf_config, qwen36_config.hf_config);
+
+        let qwen38_text = Qwen35TextConfig::from_hf_config_value(&qwen38_config.hf_config).unwrap();
+        let qwen36_text = Qwen35TextConfig::from_hf_config_value(&qwen36_config.hf_config).unwrap();
+        assert_eq!(qwen38_text, qwen36_text);
+
+        let qwen38 = TypedFamilyRegistration::new(Qwen35FamilyProvider::new().unwrap())
+            .prepare(&serde_json::to_value(qwen38_config).unwrap())
+            .unwrap();
+        let qwen36 = TypedFamilyRegistration::new(Qwen35FamilyProvider::new().unwrap())
+            .prepare(&serde_json::to_value(qwen36_config).unwrap())
+            .unwrap();
+        assert_eq!(
+            qwen38.weight_schema().fingerprint().unwrap(),
+            qwen36.weight_schema().fingerprint().unwrap()
+        );
+        assert_eq!(
+            qwen38.program().fingerprint().unwrap(),
+            qwen36.program().fingerprint().unwrap()
+        );
+
+        let qwen38_denominator =
+            QuantizedProviderAttributionDenominator::from_prepared_family(&qwen38)
+                .unwrap()
+                .unwrap();
+        let qwen36_denominator =
+            QuantizedProviderAttributionDenominator::from_prepared_family(&qwen36)
+                .unwrap()
+                .unwrap();
+        assert_eq!(qwen38_denominator, qwen36_denominator);
+        assert_eq!(qwen36_denominator.quant_tensor_count(), 400);
+        assert_eq!(qwen36_denominator.operation_count(), 3);
+        assert_eq!(qwen36_denominator.item_count(), 403);
+        assert_eq!(
+            qwen36_denominator.sha256(),
+            "5e366997e15e1a94d90b1ae07281269e8a46f75904306564d56354c8ebea2e4e"
+        );
+
+        let device = DeviceDescriptor {
+            id: DeviceId::new("device.test.qwen36-block-fp8-marlin").unwrap(),
+            class: DeviceClass::Accelerator,
+            ordinal: 0,
+            total_memory_bytes: 1 << 30,
+            runtime_implementation_fingerprint: "0".repeat(64),
+            capabilities: BTreeSet::new(),
+            dynamic_storage_profiles: BTreeSet::from([DynamicStorageProfile::new(
+                DynamicStorageAllocator::LinearArena,
+                DynamicStorageView::Contiguous,
+            )
+            .unwrap()]),
+        };
+        device.validate().unwrap();
+        let materializer = block_fp8_to_marlin_fp8_weight_materializer().unwrap();
+        let qwen38_execution = materializer.execution_schema(&qwen38, &device).unwrap();
+        let qwen36_execution = materializer.execution_schema(&qwen36, &device).unwrap();
+        assert_eq!(
+            qwen38_execution.fingerprint().unwrap(),
+            qwen36_execution.fingerprint().unwrap()
+        );
+    }
+
+    #[test]
     fn qwen38_block_fp8_program_matches_standard_operation_contracts() {
         let prepared = TypedFamilyRegistration::new(Qwen35FamilyProvider::new().unwrap())
             .prepare(&serde_json::to_value(test_block_fp8_config()).unwrap())

--- a/scripts/release/configs/runtime_vnext_g08a_source_contract.json
+++ b/scripts/release/configs/runtime_vnext_g08a_source_contract.json
@@ -19,7 +19,7 @@
       "path": "crates/ferrum-models/src/qwen35_config.rs",
       "classification": "excluded-parser",
       "owner": "ferrum-models/qwen35_config",
-      "reviewed_at_git_sha": "4e946f5cbcc19ee65420d5da1026f2c4aaa25b33",
+      "reviewed_at_git_sha": "cb65d9ce6b951c06aaaba144555ce579be56dec2",
       "reason": "Typed external configuration parsing is excluded by the frozen G00 scaffolding definition."
     },
     {
@@ -33,14 +33,14 @@
       "path": "crates/ferrum-models/src/qwen35_weights.rs",
       "classification": "excluded-weights",
       "owner": "ferrum-models/qwen35_weights",
-      "reviewed_at_git_sha": "4e946f5cbcc19ee65420d5da1026f2c4aaa25b33",
+      "reviewed_at_git_sha": "cb65d9ce6b951c06aaaba144555ce579be56dec2",
       "reason": "Typed checkpoint inventory and weight declarations are excluded by the frozen G00 scaffolding definition."
     },
     {
       "path": "crates/ferrum-models/src/vnext/qwen35.rs",
       "classification": "reviewed-provider",
       "owner": "ferrum-models/vnext::qwen35",
-      "reviewed_at_git_sha": "e55a1c93f0ef23447919b91dce428cd52bd30025",
+      "reviewed_at_git_sha": "cb65d9ce6b951c06aaaba144555ce579be56dec2",
       "reason": "The typed family provider is reviewed function by function below."
         }
     ],
@@ -64,7 +64,7 @@
 	    "provider_review": {
     "path": "crates/ferrum-models/src/vnext/qwen35.rs",
     "owner": "ferrum-models/vnext::qwen35",
-    "reviewed_at_git_sha": "e55a1c93f0ef23447919b91dce428cd52bd30025",
+    "reviewed_at_git_sha": "cb65d9ce6b951c06aaaba144555ce579be56dec2",
 	        "classification_reasons": {
             "counted-execution-scaffolding": "Family-owned execution, scheduling, batching, state transition, or lifecycle code counts toward the frozen G00 scaffolding delta.",
             "counted-provider-glue": "Typed family identity, validation, preparation, and descriptor glue count toward the G08A provider limit.",
@@ -196,7 +196,7 @@
         "path": "crates/ferrum-interfaces/src/vnext/model.rs",
         "name": "ModelFamilyProvider",
         "owner": "ferrum-interfaces/vnext-model-contract",
-        "reviewed_at_git_sha": "4e946f5cbcc19ee65420d5da1026f2c4aaa25b33",
+        "reviewed_at_git_sha": "cb65d9ce6b951c06aaaba144555ce579be56dec2",
     "required_methods": [
       "family_id",
       "external_metadata_ids",
@@ -249,7 +249,7 @@
 	            "symbol": "create",
 	            "line_hint": 1352,
 	            "owner": "ferrum-engine/llm-executor-factory",
-	            "reviewed_at_git_sha": "fd1c0eb4114b3468bd8585a1bc84c04b65e1aee2",
+	            "reviewed_at_git_sha": "cb65d9ce6b951c06aaaba144555ce579be56dec2",
 	            "required_fragments": [
 	                "resolve_registered_model_from_sources",
 	                "resolve_registered_model_from_dir",
@@ -262,7 +262,7 @@
             "symbol": "create_vnext_executor",
             "line_hint": 29,
             "owner": "ferrum-engine/product-composition",
-            "reviewed_at_git_sha": "fd1c0eb4114b3468bd8585a1bc84c04b65e1aee2",
+            "reviewed_at_git_sha": "cb65d9ce6b951c06aaaba144555ce579be56dec2",
             "required_fragments": [
                 "PreparedProductionModel",
                 "VNextModelExecutor::from_runtime_composition"
@@ -273,7 +273,7 @@
             "symbol": "create_registered_vnext_executor",
             "line_hint": 1159,
             "owner": "ferrum-engine/registered-vnext-selection",
-            "reviewed_at_git_sha": "fd1c0eb4114b3468bd8585a1bc84c04b65e1aee2",
+            "reviewed_at_git_sha": "cb65d9ce6b951c06aaaba144555ce579be56dec2",
 	            "required_fragments": [
 	                "ProductionExecutionKind::CausalLanguage",
 	                "CudaVNextComposition::create",

--- a/scripts/release/configs/vnext_model_adoption/qwen36_27b_fp8.json
+++ b/scripts/release/configs/vnext_model_adoption/qwen36_27b_fp8.json
@@ -1,0 +1,94 @@
+{
+  "schema_version": 1,
+  "catalog_id": "vnext-model-adoption-qwen36-27b-fp8",
+  "description": "Pinned source catalog for the A2 Qwen3.6 27B official block-FP8 qualification lane.",
+  "models": [
+    {
+      "id": "qwen36-27b-fp8",
+      "model_id": "qwen36-27b-fp8",
+      "role": "a2_official_dense_block_fp8",
+      "backend": "cuda",
+      "repo": "Qwen/Qwen3.6-27B-FP8",
+      "revision": {
+        "status": "pinned",
+        "value": "e89b16ebf1988b3d6befa7de50abc2d76f26eb09",
+        "evidence": "docs/goals/vnext-model-adoption-2026-08-29/GOAL.md"
+      },
+      "files": [
+        {
+          "path": "README.md",
+          "required": true
+        },
+        {
+          "path": "LICENSE",
+          "required": true
+        },
+        {
+          "path": "chat_template.jinja",
+          "required": true
+        },
+        {
+          "path": "config.json",
+          "required": true
+        },
+        {
+          "path": "generation_config.json",
+          "required": true
+        },
+        {
+          "path": "tokenizer_config.json",
+          "required": true
+        },
+        {
+          "path": "tokenizer.json",
+          "required": true
+        },
+        {
+          "glob": "*.safetensors",
+          "required": true
+        },
+        {
+          "path": "model.safetensors.index.json",
+          "required_if_sharded": true
+        }
+      ],
+      "format": "safetensors_fp8_e4m3_dynamic_block_128x128",
+      "safetensors_shard_naming": "index_authoritative",
+      "reference": {
+        "semantic_repo": "Qwen/Qwen3.6-27B-FP8",
+        "semantic_revision": {
+          "status": "same_as_weight_revision"
+        },
+        "required_semantic_files": [
+          "README.md",
+          "chat_template.jinja",
+          "config.json",
+          "generation_config.json",
+          "tokenizer_config.json",
+          "tokenizer.json"
+        ],
+        "semantic_file_sha256": {
+          "README.md": "1d812aa4505b65e4893130b61d8e60498f15f751ed180e60dab0650823f2dced",
+          "chat_template.jinja": "e84f32a23fdda27689f868aa4a1a5621f41133e51a48d7f3efcbea2839574259",
+          "config.json": "885e6830f8d6883fefd63e3608c267452da2e6ce353a3494f42a7aa3d70c8434",
+          "generation_config.json": "e70c136c1b78ddc1fb0905bac8e733a4dc448d4f852a5dd75143fffc70be550e",
+          "tokenizer_config.json": "5186f0defcd7f232382c7f0aebcd2252d073bb921ab240e407b7ae8745d2b29b",
+          "tokenizer.json": "5f9e4d4901a92b997e463c1f46055088b6cca5ca61a6522d1b9f64c4bb81cb42"
+        },
+        "generation_config_source": {
+          "source": "semantic_source",
+          "path": "generation_config.json",
+          "policy": "required",
+          "content_sha256": "e70c136c1b78ddc1fb0905bac8e733a4dc448d4f852a5dd75143fffc70be550e"
+        },
+        "chat_template_source": {
+          "source": "semantic_source",
+          "path": "tokenizer_config.json",
+          "json_pointer": "/chat_template",
+          "container_sha256": "5186f0defcd7f232382c7f0aebcd2252d073bb921ab240e407b7ae8745d2b29b",
+          "content_sha256": "e84f32a23fdda27689f868aa4a1a5621f41133e51a48d7f3efcbea2839574259"
+        }
+      }
+    }
+  ]
+}

--- a/scripts/release/vnext_block_fp8_source_lock.py
+++ b/scripts/release/vnext_block_fp8_source_lock.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
-"""Build a metadata-only source lock for the fixed Qwen3.8 block-FP8 checkpoint.
+"""Build a metadata-only source lock for a fixed Qwen block-FP8 checkpoint.
 
 The tool consumes the immutable output of ``runtime_vnext_model_resolver.py``.
 It fetches the already-locked config and safetensors index as bounded metadata,
 then reads only each shard's eight-byte safetensors prefix and JSON header with
 strict HTTP Range requests. Tensor payload bytes are never requested.
 
-The result is diagnostic input for A1 M0. It is deliberately not a final
+The result is diagnostic input for the selected checkpoint's M0. It is deliberately not a final
 ``model-lock.json`` receipt: execution and quality approval identities remain
 null until their respective implementation and CUDA evidence exist.
 """
@@ -35,12 +35,7 @@ from typing import Any
 ROOT = Path(__file__).resolve().parents[2]
 OUTPUT_NAME = "block-fp8-source-header-lock.json"
 
-CHECKPOINT_ID = "qwen38-27b-fp8"
-CHECKPOINT_REPO = "Qwen/Qwen3.8-27B-FP8"
-CHECKPOINT_REVISION = "017b9c7af6b5689d5dd426a76e0bc077eb5ca20a"
-CHECKPOINT_LICENSE = "apache-2.0"
-CHECKPOINT_ARCHITECTURE = "Qwen3_5ForConditionalGeneration"
-CHECKPOINT_MODEL_TYPE = "qwen3_5"
+DEFAULT_CHECKPOINT_ID = "qwen38-27b-fp8"
 CHECKPOINT_FORMAT = "safetensors_fp8_e4m3_dynamic_block_128x128"
 INDEX_PATH = "model.safetensors.index.json"
 CONFIG_PATH = "config.json"
@@ -167,10 +162,10 @@ def utc_now() -> str:
     return dt.datetime.now(dt.timezone.utc).isoformat().replace("+00:00", "Z")
 
 
-def stable_file_url(path: str) -> str:
+def stable_file_url(repository: str, revision: str, path: str) -> str:
     require_safe_repo_path(path, "checkpoint file path")
-    repo = urllib.parse.quote(CHECKPOINT_REPO, safe="/")
-    revision = urllib.parse.quote(CHECKPOINT_REVISION, safe="")
+    repo = urllib.parse.quote(repository, safe="/")
+    revision = urllib.parse.quote(revision, safe="")
     encoded_path = urllib.parse.quote(path, safe="/")
     return f"https://huggingface.co/{repo}/resolve/{revision}/{encoded_path}"
 
@@ -238,9 +233,18 @@ class Transport:
 class NetworkTransport(Transport):
     provenance = "huggingface_https_range_without_credentials"
 
-    def __init__(self, *, timeout_seconds: float, retries: int) -> None:
+    def __init__(
+        self,
+        *,
+        timeout_seconds: float,
+        retries: int,
+        repository: str,
+        revision: str,
+    ) -> None:
         self.timeout_seconds = timeout_seconds
         self.retries = retries
+        self.repository = repository
+        self.revision = revision
 
     def _open_once(self, request: urllib.request.Request) -> Any:
         opener = urllib.request.build_opener(SafeHttpsRedirectHandler())
@@ -273,7 +277,7 @@ class NetworkTransport(Transport):
     def fetch_metadata(self, path: str, expected_size: int, expected_sha256: str) -> bytes:
         require(expected_size <= MAX_METADATA_BYTES, f"{path} exceeds metadata byte limit")
         request = urllib.request.Request(
-            stable_file_url(path),
+            stable_file_url(self.repository, self.revision, path),
             headers={
                 "Accept": "application/octet-stream",
                 "Accept-Encoding": "identity",
@@ -309,7 +313,7 @@ class NetworkTransport(Transport):
         requested = end - start + 1
         require(requested <= MAX_HEADER_BYTES, f"range response limit exceeded for {path}")
         request = urllib.request.Request(
-            stable_file_url(path),
+            stable_file_url(self.repository, self.revision, path),
             headers={
                 "Accept": "application/octet-stream",
                 "Accept-Encoding": "identity",
@@ -385,6 +389,43 @@ PRODUCTION_PROFILE = ExpectedProfile(
 
 
 @dataclass(frozen=True)
+class CheckpointProfile:
+    checkpoint_id: str
+    repository: str
+    revision: str
+    license_id: str
+    architecture: str
+    model_type: str
+    format_id: str
+    expected: ExpectedProfile
+
+
+CHECKPOINT_PROFILES = {
+    "qwen38-27b-fp8": CheckpointProfile(
+        checkpoint_id="qwen38-27b-fp8",
+        repository="Qwen/Qwen3.8-27B-FP8",
+        revision="017b9c7af6b5689d5dd426a76e0bc077eb5ca20a",
+        license_id="apache-2.0",
+        architecture="Qwen3_5ForConditionalGeneration",
+        model_type="qwen3_5",
+        format_id=CHECKPOINT_FORMAT,
+        expected=PRODUCTION_PROFILE,
+    ),
+    "qwen36-27b-fp8": CheckpointProfile(
+        checkpoint_id="qwen36-27b-fp8",
+        repository="Qwen/Qwen3.6-27B-FP8",
+        revision="e89b16ebf1988b3d6befa7de50abc2d76f26eb09",
+        license_id="apache-2.0",
+        architecture="Qwen3_5ForConditionalGeneration",
+        model_type="qwen3_5",
+        format_id=CHECKPOINT_FORMAT,
+        expected=PRODUCTION_PROFILE,
+    ),
+}
+DEFAULT_CHECKPOINT = CHECKPOINT_PROFILES[DEFAULT_CHECKPOINT_ID]
+
+
+@dataclass(frozen=True)
 class ResolutionInput:
     document: dict[str, Any]
     lane: dict[str, Any]
@@ -408,7 +449,7 @@ def validate_locked_file(row_raw: Any, label: str) -> dict[str, Any]:
     return result
 
 
-def load_resolution(path: Path, profile: ExpectedProfile = PRODUCTION_PROFILE) -> ResolutionInput:
+def load_resolution(path: Path, checkpoint: CheckpointProfile = DEFAULT_CHECKPOINT) -> ResolutionInput:
     try:
         raw = path.read_bytes()
     except OSError as exc:
@@ -422,25 +463,25 @@ def load_resolution(path: Path, profile: ExpectedProfile = PRODUCTION_PROFILE) -
     lanes = as_list(document.get("lanes"), "source resolution.lanes")
     require(len(lanes) == 1, "source resolution must contain exactly one lane")
     lane = as_object(lanes[0], "source resolution.lanes[0]")
-    require(lane.get("catalog_lane_id") == CHECKPOINT_ID, "source resolution lane id differs")
-    require(lane.get("model_id") == CHECKPOINT_ID, "source resolution model id differs")
+    require(lane.get("catalog_lane_id") == checkpoint.checkpoint_id, "source resolution lane id differs")
+    require(lane.get("model_id") == checkpoint.checkpoint_id, "source resolution model id differs")
     require(lane.get("backend") == "cuda", "source resolution backend differs")
-    require(lane.get("format") == CHECKPOINT_FORMAT, "source resolution format differs")
+    require(lane.get("format") == checkpoint.format_id, "source resolution format differs")
     require(
         lane.get("safetensors_shard_naming") == "index_authoritative",
         "source resolution must use index-authoritative shard naming",
     )
     source = as_object(lane.get("weight_source"), "source resolution weight_source")
-    require(source.get("repo") == CHECKPOINT_REPO, "source resolution repo differs")
-    require(source.get("revision") == CHECKPOINT_REVISION, "source resolution revision differs")
-    require(GIT_SHA_RE.fullmatch(CHECKPOINT_REVISION) is not None, "checkpoint revision is not full")
-    require(source.get("gated") in {False, None}, "fixed A1 checkpoint must remain public")
+    require(source.get("repo") == checkpoint.repository, "source resolution repo differs")
+    require(source.get("revision") == checkpoint.revision, "source resolution revision differs")
+    require(GIT_SHA_RE.fullmatch(checkpoint.revision) is not None, "checkpoint revision is not full")
+    require(source.get("gated") in {False, None}, "fixed checkpoint must remain public")
     license_lock = as_object(source.get("license"), "source resolution license")
     license_id = as_string(
         license_lock.get("hugging_face_id"),
         "source resolution license.hugging_face_id",
     ).lower()
-    require(license_id == CHECKPOINT_LICENSE, "source resolution license differs")
+    require(license_id == checkpoint.license_id, "source resolution license differs")
 
     rows = as_list(source.get("files"), "source resolution weight_source.files")
     files: dict[str, dict[str, Any]] = {}
@@ -449,7 +490,10 @@ def load_resolution(path: Path, profile: ExpectedProfile = PRODUCTION_PROFILE) -
         require(row["path"] not in files, f"duplicate locked file {row['path']}")
         content_url = row.get("content_request_url")
         if content_url is not None:
-            require(content_url == stable_file_url(row["path"]), f"stable URL differs for {row['path']}")
+            require(
+                content_url == stable_file_url(checkpoint.repository, checkpoint.revision, row["path"]),
+                f"stable URL differs for {row['path']}",
+            )
         files[row["path"]] = row
     require(CONFIG_PATH in files, "source resolution lacks config.json")
     require(INDEX_PATH in files, "source resolution lacks safetensors index")
@@ -458,7 +502,7 @@ def load_resolution(path: Path, profile: ExpectedProfile = PRODUCTION_PROFILE) -
         (row for row in files.values() if row["path"].endswith(".safetensors")),
         key=lambda row: row["path"],
     )
-    require(len(shards) == profile.shard_count, "source resolution shard count differs")
+    require(len(shards) == checkpoint.expected.shard_count, "source resolution shard count differs")
     for shard in shards:
         require(shard.get("sha256_source") == "hugging_face_lfs_oid", f"{shard['path']} is not LFS-locked")
         lfs_oid = as_string(shard.get("lfs_oid"), f"{shard['path']}.lfs_oid").lower()
@@ -487,11 +531,11 @@ def metadata_file(transport: Transport, row: dict[str, Any], label: str) -> byte
     return transport.fetch_metadata(row["path"], row["size_bytes"], row["sha256"])
 
 
-def parse_recipe(config_body: bytes) -> dict[str, Any]:
+def parse_recipe(config_body: bytes, checkpoint: CheckpointProfile = DEFAULT_CHECKPOINT) -> dict[str, Any]:
     config = as_object(strict_json_loads(config_body, CONFIG_PATH), CONFIG_PATH)
     architectures = as_list(config.get("architectures"), "config.architectures")
-    require(architectures == [CHECKPOINT_ARCHITECTURE], "config architecture differs")
-    require(config.get("model_type") == CHECKPOINT_MODEL_TYPE, "config model_type differs")
+    require(architectures == [checkpoint.architecture], "config architecture differs")
+    require(config.get("model_type") == checkpoint.model_type, "config model_type differs")
     require(config.get("language_model_only") is False, "config language_model_only differs")
     quant = as_object(config.get("quantization_config"), "config.quantization_config")
     require(set(quant) == {
@@ -532,7 +576,7 @@ def parse_index(index_body: bytes, expected_shards: set[str]) -> dict[str, str]:
     index = as_object(strict_json_loads(index_body, INDEX_PATH), INDEX_PATH)
     require(set(index).issubset({"metadata", "weight_map"}), "safetensors index has unknown fields")
     metadata = as_object(index.get("metadata"), "safetensors index.metadata")
-    require(not metadata, "fixed A1 safetensors index metadata must remain empty")
+    require(not metadata, "fixed safetensors index metadata must remain empty")
     weight_map_raw = as_object(index.get("weight_map"), "safetensors index.weight_map")
     require(weight_map_raw, "safetensors index weight_map is empty")
     weight_map: dict[str, str] = {}
@@ -805,17 +849,19 @@ def build_lock(
     resolution: ResolutionInput,
     transport: Transport,
     *,
-    profile: ExpectedProfile = PRODUCTION_PROFILE,
+    checkpoint: CheckpointProfile = DEFAULT_CHECKPOINT,
+    profile: ExpectedProfile | None = None,
     emit_progress: bool = True,
     shard_workers: int = 1,
 ) -> dict[str, Any]:
+    profile = checkpoint.expected if profile is None else profile
     require(
         1 <= shard_workers <= MAX_SHARD_WORKERS,
         f"shard_workers must be between one and {MAX_SHARD_WORKERS}",
     )
     config_body = metadata_file(transport, resolution.files[CONFIG_PATH], CONFIG_PATH)
     index_body = metadata_file(transport, resolution.files[INDEX_PATH], INDEX_PATH)
-    recipe = parse_recipe(config_body)
+    recipe = parse_recipe(config_body, checkpoint)
     weight_map = parse_index(index_body, {row["path"] for row in resolution.shards})
 
     def scan_shard(
@@ -887,8 +933,8 @@ def build_lock(
 
     files = [locked_file_identity(row) for row in sorted(resolution.files.values(), key=lambda row: row["path"])]
     checkpoint_content_document = {
-        "repository": CHECKPOINT_REPO,
-        "revision": CHECKPOINT_REVISION,
+        "repository": checkpoint.repository,
+        "revision": checkpoint.revision,
         "files": files,
     }
     checkpoint_content_digest = canonical_sha256(checkpoint_content_document)
@@ -913,15 +959,15 @@ def build_lock(
         "artifact_type": "vnext_block_fp8_source_header_lock_diagnostic",
         "generated_at": utc_now(),
         "checkpoint": {
-            "id": CHECKPOINT_ID,
-            "repository": CHECKPOINT_REPO,
-            "revision": CHECKPOINT_REVISION,
-            "license": CHECKPOINT_LICENSE,
-            "architecture": CHECKPOINT_ARCHITECTURE,
-            "model_type": CHECKPOINT_MODEL_TYPE,
+            "id": checkpoint.checkpoint_id,
+            "repository": checkpoint.repository,
+            "revision": checkpoint.revision,
+            "license": checkpoint.license_id,
+            "architecture": checkpoint.architecture,
+            "model_type": checkpoint.model_type,
             "language_model_only": False,
             "backend": "cuda",
-            "format": CHECKPOINT_FORMAT,
+            "format": checkpoint.format_id,
         },
         "input_resolution": {
             "path": resolution.resolution_path,
@@ -1044,9 +1090,9 @@ def selftest_world(case: str) -> tuple[ResolutionInput, FixtureTransport, Expect
     require(case in {"good", "bad_scale", "unknown_namespace", "orphan_sidecar"}, "bad fixture case")
     config = canonical_json_bytes(
         {
-            "architectures": [CHECKPOINT_ARCHITECTURE],
+            "architectures": [DEFAULT_CHECKPOINT.architecture],
             "language_model_only": False,
-            "model_type": CHECKPOINT_MODEL_TYPE,
+            "model_type": DEFAULT_CHECKPOINT.model_type,
             "quantization_config": {
                 "activation_scheme": "dynamic",
                 "fmt": "e4m3",
@@ -1102,7 +1148,11 @@ def selftest_world(case: str) -> tuple[ResolutionInput, FixtureTransport, Expect
                 "size_bytes": len(body),
                 "sha256": sha256_bytes(body),
                 "sha256_source": "downloaded_content",
-                "content_request_url": stable_file_url(path),
+                "content_request_url": stable_file_url(
+                    DEFAULT_CHECKPOINT.repository,
+                    DEFAULT_CHECKPOINT.revision,
+                    path,
+                ),
             }
         )
     for index_number, (path, body) in enumerate(shards.items(), start=1):
@@ -1123,19 +1173,22 @@ def selftest_world(case: str) -> tuple[ResolutionInput, FixtureTransport, Expect
         "resolver": {"path": "fixture", "sha256": "f" * 64},
         "lanes": [
             {
-                "catalog_lane_id": CHECKPOINT_ID,
-                "model_id": CHECKPOINT_ID,
+                "catalog_lane_id": DEFAULT_CHECKPOINT.checkpoint_id,
+                "model_id": DEFAULT_CHECKPOINT.checkpoint_id,
                 "backend": "cuda",
-                "format": CHECKPOINT_FORMAT,
+                "format": DEFAULT_CHECKPOINT.format_id,
                 "safetensors_shard_naming": "index_authoritative",
                 "weight_source": {
-                    "repo": CHECKPOINT_REPO,
-                    "revision": CHECKPOINT_REVISION,
+                    "repo": DEFAULT_CHECKPOINT.repository,
+                    "revision": DEFAULT_CHECKPOINT.revision,
                     "gated": False,
-                    "license": {"hugging_face_id": CHECKPOINT_LICENSE, "files": []},
+                    "license": {"hugging_face_id": DEFAULT_CHECKPOINT.license_id, "files": []},
                     "files": file_rows,
                 },
-                "semantic_source": {"repo": CHECKPOINT_REPO, "revision": CHECKPOINT_REVISION},
+                "semantic_source": {
+                    "repo": DEFAULT_CHECKPOINT.repository,
+                    "revision": DEFAULT_CHECKPOINT.revision,
+                },
                 "chat_template": {
                     "content_sha256": "a" * 64,
                     "container_sha256": "b" * 64,
@@ -1218,7 +1271,12 @@ def run_selftest() -> None:
 
     class ReadTimeoutThenSuccessTransport(NetworkTransport):
         def __init__(self) -> None:
-            super().__init__(timeout_seconds=1.0, retries=1)
+            super().__init__(
+                timeout_seconds=1.0,
+                retries=1,
+                repository=DEFAULT_CHECKPOINT.repository,
+                revision=DEFAULT_CHECKPOINT.revision,
+            )
             self.attempts = 0
 
         def _open_once(self, _request: urllib.request.Request) -> FakeRangeHandle:
@@ -1279,6 +1337,11 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--resolution", type=Path, help="runtime_vnext_model_resolver.py output")
     parser.add_argument("--out", type=Path, help="output JSON path or artifact directory")
+    parser.add_argument(
+        "--checkpoint-id",
+        choices=sorted(CHECKPOINT_PROFILES),
+        default=DEFAULT_CHECKPOINT_ID,
+    )
     parser.add_argument("--timeout-seconds", type=float, default=45.0)
     parser.add_argument("--retries", type=int, default=2)
     parser.add_argument("--shard-workers", type=int, default=MAX_SHARD_WORKERS)
@@ -1307,14 +1370,18 @@ def main(argv: list[str] | None = None) -> int:
         resolution_path = args.resolution
         if not resolution_path.is_absolute():
             resolution_path = ROOT / resolution_path
-        resolution = load_resolution(resolution_path)
+        checkpoint = CHECKPOINT_PROFILES[args.checkpoint_id]
+        resolution = load_resolution(resolution_path, checkpoint)
         transport = NetworkTransport(
             timeout_seconds=args.timeout_seconds,
             retries=args.retries,
+            repository=checkpoint.repository,
+            revision=checkpoint.revision,
         )
         document = build_lock(
             resolution,
             transport,
+            checkpoint=checkpoint,
             shard_workers=args.shard_workers,
         )
         output = write_output(args.out, document)

--- a/scripts/release/vnext_model_adoption_gate.py
+++ b/scripts/release/vnext_model_adoption_gate.py
@@ -95,7 +95,17 @@ M1_RUST_CONTRACTS = {
             "vnext::qwen35::tests::"
             "rejects_block_fp8_inverse_scale_grid_drift_before_runtime"
         ),
-    }
+    },
+    "qwen36-27b-fp8": {
+        "qwen36-fp8-wrong-format": (
+            "vnext::qwen35::tests::"
+            "rejects_block_fp8_metadata_recipe_drift_with_typed_error_before_runtime"
+        ),
+        "qwen36-fp8-scale-grid-drift": (
+            "vnext::qwen35::tests::"
+            "rejects_block_fp8_inverse_scale_grid_drift_before_runtime"
+        ),
+    },
 }
 HEX64 = re.compile(r"^[0-9a-f]{64}$")
 SECRET_KEY = re.compile(r"(?:api[_-]?key|token|password|secret|authorization)", re.I)


### PR DESCRIPTION
## Summary

- add the fixed Qwen3.6-27B-FP8 source contract without adding a new release script
- parameterize the existing block-FP8 source lock for Qwen3.8 and Qwen3.6
- qualify same-architecture contract reuse with a Rust test and bind A2 gate cases
- rebind source reviews to the retained candidate commit after the A1 squash merge

## Validation

- `FERRUM GATE unit PASS: /private/tmp/ferrum-a2-unit-b047325f`
- RTX 4050 correctness canary: BF16 + derived block-FP8 `run`, `serve`, stream PASS; CUDA reuse canary relative L2 `0.02040258`
- L40S target checkpoint: `run`, non-stream, stream, c2 4/4, c1 3/3 PASS; attribution 403/403; fallback/error counters 0
- load-to-ready `162.227s`; diagnostic c1 `16.3573 tok/s`, p50 TTFT `0.3141s`
- `FERRUM VNEXT MODEL ADOPTION PASS: qwen36-27b-fp8 /private/tmp/ferrum-vnext-a2-final-b047325f`

The L40S numbers are goal-gate diagnostics, not RTX 4090 release-performance evidence. The paid instance was stopped after artifacts were copied back.