### PR TITLE
docs: publish optimized Qwen3.6 35B-A3B FP8 results

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ mean tok/s with the 95% confidence-interval half-width across three repeats.
 | Qwen3.8 27B AWQ INT4 |  | c=4 · 78.19 ± 0.04 · c=16 · 115.12 ± 1.18 · c=32 · 115.18 ± 0.97 |  |
 | [Qwen3.8 27B official block-FP8](https://huggingface.co/Qwen/Qwen3.8-27B-FP8/tree/017b9c7af6b5689d5dd426a76e0bc077eb5ca20a) |  |  | ready 80.91 s · c=1 · 15.23 ± 0.19 · c=8 · 41.75 ± 1.26 · c=32 · 49.75 ± 0.95 |
 | [Qwen3.6 27B official block-FP8](https://huggingface.co/Qwen/Qwen3.6-27B-FP8/tree/e89b16ebf1988b3d6befa7de50abc2d76f26eb09) |  |  | ready 93.39 s · c=1 · 15.15 ± 0.05 · c=8 · 42.37 ± 3.04 · c=32 · 50.38 ± 0.29 |
-| [Qwen3.6 35B-A3B official block-FP8](https://huggingface.co/Qwen/Qwen3.6-35B-A3B-FP8/tree/95a723d08a9490559dae23d0cff1d9466213d989) |  |  | load 568.70 s · c=1 · 36.25 ± 1.33 · c=8 · 77.18 ± 7.10 · c=32 · 83.70 ± 11.76 |
+| [Qwen3.6 35B-A3B official block-FP8](https://huggingface.co/Qwen/Qwen3.6-35B-A3B-FP8/tree/95a723d08a9490559dae23d0cff1d9466213d989) |  |  | ready 69.62 s · c=1 · 45.01 ± 7.54 · c=8 · 92.78 ± 2.03 · c=32 · 92.78 ± 0.84 |
 
 `c` is active server concurrency. The first three rows completed 100 requests ×
 3 repeats with zero errors. [Measurement details](docs/release/runtime-vnext/0.8.0/PERFORMANCE_REPORT.md).


### PR DESCRIPTION
## Summary

- update the existing README performance-table row for Qwen3.6 35B-A3B official block-FP8
- report native `ready` plus c=1/8/32, each from 32 requests x 3 repeats
- keep artifacts and the supplied GOAL document out of the commit

## Evidence

- exact final gate: `FERRUM VNEXT MODEL ADOPTION PASS: qwen36-35b-a3b-fp8 /private/tmp/ferrum-vnext-a3-final-e0aa7567`
- validated source candidate: `e0aa756764dc813c7517e7aa81a5a8709ff4bb4b` (this PR is a README-only commit on top)
- paid binary SHA256: `15ba2b412f37d363e74fa054b1c9c074a4fee87bcd717b6ac20eef213ba57b2c`
- L40S A3: ready 69.618702 s; c1 45.013742 +/- 7.535919, c8 92.775514 +/- 2.025430, c32 92.777012 +/- 0.843778 tok/s; 288/288 requests, zero errors
- same-binary L40S Qwen3.8 regression: ready 85.661777 s; c1 15.6, c8 41.8, c32 50.3 tok/s; 288/288 requests, zero errors
- current candidate unit gate and RTX 4050 small-model/CUDA numerical/product E2E gates passed before the paid run

## Scope

README only; no source, script, GOAL, or artifact changes.