### PR TITLE
docs: refresh Qwen3.6 27B FP8 benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ mean tok/s with the 95% confidence-interval half-width across three repeats.
 | Qwen3 30B-A3B | c=16 · 39.6 ± 1.2 | c=32 · 214.9 ± 2.7 |  |
 | Qwen3.8 27B AWQ INT4 |  | c=4 · 78.19 ± 0.04 · c=16 · 115.12 ± 1.18 · c=32 · 115.18 ± 0.97 |  |
 | [Qwen3.8 27B official block-FP8](https://huggingface.co/Qwen/Qwen3.8-27B-FP8/tree/017b9c7af6b5689d5dd426a76e0bc077eb5ca20a) |  |  | ready 80.91 s · c=1 · 15.23 ± 0.19 · c=8 · 41.75 ± 1.26 · c=32 · 49.75 ± 0.95 |
-| [Qwen3.6 27B official block-FP8](https://huggingface.co/Qwen/Qwen3.6-27B-FP8/tree/e89b16ebf1988b3d6befa7de50abc2d76f26eb09) |  |  | ready 162.23 s · c=1 · 16.36 · c=2 · 20.33 |
+| [Qwen3.6 27B official block-FP8](https://huggingface.co/Qwen/Qwen3.6-27B-FP8/tree/e89b16ebf1988b3d6befa7de50abc2d76f26eb09) |  |  | ready 93.39 s · c=1 · 15.15 ± 0.05 · c=8 · 42.37 ± 3.04 · c=32 · 50.38 ± 0.29 |
 | [Qwen3.6 35B-A3B official block-FP8](https://huggingface.co/Qwen/Qwen3.6-35B-A3B-FP8/tree/95a723d08a9490559dae23d0cff1d9466213d989) |  |  | load 568.70 s · c=1 · 36.25 ± 1.33 · c=8 · 77.18 ± 7.10 · c=32 · 83.70 ± 11.76 |
 
 `c` is active server concurrency. The first three rows completed 100 requests ×


### PR DESCRIPTION
## Summary

- refresh the existing README benchmark-table row for Qwen3.6 27B official block-FP8
- report exact L40S c=1/8/32, 32 requests per repeat, 3 repeats
- replace the superseded 162.23 s startup figure with the optimized 93.39 s result

## Validation

- `FERRUM VNEXT MODEL ADOPTION PASS: qwen36-27b-fp8 /private/tmp/ferrum-vnext-a2-final-8ce94d92`
- 384/384 benchmark requests succeeded; 0 errors
- provider attribution 403/403; fallback 0/0/0
- `git diff --check`

Artifacts are intentionally not committed.